### PR TITLE
pal_uefi_dt: pal_pe: Correct idx variable when parsing fdt

### DIFF
--- a/platform/pal_uefi_dt/src/pal_pe.c
+++ b/platform/pal_uefi_dt/src/pal_pe.c
@@ -359,7 +359,7 @@ pal_pe_data_cache_ops_by_va(UINT64 addr, UINT32 type)
 VOID
 pal_pe_info_table_pmu_gsiv_dt(PE_INFO_TABLE *PeTable)
 {
-  int i, offset, prop_len;
+  int i, arr_idx, offset, prop_len;
   UINT64 dt_ptr = 0;
   UINT32 *Pintr;
   int index = 0;
@@ -379,12 +379,12 @@ pal_pe_info_table_pmu_gsiv_dt(PE_INFO_TABLE *PeTable)
 
   Ptr = PeTable->pe_info;
 
-  for (i = 0; i < (sizeof(pmu_dt_arr)/PMU_COMPATIBLE_STR_LEN); i++) {
+  for (arr_idx = 0; arr_idx < (sizeof(pmu_dt_arr)/PMU_COMPATIBLE_STR_LEN); arr_idx++) {
 
       /* Search for pmu nodes*/
-      offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, pmu_dt_arr[i]);
+      offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, pmu_dt_arr[arr_idx]);
       if (offset < 0) {
-          bsa_print(ACS_PRINT_DEBUG, L"  PMU compatible value not found for index:%d\n", i);
+          bsa_print(ACS_PRINT_DEBUG, L"  PMU compatible value not found for index:%d\n", arr_idx);
           continue; /* Search for next compatible item*/
       }
 
@@ -463,7 +463,7 @@ pal_pe_info_table_pmu_gsiv_dt(PE_INFO_TABLE *PeTable)
               }
           }
           offset =
-              fdt_node_offset_by_compatible((const void *)dt_ptr, offset, pmu_dt_arr[i]);
+              fdt_node_offset_by_compatible((const void *)dt_ptr, offset, pmu_dt_arr[arr_idx]);
       }
   }
 }


### PR DESCRIPTION
Previous 'i' is used in various place make the forever loop.

Signed-off-by: Huynh Thanh Hung <hunght.vn8@gmail.com>