### PR TITLE
SRSv1.3 Exclusion List

### DIFF
--- a/test_pool/smmu/operating_system/test_os_i003.c
+++ b/test_pool/smmu/operating_system/test_os_i003.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2022 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,47 +22,50 @@
 #include "val/include/bsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 3)
-#define TEST_RULE  "B_SMMU_03"
-#define TEST_DESC  "Check Large Virtual Addr Support      "
+#define TEST_RULE  "B_SMMU_06"
+#define TEST_DESC  "Check Large Physical Addr Support     "
 
 static
 void
 payload()
 {
 
-  uint64_t data_va_range, data_vax;
+  uint64_t data_pa_range, data_oas;
   uint32_t num_smmu;
   uint32_t index;
 
   index = val_pe_get_index_mpid(val_pe_get_mpid());
 
-  data_va_range = VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64MMFR2_EL1), 16, 19);
-  if (data_va_range == 0) {
-    val_print(ACS_PRINT_DEBUG, "\n       Large VA Not Supported by PE                        ", 0);
+  data_pa_range = VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64MMFR0_EL1), 0, 3);
+  if (data_pa_range != 0x6) {
+   val_print(ACS_PRINT_DEBUG, "\n       Large PA Not Supported by PE        "
+                                      "                  ", 0);
     val_set_status(index, RESULT_SKIP(TEST_NUM, 1));
     return;
   }
 
   num_smmu = val_smmu_get_info(SMMU_NUM_CTRL, 0);
   if (num_smmu == 0) {
-    val_print(ACS_PRINT_ERR, "\n       No SMMU Controllers are discovered                  ", 0);
+    val_print(ACS_PRINT_DEBUG, "\n       No SMMU Controllers are discovered "
+                                    "                   ", 0);
     val_set_status(index, RESULT_SKIP(TEST_NUM, 2));
     return;
   }
 
   while (num_smmu--) {
       if (val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) == 2) {
-          val_print(ACS_PRINT_WARN, "\n       Large VA Not Supported in SMMUv2", 0);
+          val_print(ACS_PRINT_ERR, "\n       Large PA Not Supported in"
+                                    " SMMUv2", 0);
           val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
           return;
       }
 
-      data_vax = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_IDR5, num_smmu), 10, 11);
+      data_oas = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_IDR5, num_smmu), 0, 2);
 
-      /* If PE Supports Large VA Range then SMMU_IDR5.VAX = 0b01 */
-      if (data_va_range == 1) {
-          if (data_vax != 1) {
-              val_print(ACS_PRINT_ERR, "\n       Large VA Not Supported in SMMU %x", num_smmu);
+      /* If PE Supports Large PA then SMMU_IDR5.OAS = 0b110 */
+      if (data_pa_range == 0x6) {
+          if (data_oas != 0x6) {
+              val_print(ACS_PRINT_WARN, "\n       Large PA Not Supported in SMMU %x", num_smmu);
               val_set_status(index, RESULT_FAIL(TEST_NUM, 2));
               return;
           }

--- a/test_pool/smmu/operating_system/test_os_i005.c
+++ b/test_pool/smmu/operating_system/test_os_i005.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2022 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,50 +22,47 @@
 #include "val/include/bsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 5)
-#define TEST_RULE  "B_SMMU_06"
-#define TEST_DESC  "Check Large Physical Addr Support     "
+#define TEST_RULE  "B_SMMU_03"
+#define TEST_DESC  "Check Large Virtual Addr Support      "
 
 static
 void
 payload()
 {
 
-  uint64_t data_pa_range, data_oas;
+  uint64_t data_va_range, data_vax;
   uint32_t num_smmu;
   uint32_t index;
 
   index = val_pe_get_index_mpid(val_pe_get_mpid());
 
-  data_pa_range = VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64MMFR0_EL1), 0, 3);
-  if (data_pa_range != 0x6) {
-   val_print(ACS_PRINT_DEBUG, "\n       Large PA Not Supported by PE        "
-                                      "                  ", 0);
+  data_va_range = VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64MMFR2_EL1), 16, 19);
+  if (data_va_range == 0) {
+    val_print(ACS_PRINT_DEBUG, "\n       Large VA Not Supported by PE                        ", 0);
     val_set_status(index, RESULT_SKIP(TEST_NUM, 1));
     return;
   }
 
   num_smmu = val_smmu_get_info(SMMU_NUM_CTRL, 0);
   if (num_smmu == 0) {
-    val_print(ACS_PRINT_DEBUG, "\n       No SMMU Controllers are discovered "
-                                    "                   ", 0);
+    val_print(ACS_PRINT_ERR, "\n       No SMMU Controllers are discovered                  ", 0);
     val_set_status(index, RESULT_SKIP(TEST_NUM, 2));
     return;
   }
 
   while (num_smmu--) {
       if (val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) == 2) {
-          val_print(ACS_PRINT_ERR, "\n       Large PA Not Supported in"
-                                    " SMMUv2", 0);
+          val_print(ACS_PRINT_WARN, "\n       Large VA Not Supported in SMMUv2", 0);
           val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
           return;
       }
 
-      data_oas = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_IDR5, num_smmu), 0, 2);
+      data_vax = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_IDR5, num_smmu), 10, 11);
 
-      /* If PE Supports Large PA then SMMU_IDR5.OAS = 0b110 */
-      if (data_pa_range == 0x6) {
-          if (data_oas != 0x6) {
-              val_print(ACS_PRINT_WARN, "\n       Large PA Not Supported in SMMU %x", num_smmu);
+      /* If PE Supports Large VA Range then SMMU_IDR5.VAX = 0b01 */
+      if (data_va_range == 1) {
+          if (data_vax != 1) {
+              val_print(ACS_PRINT_ERR, "\n       Large VA Not Supported in SMMU %x", num_smmu);
               val_set_status(index, RESULT_FAIL(TEST_NUM, 2));
               return;
           }

--- a/test_pool/smmu/operating_system/test_os_i006.c
+++ b/test_pool/smmu/operating_system/test_os_i006.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2022 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,68 +18,59 @@
 #include "val/include/bsa_acs_val.h"
 #include "val/include/val_interface.h"
 
-#include "val/include/bsa_acs_pe.h"
 #include "val/include/bsa_acs_smmu.h"
-#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_SMMU_TEST_NUM_BASE + 6)
-#define TEST_RULE  "B_SMMU_08, B_SMMU_09"
-#define TEST_DESC  "SMMU revision and S-EL2 support       "
+#define TEST_RULE  "B_SMMU_04, B_SMMU_05"
+#define TEST_DESC  "Check TLB Range Invalidation          "
 
 static
 void
 payload()
 {
 
+  uint64_t data_pe_tlb, data_ril;
   uint32_t num_smmu;
   uint32_t index;
-  uint32_t s_el2;
-  uint32_t smmu_rev;
-  uint32_t minor;
-  uint32_t s1ts, s1p;
 
   index = val_pe_get_index_mpid(val_pe_get_mpid());
-  s_el2 = VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64PFR0_EL1), 36, 39);
+
+  data_pe_tlb = VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64ISAR0_EL1), 56, 59);
+  if (data_pe_tlb != 0x2) {
+      val_print(ACS_PRINT_DEBUG, "\n       TLB Range Invalid Not "
+                                "Supported For PE              ", 0);
+      val_set_status(index, RESULT_SKIP(TEST_NUM, 1));
+      return;
+  }
 
   num_smmu = val_smmu_get_info(SMMU_NUM_CTRL, 0);
   if (num_smmu == 0) {
-    val_print(ACS_PRINT_ERR, "\n       No SMMU Controllers are discovered                  ", 0);
-    val_set_status(index, RESULT_SKIP(TEST_NUM, 3));
+    val_print(ACS_PRINT_DEBUG, "\n       No SMMU Controllers are discovered"
+                                 "                  ", 0);
+    val_set_status(index, RESULT_SKIP(TEST_NUM, 2));
     return;
   }
 
   while (num_smmu--) {
-      smmu_rev = val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu);
+    if (val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) < 3) {
+      val_print(ACS_PRINT_DEBUG, "\n       Not valid for SMMUv2 or older"
+                                    "version               ", 0);
+      val_set_status(index, RESULT_SKIP(TEST_NUM, 3));
+      return;
+    }
 
-      if (s_el2) {
-            if (smmu_rev == 2) {
-                s1ts = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv2_IDR0, num_smmu), 30, 30);
-                // Stage 1 translation functionality cannot be provided by SMMU v2 revision
-                if (s1ts) {
-                    val_print(ACS_PRINT_ERR,
-                        "\n       SMMUv2 detected: revision must be v3.2 or higher  ", 0);
-                    val_set_status(index, RESULT_FAIL(TEST_NUM, 4));
-                    return;
-                }
-            }
-            else if (smmu_rev == 3) {
-                minor = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_AIDR, num_smmu), 0, 3);
-                s1p = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_IDR0, num_smmu), 1, 1);
-                // Stage 1 translation functionality cannot be provided by SMMU v3.0/3.1 revisions
-                if ((minor < 2) && s1p) {
-                    val_print(ACS_PRINT_ERR,
-                        "\n       SMMUv3.%d detected: revision must be v3.2 or higher  ", minor);
-                    val_set_status(index, RESULT_FAIL(TEST_NUM, 4));
-                    return;
-                }
-            }
-      }
-      if (smmu_rev < 2) {
-            val_print(ACS_PRINT_ERR,
-                "\n       SMMU revision must be at least v2  ", 0);
-            val_set_status(index, RESULT_FAIL(TEST_NUM, 4));
+    data_ril = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_IDR3, num_smmu), 10, 10);
+
+    /* If PE TLB Range Invalidation then SMMU_IDR3.RIL = 0b1 */
+    if (data_pe_tlb == 0x2) {
+        if (data_ril != 0x1) {
+            val_print(ACS_PRINT_ERR, "\n       Range Invalidation unsupported "
+                                     "for SMMU %x", num_smmu);
+            val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
             return;
-      }
+        }
+    }
   }
 
   val_set_status(index, RESULT_PASS(TEST_NUM, 1));
@@ -94,6 +85,7 @@ os_i006_entry(uint32_t num_pe)
   num_pe = 1;  //This test is run on single processor
 
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
+
   if (status != ACS_STATUS_SKIP)
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
 

--- a/val/src/acs_pe.c
+++ b/val/src/acs_pe.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2022, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,12 +69,14 @@ val_pe_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
       status |= os_c012_entry(num_pe);
       status |= os_c013_entry(num_pe);
       status |= os_c014_entry(num_pe);
+#ifdef EXCLUSION_LIST
       status |= os_c015_entry(num_pe);
       status |= os_c016_entry(num_pe);
       status |= os_c017_entry(num_pe);
       status |= os_c018_entry(num_pe);
       status |= os_c019_entry(num_pe);
       status |= os_c020_entry(num_pe);
+#endif
   }
 
   if (g_sw_view[G_SW_HYP]) {

--- a/val/src/acs_smmu.c
+++ b/val/src/acs_smmu.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2022 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -79,11 +79,13 @@ val_smmu_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
        status |= os_i002_entry(num_pe);
        status |= os_i003_entry(num_pe);
        status |= os_i004_entry(num_pe);
+#ifdef EXCLUSION_TEST
        status |= os_i005_entry(num_pe);
        status |= os_i006_entry(num_pe);
        status |= os_i007_entry(num_pe);
        status |= os_i008_entry(num_pe);
        status |= os_i009_entry(num_pe);
+#endif
   }
 
   if (g_sw_view[G_SW_HYP]) {
@@ -91,8 +93,10 @@ val_smmu_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
        status |= hyp_i001_entry(num_pe);
        status |= hyp_i002_entry(num_pe);
        status |= hyp_i003_entry(num_pe);
+#ifdef EXCLUSION_TEST
        status |= hyp_i004_entry(num_pe);
        status |= hyp_i005_entry(num_pe);
+#endif
   /* if OS view is not enabled run below test as part of hyp view, else skip */
        if (!g_sw_view[G_SW_OS])
             status |= os_i009_entry(num_pe);

--- a/val/src/acs_status.c
+++ b/val/src/acs_status.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2020, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2022, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,8 +37,12 @@ val_report_status(uint32_t index, uint32_t status, char8_t *ruleid)
       val_print(ACS_PRINT_ERR, "\n       Failed on PE - %4d", index);
   }
 
-  if (IS_TEST_PASS(status))
-    val_print(ACS_PRINT_TEST, "     : Result:  PASS \n", status);
+  if (IS_TEST_PASS(status)) {
+      val_print(ACS_PRINT_DEBUG, "\n       ", 0);
+      val_print(ACS_PRINT_DEBUG, ruleid, 0);
+      val_print(ACS_PRINT_DEBUG, "\n                                  ", 0);
+      val_print(ACS_PRINT_TEST, "     : Result:  PASS \n", status);
+  }
   else
     if (IS_TEST_FAIL(status)) {
         if (ruleid) {


### PR DESCRIPTION
Implementation of SRSv1.3 exclusion list.

Below is the list of tests excluded from the BSA binary and the rules which test used to cover.

* 15 - B_PE_17
* 16 - B_SEC_01
* 17 - B_SEC_02
* 18 - B_SEC_03
* 19 - B_SEC_04
* 20 - B_SEC_05
* 309 - B_SMMU_11, B_SMMU_22
* 307 - B_SMMU_13
* 308 - B_SMMU_14
* 303 - B_SMMU_03  (305 test is now renamed to 303)
* 304 - B_SMMU_04, B_SMMU_05 (306 test is now renamed to 304)
* 352 - B_SMMU_20 (352 now checks only B_SMMU_18)
* 354 - B_SMMU_21
* 355 - B_SMMU_23 