### PR TITLE
Fix for WD test and wakeup tests status field incorrect update

### DIFF
--- a/platform/pal_uefi_acpi/src/pal_misc.c
+++ b/platform/pal_uefi_acpi/src/pal_misc.c
@@ -39,9 +39,8 @@ UINT8   *gSharedMemory;
 VOID
 pal_mmio_write8(UINT64 addr, UINT8 data)
 {
+  bsa_print(ACS_PRINT_INFO, L" pal_mmio_write8 Address = %llx  Data = %lx \n", addr, data);
   *(volatile UINT8 *)addr = data;
-  bsa_print(ACS_PRINT_INFO, L" pal_mmio_write8 Address = %lx  Data = %lx \n", addr, data);
-
 }
 
 /**
@@ -56,9 +55,8 @@ pal_mmio_write8(UINT64 addr, UINT8 data)
 VOID
 pal_mmio_write16(UINT64 addr, UINT16 data)
 {
+  bsa_print(ACS_PRINT_INFO, L" pal_mmio_write16 Address = %llx  Data = %lx \n", addr, data);
   *(volatile UINT16 *)addr = data;
-  bsa_print(ACS_PRINT_INFO, L" pal_mmio_write16 Address = %lx  Data = %lx \n", addr, data);
-
 }
 
 /**
@@ -73,9 +71,8 @@ pal_mmio_write16(UINT64 addr, UINT16 data)
 VOID
 pal_mmio_write64(UINT64 addr, UINT64 data)
 {
+  bsa_print(ACS_PRINT_INFO, L" pal_mmio_write64 Address = %llx  Data = %lx \n", addr, data);
   *(volatile UINT64 *)addr = data;
-  bsa_print(ACS_PRINT_INFO, L" pal_mmio_write64 Address = %lx  Data = %lx \n", addr, data);
-
 }
 
 /**
@@ -171,7 +168,7 @@ pal_mmio_read(UINT64 addr)
 VOID
 pal_mmio_write(UINT64 addr, UINT32 data)
 {
-  bsa_print(ACS_PRINT_INFO, L" pal_mmio_write Address = %lx  Data = %x \n", addr, data);
+  bsa_print(ACS_PRINT_INFO, L" pal_mmio_write Address = %llx  Data = %x \n", addr, data);
   *(volatile UINT32 *)addr = data;
 }
 

--- a/platform/pal_uefi_acpi/src/pal_timer_wd.c
+++ b/platform/pal_uefi_acpi/src/pal_timer_wd.c
@@ -114,7 +114,7 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
       GtEntry->type = TIMER_TYPE_SYS_TIMER;
       GtEntry->block_cntl_base = Entry->CntCtlBase;
       GtEntry->timer_count     = Entry->GTBlockTimerCount;
-      bsa_print(ACS_PRINT_DEBUG, L"  CNTCTLBase = %x \n", GtEntry->block_cntl_base);
+      bsa_print(ACS_PRINT_DEBUG, L"  CNTCTLBase = %llx \n", GtEntry->block_cntl_base);
       GtBlockTimer = (EFI_ACPI_6_1_GTDT_GT_BLOCK_TIMER_STRUCTURE *)(((UINT8 *)Entry) + Entry->GTBlockTimerOffset);
       for (i = 0; i < GtEntry->timer_count; i++) {
         bsa_print(ACS_PRINT_INFO, L"  Found timer entry \n");
@@ -124,7 +124,7 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
         GtEntry->gsiv[i]         = GtBlockTimer->GTxPhysicalTimerGSIV;
         GtEntry->virt_gsiv[i]    = GtBlockTimer->GTxVirtualTimerGSIV;
         GtEntry->flags[i]        = GtBlockTimer->GTxPhysicalTimerFlags | (GtBlockTimer->GTxVirtualTimerFlags << 8) | (GtBlockTimer->GTxCommonFlags << 16);
-        bsa_print(ACS_PRINT_DEBUG, L"  CNTBaseN = %x for sys counter = %d\n",
+        bsa_print(ACS_PRINT_DEBUG, L"  CNTBaseN = %llx for sys counter = %d\n",
                                                      GtEntry->GtCntBase[i], i);
         GtBlockTimer++;
         TimerTable->header.num_platform_timer++;
@@ -219,7 +219,7 @@ pal_wd_create_info_table(WD_INFO_TABLE *WdTable)
       WdEntry->wd_gsiv         = Entry->WatchdogTimerGSIV;
       WdEntry->wd_flags        = Entry->WatchdogTimerFlags;
       WdTable->header.num_wd++;
-      bsa_print(ACS_PRINT_DEBUG, L"  Watchdog base = 0x%x INTID = 0x%x \n",
+      bsa_print(ACS_PRINT_DEBUG, L"  Watchdog base = 0x%llx INTID = 0x%x \n",
                                       WdEntry->wd_ctrl_base, WdEntry->wd_gsiv);
       WdEntry++;
     }

--- a/platform/pal_uefi_dt/src/pal_misc.c
+++ b/platform/pal_uefi_dt/src/pal_misc.c
@@ -39,9 +39,8 @@ UINT8   *gSharedMemory;
 VOID
 pal_mmio_write8(UINT64 addr, UINT8 data)
 {
+  bsa_print(ACS_PRINT_INFO, L" pal_mmio_write8 Address = %llx  Data = %lx \n", addr, data);
   *(volatile UINT8 *)addr = data;
-  bsa_print(ACS_PRINT_INFO, L" pal_mmio_write8 Address = %lx  Data = %lx \n", addr, data);
-
 }
 
 /**
@@ -56,9 +55,8 @@ pal_mmio_write8(UINT64 addr, UINT8 data)
 VOID
 pal_mmio_write16(UINT64 addr, UINT16 data)
 {
+  bsa_print(ACS_PRINT_INFO, L" pal_mmio_write16 Address = %llx  Data = %lx \n", addr, data);
   *(volatile UINT16 *)addr = data;
-  bsa_print(ACS_PRINT_INFO, L" pal_mmio_write16 Address = %lx  Data = %lx \n", addr, data);
-
 }
 
 /**
@@ -73,9 +71,8 @@ pal_mmio_write16(UINT64 addr, UINT16 data)
 VOID
 pal_mmio_write64(UINT64 addr, UINT64 data)
 {
+  bsa_print(ACS_PRINT_INFO, L" pal_mmio_write64 Address = %llx  Data = %llx \n", addr, data);
   *(volatile UINT64 *)addr = data;
-  bsa_print(ACS_PRINT_INFO, L" pal_mmio_write64 Address = %lx  Data = %lx \n", addr, data);
-
 }
 
 /**
@@ -171,7 +168,7 @@ pal_mmio_read(UINT64 addr)
 VOID
 pal_mmio_write(UINT64 addr, UINT32 data)
 {
-  bsa_print(ACS_PRINT_INFO, L" pal_mmio_write Address = %lx  Data = %x \n", addr, data);
+  bsa_print(ACS_PRINT_INFO, L" pal_mmio_write Address = %llx  Data = %x \n", addr, data);
   *(volatile UINT32 *)addr = data;
 }
 

--- a/platform/pal_uefi_dt/src/pal_timer_wd.c
+++ b/platform/pal_uefi_dt/src/pal_timer_wd.c
@@ -130,7 +130,7 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
       GtEntry->type = TIMER_TYPE_SYS_TIMER;
       GtEntry->block_cntl_base = Entry->CntCtlBase;
       GtEntry->timer_count     = Entry->GTBlockTimerCount;
-      bsa_print(ACS_PRINT_DEBUG, L"  CNTCTLBase = %x \n", GtEntry->block_cntl_base);
+      bsa_print(ACS_PRINT_DEBUG, L"  CNTCTLBase = %llx \n", GtEntry->block_cntl_base);
       GtBlockTimer = (EFI_ACPI_6_1_GTDT_GT_BLOCK_TIMER_STRUCTURE *)(((UINT8 *)Entry) + Entry->GTBlockTimerOffset);
       for (i = 0; i < GtEntry->timer_count; i++) {
         bsa_print(ACS_PRINT_INFO, L"  Found timer entry \n");
@@ -140,7 +140,7 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
         GtEntry->gsiv[i]         = GtBlockTimer->GTxPhysicalTimerGSIV;
         GtEntry->virt_gsiv[i]    = GtBlockTimer->GTxVirtualTimerGSIV;
         GtEntry->flags[i]        = GtBlockTimer->GTxPhysicalTimerFlags | (GtBlockTimer->GTxVirtualTimerFlags << 8) | (GtBlockTimer->GTxCommonFlags << 16);
-        bsa_print(ACS_PRINT_DEBUG, L"  CNTBaseN = %x for sys counter = %d\n", GtEntry->GtCntBase[i], i);
+        bsa_print(ACS_PRINT_DEBUG, L"  CNTBaseN = %llx for sys counter = %d\n", GtEntry->GtCntBase[i], i);
         GtBlockTimer++;
         TimerTable->header.num_platform_timer++;
       }
@@ -234,7 +234,7 @@ pal_wd_create_info_table(WD_INFO_TABLE *WdTable)
       WdEntry->wd_flags        = Entry->WatchdogTimerFlags;
       WdTable->header.num_wd++;
       bsa_print(ACS_PRINT_DEBUG,
-                L"  Watchdog base = 0x%x INTID = 0x%x \n",
+                L"  Watchdog base = 0x%llx INTID = 0x%x \n",
                 WdEntry->wd_ctrl_base,
                 WdEntry->wd_gsiv);
       WdEntry++;

--- a/test_pool/power_wakeup/operating_system/test_os_u002.c
+++ b/test_pool/power_wakeup/operating_system/test_os_u002.c
@@ -168,7 +168,7 @@ payload()
   else if (wakeup_event == WATCHDOG_SEMF) {
       status = val_wd_set_ws0(wd_num, timer_expire_ticks);
       if (status) {
-          val_print(ACS_PRINT_ERR, "\n       Setting watchdof timeout failed", 0);
+          val_print(ACS_PRINT_ERR, "\n       Setting watchdog timeout failed", 0);
           val_set_status(index, RESULT_FAIL(TEST_NUM, 2));
           return;
       }
@@ -191,7 +191,7 @@ payload()
       else if (wakeup_event == WATCHDOG_SEMF) {
           status = val_wd_set_ws0(wd_num, 0);
           if (status) {
-              val_print(ACS_PRINT_ERR, "\n       Setting watchdof timeout failed", 0);
+              val_print(ACS_PRINT_ERR, "\n       Setting watchdog timeout failed", 0);
               val_set_status(index, RESULT_FAIL(TEST_NUM, 3));
               return;
           }
@@ -222,7 +222,7 @@ payload()
   else if (wakeup_event == WATCHDOG_SEMF) {
       status = val_wd_set_ws0(wd_num, timer_expire_ticks);
           if (status) {
-              val_print(ACS_PRINT_ERR, "\n       Setting watchdof timeout failed", 0);
+              val_print(ACS_PRINT_ERR, "\n       Setting watchdog timeout failed", 0);
               val_set_status(index, RESULT_FAIL(TEST_NUM, 4));
               return;
           }
@@ -245,7 +245,7 @@ payload()
       else if (wakeup_event == WATCHDOG_SEMF) {
           status = val_wd_set_ws0(wd_num, 0);
           if (status) {
-              val_print(ACS_PRINT_ERR, "\n       Setting watchdof timeout failed", 0);
+              val_print(ACS_PRINT_ERR, "\n       Setting watchdog timeout failed", 0);
               val_set_status(index, RESULT_FAIL(TEST_NUM, 5));
               return;
           }

--- a/test_pool/timer/operating_system/test_os_t004.c
+++ b/test_pool/timer/operating_system/test_os_t004.c
@@ -47,7 +47,7 @@ payload()
 {
 
   volatile uint32_t timeout;
-  uint32_t timer_expire_val = 1000;
+  uint32_t timer_expire_val = TIMEOUT_MEDIUM;
   uint32_t status, ns_timer = 0;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
   uint64_t timer_num = val_timer_get_info(TIMER_INFO_NUM_PLATFORM_TIMERS, 0);

--- a/test_pool/watchdog/operating_system/test_os_w001.c
+++ b/test_pool/watchdog/operating_system/test_os_w001.c
@@ -52,9 +52,9 @@ payload()
 
       ns_wdg++;
       refresh_base = val_wd_get_info(wd_num, WD_INFO_REFRESH_BASE);
-      val_print(ACS_PRINT_INFO, "\n       Watchdog Refresh base is %x ", refresh_base);
+      val_print(ACS_PRINT_INFO, "\n       Watchdog Refresh base is %llx ", refresh_base);
       ctrl_base    = val_wd_get_info(wd_num, WD_INFO_CTRL_BASE);
-      val_print(ACS_PRINT_INFO, "\n       Watchdog CTRL base is  %x      ", ctrl_base);
+      val_print(ACS_PRINT_INFO, "\n       Watchdog CTRL base is  %llx      ", ctrl_base);
 
       data = val_mmio_read(ctrl_base);
       //Control register bits 31:3 are reserved 0

--- a/test_pool/watchdog/operating_system/test_os_w002.c
+++ b/test_pool/watchdog/operating_system/test_os_w002.c
@@ -83,7 +83,7 @@ payload()
 
       status = val_wd_set_ws0(wd_num, timer_expire_ticks);
       if (status) {
-          val_print(ACS_PRINT_ERR, "\n       Setting watchdof timeout failed", 0);
+          val_print(ACS_PRINT_ERR, "\n       Setting watchdog timeout failed", 0);
           val_set_status(index, RESULT_FAIL(TEST_NUM, 2));
           return;
       }

--- a/val/src/acs_wd.c
+++ b/val/src/acs_wd.c
@@ -175,7 +175,7 @@ val_wd_set_ws0(uint32_t index, uint32_t timeout)
   uint64_t counter_freq;
   uint32_t wor_l;
   uint32_t wor_h = 0;
-  uint32_t ctrl_base;
+  uint64_t ctrl_base;
   uint32_t data;
 
   if (timeout == 0) {


### PR DESCRIPTION
WD: Watchdog ctrl base is incorrectly accessed as 32 bit which was leading to crash in some systems.
Status Field: Due to UART print delay after enabling timeout in wakeup test the status field was not correctly updated in some systems.