### PR TITLE
Port code to set interrupt level from test_os_w002.c

### DIFF
--- a/test_pool/power_wakeup/operating_system/test_os_u001.c
+++ b/test_pool/power_wakeup/operating_system/test_os_u001.c
@@ -166,6 +166,13 @@ payload1()
       ns_wdg++;
       intid = val_wd_get_info(timer_num, WD_INFO_GSIV);
       status = val_gic_install_isr(intid, isr1);
+
+      /* Set Interrupt Type Edge/Level Trigger */
+      if (val_wd_get_info(timer_num, WD_INFO_IS_EDGE))
+          val_gic_set_intr_trigger(intid, INTR_TRIGGER_INFO_EDGE_RISING);
+      else
+          val_gic_set_intr_trigger(intid, INTR_TRIGGER_INFO_LEVEL_HIGH);
+
       if (status == 0) {
           failsafe_test_num = TEST_NUM1;
           wakeup_set_failsafe();


### PR DESCRIPTION
Test `501 : Wake from Watchdog WS0 Int` fails dues to interrupt type (edge vs level) not being set as specified in the GTDT table.  The code is present in test `701  : Non Secure Watchdog Access`, which passes.
 
This patch ports the code to set the interrupt type from 701 to 501.  Test 501 passes with the fix.