### PR TITLE
Excluding memory barrier API from linux acs build

### DIFF
--- a/val/sys_arch_src/smmu_v3/smmu_v3.c
+++ b/val/sys_arch_src/smmu_v3/smmu_v3.c
@@ -99,7 +99,9 @@ static int smmu_cmdq_write_cmd(smmu_dev_t *smmu, uint64_t *cmd)
     for (i = 0; i < CMDQ_DWORDS_PER_ENT; ++i)
         cmd_dst[i] = cmd[i];
     queue.prod = smmu_cmdq_inc_prod(&queue);
+#ifndef TARGET_LINUX    
     ArmExecuteMemoryBarrier();
+#endif
     val_mmio_write((uint64_t)cmdq->prod_reg, queue.prod);
 
     return ret;


### PR DESCRIPTION
ArmExecuteMemoryBarrier functionality is needed only for UEFI targets.