### PR TITLE
RCiEP and iEP device rules are for SBSA L6

### DIFF
--- a/test_pool/pcie/operating_system/test_os_p020.c
+++ b/test_pool/pcie/operating_system/test_os_p020.c
@@ -20,7 +20,7 @@
 #include "val/include/bsa_acs_val.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 20)
-#define TEST_RULE  "RE_REG_1, RE_REC_1, RE_REC_2"
+#define TEST_RULE  "PCI_IN_05, PCI_IN_19"
 #define TEST_DESC  "Type 0/1 common config rule           "
 
 static

--- a/test_pool/pcie/operating_system/test_os_p021.c
+++ b/test_pool/pcie/operating_system/test_os_p021.c
@@ -20,7 +20,7 @@
 #include "val/include/bsa_acs_val.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 21)
-#define TEST_RULE  "RE_REG_1, RE_REC_1, RE_REC_2"
+#define TEST_RULE  "B_PER_12"
 #define TEST_DESC  "Type 0 config header rules            "
 
 static

--- a/test_pool/pcie/operating_system/test_os_p022.c
+++ b/test_pool/pcie/operating_system/test_os_p022.c
@@ -20,7 +20,7 @@
 #include "test_os_p022_data.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 22)
-#define TEST_RULE  "RE_REC_1, RE_REC_2"
+#define TEST_RULE  "PCI_IN_05, PCI_IN_19"
 #define TEST_DESC  "Check Type 1 config header rules      "
 
 static

--- a/test_pool/pcie/operating_system/test_os_p024.c
+++ b/test_pool/pcie/operating_system/test_os_p024.c
@@ -21,7 +21,7 @@
 #include "test_os_p024_data.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 24)
-#define TEST_RULE  "RE_REG_3, RE_REC_1, RE_REC_2"
+#define TEST_RULE  "PCI_IN_05"
 #define TEST_DESC  "Device capabilities reg rule          "
 
 static

--- a/test_pool/pcie/operating_system/test_os_p025.c
+++ b/test_pool/pcie/operating_system/test_os_p025.c
@@ -21,7 +21,7 @@
 #include "test_os_p025_data.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 25)
-#define TEST_RULE  "RE_REG_3, RE_REC_1, RE_REC_2"
+#define TEST_RULE  "PCI_IN_05"
 #define TEST_DESC  "Device Control register rule          "
 
 static

--- a/test_pool/pcie/operating_system/test_os_p026.c
+++ b/test_pool/pcie/operating_system/test_os_p026.c
@@ -21,7 +21,7 @@
 #include "test_os_p026_data.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 26)
-#define TEST_RULE  "RE_REG_3, RE_REC_1, RE_REC_2"
+#define TEST_RULE  "PCI_IN_05"
 #define TEST_DESC  "Device cap 2 register rules           "
 
 static

--- a/test_pool/pcie/operating_system/test_os_p028.c
+++ b/test_pool/pcie/operating_system/test_os_p028.c
@@ -21,7 +21,7 @@
 #include "test_os_p028_data.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 28)
-#define TEST_RULE  "RE_REG_2, RE_REC_1, RE_REC_2"
+#define TEST_RULE  "PCI_IN_05"
 #define TEST_DESC  "Power management cap rules            "
 
 static

--- a/test_pool/pcie/operating_system/test_os_p030.c
+++ b/test_pool/pcie/operating_system/test_os_p030.c
@@ -22,7 +22,7 @@
 #include "val/include/bsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 30)
-#define TEST_RULE  "RE_REC_1, RE_REC_2"
+#define TEST_RULE  "PCI_IN_19"
 #define TEST_DESC  "Check Cmd Reg memory space enable     "
 
 static void *branch_to_test;

--- a/test_pool/pcie/operating_system/test_os_p031.c
+++ b/test_pool/pcie/operating_system/test_os_p031.c
@@ -22,7 +22,7 @@
 #include "val/include/bsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 31)
-#define TEST_RULE  "RE_REC_1, RE_REC_2"
+#define TEST_RULE  "PCI_IN_19"
 #define TEST_DESC  "Check Type0/1 BIST Register rule      "
 
 static

--- a/test_pool/pcie/operating_system/test_os_p032.c
+++ b/test_pool/pcie/operating_system/test_os_p032.c
@@ -22,7 +22,7 @@
 #include "val/include/bsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 32)
-#define TEST_RULE  "RE_REC_1, RE_REC_2"
+#define TEST_RULE  "PCI_IN_19"
 #define TEST_DESC  "Check HDR CapPtr Register rule        "
 
 static

--- a/test_pool/pcie/operating_system/test_os_p033.c
+++ b/test_pool/pcie/operating_system/test_os_p033.c
@@ -22,7 +22,7 @@
 #include "val/include/bsa_acs_pe.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 33)
-#define TEST_RULE  "RE_REC_1, RE_REC_2"
+#define TEST_RULE  "PCI_IN_05"
 #define TEST_DESC  "Check Max payload size supported      "
 
 static

--- a/test_pool/pcie/operating_system/test_os_p035.c
+++ b/test_pool/pcie/operating_system/test_os_p035.c
@@ -23,7 +23,7 @@
 #include "val/include/bsa_acs_memory.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 35)
-#define TEST_RULE  "RE_RST_1, PCI_SM_02"
+#define TEST_RULE  "PCI_SM_02"
 #define TEST_DESC  "Check Function level reset            "
 
 uint32_t is_flr_failed(uint32_t bdf)

--- a/test_pool/pcie/operating_system/test_os_p061.c
+++ b/test_pool/pcie/operating_system/test_os_p061.c
@@ -22,7 +22,7 @@
 #include "val/include/bsa_acs_memory.h"
 
 #define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 61)
-#define TEST_RULE  "PCI_MM_01, PCI_MM_02, PCI_MM_03, RE_BAR_2"
+#define TEST_RULE  "PCI_MM_01, PCI_MM_02, PCI_MM_03"
 #define TEST_DESC  "PCIe Unaligned access                 "
 
 #define DATA 0xC0DECAFE

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -312,35 +312,39 @@ val_pcie_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
       status |= os_p002_entry(num_pe);
       status |= os_p003_entry(num_pe);
       status |= os_p004_entry(num_pe);
-      status |= os_p005_entry(num_pe);
       status |= os_p006_entry(num_pe);
       status |= os_p008_entry(num_pe);
       status |= os_p009_entry(num_pe);
-      status |= os_p010_entry(num_pe);
       status |= os_p011_entry(num_pe);
+
+#ifdef PCIE_ON_CHIP_DEV_TEST
+      status |= os_p005_entry(num_pe);
+      status |= os_p010_entry(num_pe);
       status |= os_p012_entry(num_pe);
       status |= os_p013_entry(num_pe);
       status |= os_p014_entry(num_pe);
       status |= os_p015_entry(num_pe);
       status |= os_p016_entry(num_pe);
+      status |= os_p023_entry(num_pe);
+      status |= os_p027_entry(num_pe);
+      status |= os_p029_entry(num_pe);
+      status |= os_p034_entry(num_pe);
+#endif
+
       status |= os_p017_entry(num_pe);
       status |= os_p018_entry(num_pe);
       status |= os_p019_entry(num_pe);
       status |= os_p020_entry(num_pe);
       status |= os_p021_entry(num_pe);
       status |= os_p022_entry(num_pe);
-      status |= os_p023_entry(num_pe);
       status |= os_p024_entry(num_pe);
       status |= os_p025_entry(num_pe);
       status |= os_p026_entry(num_pe);
-      status |= os_p027_entry(num_pe);
       status |= os_p028_entry(num_pe);
-      status |= os_p029_entry(num_pe);
       status |= os_p030_entry(num_pe);
       status |= os_p031_entry(num_pe);
       status |= os_p032_entry(num_pe);
       status |= os_p033_entry(num_pe);
-      status |= os_p034_entry(num_pe);
       status |= os_p035_entry(num_pe);
       status |= os_p036_entry(num_pe);
 
@@ -557,6 +561,7 @@ val_pcie_create_device_bdf_table()
   uint32_t reg_value;
   uint32_t cid_offset;
   uint32_t p_cap;
+  uint32_t dp_type;
 
   /* if table is already present, return success */
   if (g_pcie_bdf_table)
@@ -621,6 +626,16 @@ val_pcie_create_device_bdf_table()
                         &cid_offset);
 
                       if (p_cap != PCIE_SUCCESS)
+                          continue;
+
+                      dp_type = val_pcie_device_port_type(bdf);
+
+                      /* RCiEP device rules are for SBSA L6 */
+                      if (dp_type == RCiEP)
+                          continue;
+
+                      /* iEP device rules are for SBSA L6 */
+                      if ((dp_type == iEP_EP) || (dp_type == iEP_RP))
                           continue;
 
                       g_pcie_bdf_table->device[g_pcie_bdf_table->num_entries++].bdf = bdf;


### PR DESCRIPTION
  Fix for #40
  * rciep and iep will not be part of bdf table
  * rciep and iep only pcie test omitted from BSA
        * pcie test 5, 10, 12, 13, 14, 15, 16, 23, 27, 29, 34
  * pcie register test TEST_DESC changed to omit rciep and iep rule id