### PR TITLE
Handling different version of GTDT table

### DIFF
--- a/platform/pal_uefi_acpi/src/pal_timer_wd.c
+++ b/platform/pal_uefi_acpi/src/pal_timer_wd.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2022, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Some system are using rev 1 of GTDT table. GTDT table parsing code updated to handle different GTDT revisions.