### PR TITLE
Ported SBSA pcie linux test 407, 408 to BSA

### DIFF
--- a/test_pool/Makefile
+++ b/test_pool/Makefile
@@ -31,6 +31,8 @@ bsa_acs_test-objs += $(TEST_POOL)/pcie/operating_system/test_os_p001.o \
                      $(TEST_POOL)/pcie/operating_system/test_os_p064.o \
                      $(TEST_POOL)/pcie/operating_system/test_os_p065.o \
                      $(TEST_POOL)/pcie/operating_system/test_os_p066.o \
+                     $(TEST_POOL)/pcie/operating_system/test_os_p067.o \
+                     $(TEST_POOL)/pcie/operating_system/test_os_p068.o \
                      $(TEST_POOL)/peripherals/operating_system/test_os_d004.o \
                      $(TEST_POOL)/memory_map/operating_system/test_os_m004.o \
 

--- a/test_pool/pcie/operating_system/test_os_p067.c
+++ b/test_pool/pcie/operating_system/test_os_p067.c
@@ -1,0 +1,208 @@
+/** @file
+ * Copyright (c) 2016-2018, 2021-2022 Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_memory.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 67)
+#define TEST_RULE  "PCI_MSI_2"
+#define TEST_DESC  "Check MSI(X) vectors uniqueness   "
+
+/**
+    @brief   Returns MSI(X) status of the device
+
+    @param   dev_index    index of PCI device
+
+    @return  0    device does not support MSI(X)
+    @return  1    device supports MSI(X)
+**/
+static
+uint32_t
+check_msi_status (uint32_t dev_index) {
+  uint32_t data;
+
+  data = val_peripheral_get_info (ANY_FLAGS, dev_index);
+
+  if ((data & PER_FLAG_MSI_ENABLED) &&
+      val_peripheral_get_info (ANY_GSIV, dev_index)) {
+    return 1;
+  }
+
+  return 0;
+}
+
+/**
+    @brief   Compare two lists of MSI(X) vectors
+
+    @param   list_one    pointer to a first list of MSI(X) vectors
+    @param   list_two    pointer to a second list of MSI(X) vectors
+
+    @return  0    no vectors duplicates are found
+    @return  1    lists contain at leas one common MSI(X) vector
+**/
+static
+uint32_t
+check_list_duplicates (PERIPHERAL_VECTOR_LIST *list_one, PERIPHERAL_VECTOR_LIST *list_two)
+{
+  PERIPHERAL_VECTOR_LIST *flist_node;
+  PERIPHERAL_VECTOR_LIST *slist_node;
+
+  uint32_t fcount = 0;
+  uint32_t scount = 0;
+  uint32_t irq_start1, irq_end1;
+  uint32_t irq_start2, irq_end2;
+
+  flist_node = list_one;
+  slist_node = list_two;
+
+  while (flist_node != NULL) {
+    while (slist_node != NULL) {
+      irq_start1 = flist_node->vector.vector_irq_base;
+      irq_end1 = flist_node->vector.vector_irq_base + flist_node->vector.vector_n_irqs - 1;
+      irq_start2 = slist_node->vector.vector_irq_base;
+      irq_end2 = slist_node->vector.vector_irq_base + slist_node->vector.vector_n_irqs - 1;
+      if (!(irq_end1 < irq_start2 || irq_start1 > irq_end2))
+        return 1;
+      slist_node = slist_node->next;
+      scount++;
+    }
+    slist_node = list_two;
+    flist_node = flist_node->next;
+    fcount++;
+    scount = 0;
+  }
+
+  return 0;
+}
+
+/**
+    @brief   Free memory allocated for a list of MSI(X) vectors
+
+    @param   list    pointer to a list of MSI(X) vectors
+**/
+static
+void
+clean_msi_list (PERIPHERAL_VECTOR_LIST *list)
+{
+  PERIPHERAL_VECTOR_LIST *next_node;
+  PERIPHERAL_VECTOR_LIST *current_node;
+
+  current_node = list;
+  while (current_node != NULL) {
+    next_node = current_node->next;
+    val_memory_free (current_node);
+    current_node = next_node;
+  }
+}
+
+static
+void
+payload (void)
+{
+
+  uint32_t count = val_peripheral_get_info (NUM_ALL, 0);
+  uint32_t index = val_pe_get_index_mpid (val_pe_get_mpid());
+  uint8_t status;
+  PERIPHERAL_VECTOR_LIST *current_dev_mvec;
+  PERIPHERAL_VECTOR_LIST *next_dev_mvec;
+  uint64_t current_dev_bdf;
+  uint64_t next_dev_bdf;
+  uint32_t count_next;
+  uint32_t test_skip = 1;
+
+  if(!count) {
+     val_set_status (index, RESULT_SKIP(TEST_NUM, 3));
+     return;
+  }
+
+  status = 0;
+  current_dev_mvec = NULL;
+  next_dev_mvec = NULL;
+
+  /*
+    Pull each discovered PCI device and its list of MSI(X) vectors.
+    Compare this list with MSI(X) vector lists of other discovered
+    PCI devices and find duplicates exist.
+  */
+  while (count > 0 && !status) {
+    count_next = count - 1;
+    if (check_msi_status (count - 1)) {
+      /* Get BDF of a device */
+      current_dev_bdf = val_peripheral_get_info (ANY_BDF, count - 1);
+      if (current_dev_bdf) {
+        val_print (ACS_PRINT_INFO, "       Checking PCI device with BDF %4X\n", current_dev_bdf);
+        /* Read MSI(X) vectors */
+        if (val_get_msi_vectors (current_dev_bdf, &current_dev_mvec)) {
+
+          /* Pull other PCI devices left in the devices list */
+          while (count_next > 0 && !status) {
+            if (check_msi_status (count_next - 1)) {
+              /* Get BDF of a device */
+              next_dev_bdf = val_peripheral_get_info (ANY_BDF, count_next - 1);
+              /* Read MSI(X) vectors */
+              if (val_get_msi_vectors (next_dev_bdf, &next_dev_mvec)) {
+                test_skip = 0;
+                /* Compare two lists of MSI(X) vectors */
+                if(check_list_duplicates (current_dev_mvec, next_dev_mvec)) {
+                  val_print (ACS_STATUS_ERR, "\n       Allocated MSIs are not unique", 0);
+                  val_set_status (index, RESULT_FAIL(TEST_NUM, 02));
+                  status = 1;
+                }
+                clean_msi_list (next_dev_mvec);
+              }
+            }
+            count_next--;
+          }
+
+          clean_msi_list (current_dev_mvec);
+        }
+      } else {
+        val_print (ACS_PRINT_DEBUG, "\n       Invalid BDF 0x%x", current_dev_bdf);
+      }
+    }
+    count--;
+  }
+
+  if (test_skip) {
+    val_print(ACS_PRINT_ERR, "\n       No MSI vectors found ", 0);;
+    val_set_status (index, RESULT_SKIP(TEST_NUM, 01));
+  } else  if (!status) {
+    val_set_status (index, RESULT_PASS(TEST_NUM, 01));
+  }
+}
+
+uint32_t
+os_p067_entry (uint32_t num_pe)
+{
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_pe = 1;  //This test is run on single processor
+
+  status = val_initialize_test (TEST_NUM, TEST_DESC, num_pe);
+  if (status != ACS_STATUS_SKIP) {
+      val_run_test_payload (TEST_NUM, num_pe, payload, 0);
+  }
+
+  /* get the result from all PE and check for failure */
+  status = val_check_for_error (TEST_NUM, num_pe, TEST_RULE);
+
+  val_report_status (0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/test_os_p068.c
+++ b/test_pool/pcie/operating_system/test_os_p068.c
@@ -1,0 +1,99 @@
+/** @file
+ * Copyright (c) 2016-2019, 2022 Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_smmu.h"
+#include "val/include/bsa_acs_pcie.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 68)
+#define TEST_RULE  "PCI_PAS_1"
+#define TEST_DESC  "PASID support atleast 16 bits     "
+
+#define MIN_PASID_SUPPORT 16
+
+static void
+payload(void)
+{
+  int num_per = 0, num_smmu = 0, skip = 1;
+  uint32_t max_pasids = 0;
+  uint32_t index = val_pe_get_index_mpid (val_pe_get_mpid());
+
+  num_per = val_peripheral_get_info(NUM_ALL, 0);
+  /* For each peripheral check for PASID support */
+  /* If PASID is supported, test the max number of PASIDs supported */
+  for(num_per--; num_per >= 0; num_per--)
+  {
+     if((max_pasids = val_peripheral_get_info(MAX_PASIDS, num_per)) > 0)
+     {
+        skip = 0;
+        if(max_pasids < MIN_PASID_SUPPORT)
+        {
+           val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
+           break;
+        }
+     }
+  }
+  if(num_per < 0)
+  {
+     /* For each SMMUv3 check for PASID support */
+     /* If PASID is supported, test the max number of PASIDs supported */
+     num_smmu = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
+          for (num_smmu--; num_smmu >= 0; num_smmu--)
+     {
+         if (val_iovirt_get_smmu_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) == 3)
+         {
+             if((max_pasids = val_smmu_max_pasids(num_smmu)) > 0)
+             {
+                 skip = 0;
+                 if(max_pasids < MIN_PASID_SUPPORT)
+                 {
+                    val_set_status(index, RESULT_FAIL(TEST_NUM, 2));
+                    break;
+                 }
+             }
+         }
+     }
+  }
+  if(num_smmu < 0) {
+      if(skip)
+          val_set_status(index, RESULT_SKIP(TEST_NUM, 3));
+      else
+          val_set_status(index, RESULT_PASS(TEST_NUM, 0));
+  }
+}
+
+uint32_t
+os_p068_entry(uint32_t num_pe)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_pe = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_pe, payload, 0);
+
+  /* get the result from all PE and check for failure */
+  status = val_check_for_error(TEST_NUM, num_pe, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/val/include/bsa_acs_pcie.h
+++ b/val/include/bsa_acs_pcie.h
@@ -255,5 +255,7 @@ uint32_t os_p063_entry(uint32_t num_pe);
 uint32_t os_p064_entry(uint32_t num_pe);
 uint32_t os_p065_entry(uint32_t num_pe);
 uint32_t os_p066_entry(uint32_t num_pe);
+uint32_t os_p067_entry(uint32_t num_pe);
+uint32_t os_p068_entry(uint32_t num_pe);
 
 #endif

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -262,6 +262,7 @@ void     val_iovirt_free_info_table(void);
 uint32_t val_iovirt_get_rc_smmu_index(uint32_t rc_seg_num, uint32_t rid);
 uint32_t val_smmu_execute_tests(uint32_t num_pe, uint32_t *g_sw_view);
 uint64_t val_smmu_get_info(SMMU_INFO_e, uint32_t index);
+uint64_t val_iovirt_get_smmu_info(SMMU_INFO_e type, uint32_t index);
 
 typedef enum {
     DMA_NUM_CTRL = 1,

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -317,6 +317,8 @@ val_pcie_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
       status |= os_p064_entry(num_pe);
       status |= os_p065_entry(num_pe);
       status |= os_p066_entry(num_pe);
+      status |= os_p067_entry(num_pe);
+      status |= os_p068_entry(num_pe);
 #else
       status |= os_p002_entry(num_pe);
       status |= os_p003_entry(num_pe);

--- a/val/src/acs_smmu.c
+++ b/val/src/acs_smmu.c
@@ -233,7 +233,7 @@ val_smmu_max_pasids(uint32_t smmu_index)
 {
   uint64_t smmu_base;
 
-  smmu_base = val_smmu_get_info(SMMU_CTRL_BASE, smmu_index);
+  smmu_base = val_iovirt_get_smmu_info(SMMU_CTRL_BASE, smmu_index);
   return pal_smmu_max_pasids(smmu_base);
 }
 


### PR DESCRIPTION
SBSA linux test 407 and 408 targetting BSA rules PCI_MSI_01 and PCI_MSI_02 are ported to BSA as pcie linux test 863 and 867