### PR TITLE
PCIe: Test p002 enhancement

### DIFF
--- a/val/include/bsa_acs_pcie.h
+++ b/val/include/bsa_acs_pcie.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2020,2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2020,2021,2022 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,6 +37,7 @@
 #define PCIE_MAX_DEV    32
 #define PCIE_MAX_FUNC    8
 
+#define PCIE_BUS_SHIFT 8
 #define PCIE_CFG_SIZE  4096
 
 #define PCIE_INTERRUPT_LINE  0x3c


### PR DESCRIPTION
- If the device is valid PCIe device, checks if the config space till last capability is accessible.
- If the device is not a valid PCIe device, then access to the start and end of the config space should return all 1's.

Signed-off-by: Sujana M <sujana.m@arm.com>