### PR TITLE
PCIe: Updates to tests and fixes

### DIFF
--- a/test_pool/pcie/operating_system/test_os_p037.c
+++ b/test_pool/pcie/operating_system/test_os_p037.c
@@ -1,0 +1,115 @@
+/** @file
+ * Copyright (c) 2022 Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_pe.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 37)
+#define TEST_DESC  "Check Config Txn for RP in HB         "
+#define TEST_RULE  "PCI_IN_12"
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t Status;
+  uint32_t dp_type;
+  uint32_t pe_index;
+  uint32_t tbl_index;
+  uint32_t fail_cnt;
+  uint32_t test_skip = 1;
+  uint32_t ecam_cc;
+  uint32_t pciio_proto_cc;
+  addr_t ecam_base;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  fail_cnt = 0;
+  tbl_index = 0;
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
+
+  while (tbl_index < bdf_tbl_ptr->num_entries)
+  {
+      /*
+       * Check that Host Bridge Consumes the Configuration
+       * request intended for RootPort Configuration space.
+       * Access RootPort Config Space using ECAM Method.
+       */
+      bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+      if ((dp_type == RP) || (dp_type == iEP_RP)) {
+        /* Read Vendor ID of RP with ECAM based mechanism, and compare it with the */
+        ecam_base = val_pcie_get_ecam_base(bdf);
+
+        /* Read Function's Class Code through ECAM method */
+        ecam_cc = val_mmio_read(ecam_base +
+                  PCIE_EXTRACT_BDF_BUS(bdf) * PCIE_MAX_DEV * PCIE_MAX_FUNC * PCIE_CFG_SIZE +
+                  PCIE_EXTRACT_BDF_DEV(bdf) * PCIE_MAX_FUNC * PCIE_CFG_SIZE +
+                  PCIE_EXTRACT_BDF_FUNC(bdf) * PCIE_CFG_SIZE +
+                  TYPE01_RIDR);
+
+        /* Read Function's Class Code through Pciio Protocol method */
+        Status = val_pcie_io_read_cfg(bdf, TYPE01_RIDR, &pciio_proto_cc);
+        if (Status == PCIE_NO_MAPPING) {
+          val_print(ACS_PRINT_ERR, "\n       Reading Class code using PciIo protocol failed ", 0);
+          val_set_status(pe_index, RESULT_FAIL(TEST_NUM, 01));
+          return;
+        }
+
+        /* If test runs for atleast an endpoint */
+        test_skip = 0;
+
+        if (ecam_cc != pciio_proto_cc)
+        {
+          val_print(ACS_PRINT_ERR, "\n        Config Txn Error : 0x%x ", bdf);
+          fail_cnt++;
+        }
+      }
+  }
+
+  if (test_skip == 1)
+      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 01));
+  else if (fail_cnt)
+      val_set_status(pe_index, RESULT_FAIL(TEST_NUM, fail_cnt));
+  else
+      val_set_status(pe_index, RESULT_PASS(TEST_NUM, 01));
+}
+
+uint32_t
+os_p037_entry(uint32_t num_pe)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_pe = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_pe, payload, 0);
+
+  /* get the result from all PE and check for failure */
+  status = val_check_for_error(TEST_NUM, num_pe, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/test_pool/pcie/operating_system/test_os_p038.c
+++ b/test_pool/pcie/operating_system/test_os_p038.c
@@ -1,0 +1,125 @@
+/** @file
+ * Copyright (c) 2022 Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/bsa_acs_val.h"
+#include "val/include/val_interface.h"
+
+#include "val/include/bsa_acs_pcie.h"
+#include "val/include/bsa_acs_pe.h"
+#include "val/include/bsa_acs_memory.h"
+
+#define TEST_NUM   (ACS_PCIE_TEST_NUM_BASE + 38)
+#define TEST_DESC  "Check all RP in HB is in same ECAM    "
+#define TEST_RULE  "PCI_IN_03"
+
+
+static
+void
+payload(void)
+{
+
+  uint32_t bdf;
+  uint32_t dp_type;
+  uint32_t pe_index;
+  uint32_t tbl_index;
+  uint32_t ecam_index;
+  uint64_t ecam_base;
+  uint32_t reg_value;
+  uint16_t vendor_id;
+  uint32_t device_id;
+  uint32_t test_skip = 1;
+  uint32_t test_fail = 0;
+  uint32_t segment;
+  uint64_t rp_ecam_base;
+  uint32_t rp_segment;
+
+  pcie_device_bdf_table *bdf_tbl_ptr;
+
+  tbl_index = 0;
+  ecam_index = 0;
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
+
+  while (tbl_index < bdf_tbl_ptr->num_entries)
+  {
+      next_bdf:
+      bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+      dp_type = val_pcie_device_port_type(bdf);
+
+      if (dp_type == RP || dp_type == iEP_RP)
+      {
+          test_skip = 0;
+          ecam_index = 0;
+
+          val_pcie_read_cfg(bdf, TYPE01_VIDR, &reg_value);
+          device_id = (reg_value >> TYPE01_DIDR_SHIFT) & TYPE01_DIDR_MASK;
+          vendor_id = (reg_value >> TYPE01_VIDR_SHIFT) & TYPE01_VIDR_MASK;
+          val_print(ACS_PRINT_DEBUG, "\n       BDF: 0x%x ", bdf);
+          val_print(ACS_PRINT_DEBUG, "Dev ID: 0x%x ", device_id);
+          val_print(ACS_PRINT_DEBUG, "Vendor ID: 0x%x", vendor_id);
+
+          rp_ecam_base = val_pcie_get_ecam_base(bdf);
+          rp_segment = PCIE_EXTRACT_BDF_SEG(bdf);
+
+          while (ecam_index < val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0))
+          {
+              ecam_base = val_pcie_get_info(PCIE_INFO_ECAM, ecam_index);
+              segment = val_pcie_get_info(PCIE_INFO_SEGMENT, ecam_index);
+
+              if (ecam_base == rp_ecam_base && segment == rp_segment)
+              {
+                  val_print(ACS_PRINT_DEBUG,
+                            "\n       ECAM base 0x%x matches with RPs base address ", ecam_base);
+                  goto next_bdf;
+              }
+
+              ecam_index++;
+          }
+
+          val_print(ACS_PRINT_ERR, "\n       RP BDF 0x%x not under any HB", bdf);
+          test_fail++;
+      }
+  }
+
+  if (test_skip == 1)
+      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 01));
+  else if (test_fail)
+      val_set_status(pe_index, RESULT_FAIL(TEST_NUM, test_fail));
+  else
+      val_set_status(pe_index, RESULT_PASS(TEST_NUM, 01));
+}
+
+uint32_t
+os_p038_entry(uint32_t num_pe)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+
+  num_pe = 1;  //This test is run on single processor
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_pe, payload, 0);
+
+  /* get the result from all PE and check for failure */
+  status = val_check_for_error(TEST_NUM, num_pe, TEST_RULE);
+
+  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+
+  return status;
+}
+

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -1,5 +1,5 @@
 ## @file
-#  Copyright (c) 2016-2021 Arm Limited or its affiliates. All rights reserved.
+#  Copyright (c) 2016-2022 Arm Limited or its affiliates. All rights reserved.
 #  SPDX-License-Identifier : Apache-2.0
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -101,6 +101,8 @@
   ../test_pool/pcie/operating_system/test_os_p033.c
   ../test_pool/pcie/operating_system/test_os_p035.c
   ../test_pool/pcie/operating_system/test_os_p036.c
+  ../test_pool/pcie/operating_system/test_os_p037.c
+  ../test_pool/pcie/operating_system/test_os_p038.c
   ../test_pool/smmu/operating_system/test_os_i001.c
   ../test_pool/smmu/operating_system/test_os_i002.c
   ../test_pool/smmu/operating_system/test_os_i005.c

--- a/val/include/bsa_acs_pcie.h
+++ b/val/include/bsa_acs_pcie.h
@@ -252,6 +252,8 @@ uint32_t os_p033_entry(uint32_t num_pe);
 uint32_t os_p034_entry(uint32_t num_pe);
 uint32_t os_p035_entry(uint32_t num_pe);
 uint32_t os_p036_entry(uint32_t num_pe);
+uint32_t os_p037_entry(uint32_t num_pe);
+uint32_t os_p038_entry(uint32_t num_pe);
 
 /* Linux test */
 uint32_t os_p061_entry(uint32_t num_pe);

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -345,6 +345,8 @@ val_pcie_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
       status |= os_p033_entry(num_pe);
       status |= os_p035_entry(num_pe);
       status |= os_p036_entry(num_pe);
+      status |= os_p037_entry(num_pe);
+      status |= os_p038_entry(num_pe);
 
 #endif
 


### PR DESCRIPTION
- Added tests test_os_p037.c and test_os_p038.c
- Skip the port if the DLL is not active. Test previously checks if DLL is active and if not skip the DP. There is another status where DLL is not supported. So, the check is modified to skip if the DLL is not active.

Signed-off-by: Sujana M <sujana.m@arm.com>

Co-authored-by: Gowtham Siddarth <gowtham.siddarth@arm.com>
Co-authored-by: Sujana M <sujana.m@arm.com>