### PR TITLE
GIC test 226 divided into three separate tests

### DIFF
--- a/platform/pal_uefi_acpi/src/pal_timer_wd.c
+++ b/platform/pal_uefi_acpi/src/pal_timer_wd.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2022, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -150,8 +150,8 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
       TimerTable->header.el2_virt_timer_gsiv = *(++virtualpl2);
       TimerTable->header.el2_virt_timer_flag = *(++virtualpl2);
       if (TimerTable->header.el2_virt_timer_gsiv == 0) {
-         bsa_print(ACS_PRINT_WARN, L" \n GTDT don't have el2 virt timer info");
-         bsa_print(ACS_PRINT_WARN, L" \n using bsa recommended value 28");
+         bsa_print(ACS_PRINT_DEBUG, L"  GTDT don't have el2 virt timer info\n");
+         bsa_print(ACS_PRINT_DEBUG, L"  using bsa recommended value 28\n");
          TimerTable->header.el2_virt_timer_gsiv = PLATFORM_OVERRIDE_EL2_VIR_TIMER_GSIV;
       }
 

--- a/test_pool/gic/hypervisor/test_hyp_g002.c
+++ b/test_pool/gic/hypervisor/test_hyp_g002.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2021, 2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,21 +23,21 @@
 #include "val/include/bsa_acs_gic.h"
 #include "val/include/bsa_acs_gic_support.h"
 
-#define TEST_NUM   (ACS_GIC_HYP_TEST_NUM_BASE + 1)
+#define TEST_NUM   (ACS_GIC_HYP_TEST_NUM_BASE + 2)
 #define TEST_RULE  "B_PPI_02"
-#define TEST_DESC  "Check NS EL2-Virt timer PPI Assignment"
+#define TEST_DESC  "Check NS EL2-Phy timer PPI Assignment "
 
 static uint32_t intid;
 
-/*Interrupt handler for the hypervisor virtual timer interrupt*/
+/*Interrupt handler for the hypervisor physical timer interrupt*/
 static
 void
-isr_vir()
+isr_phy()
 {
     uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
     /* We received our interrupt, so disable timer from generating further interrupts */
-    val_timer_set_vir_el2(0);
-    val_print(ACS_PRINT_INFO, "\n       Received interrupt    ", 0);
+    val_timer_set_phy_el2(0);
+    val_print(ACS_PRINT_INFO, "\n       Received interrupt     ", 0);
     val_set_status(index, RESULT_PASS(TEST_NUM, 1));
     val_gic_end_of_interrupt(intid);
 }
@@ -47,8 +47,7 @@ void
 payload()
 {
 
-    /*Check CNTHV interrupt received*/
-    uint32_t data;
+    /*Check CNTHP interrupt received*/
     uint32_t timeout = TIMEOUT_LARGE;
     uint64_t timer_expire_val = 100;
     uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
@@ -60,61 +59,48 @@ payload()
         return;
     }
 
-    /*Check non-secure EL2 virtual timer*/
+    /*Check non-secure EL2 physical timer*/
     val_set_status(index, RESULT_PENDING(TEST_NUM));
-
-    /* This test is run only when ARM v8.1 Virtualized Host Extensions are supported */
-    data = val_pe_reg_read(ID_AA64MMFR1_EL1);
-
-    /* Check for EL2 virtual timer interrupt, if PE supports 8.1 or greater.
-     * ID_AA64MMFR1_EL1 VH, bits [11:8] should be 0x1 */
-    if (!((data >> 8) & 0xF)) {
-        val_print(ACS_PRINT_DEBUG, "\n       v8.1 VHE not supported on this PE ", 0);
-        val_set_status(index, RESULT_SKIP(TEST_NUM, 2));
-        return;
-    }
-
-    /*Get EL2 virtual timer interrupt ID*/
-    intid = val_timer_get_info(TIMER_INFO_VIR_EL2_INTID, 0);
-    /*Recommended EL2 virtual timer interrupt ID is 28 as per SBSA*/
+    /*Get EL2 physical timer interrupt ID*/
+    intid = val_timer_get_info(TIMER_INFO_PHY_EL2_INTID, 0);
+    /*Recommended EL2 physical timer interrupt ID is 26 as per SBSA*/
     if (g_build_sbsa) {
-        if (intid != 28) {
-           val_print(ACS_PRINT_ERR, "\n       NS EL2 virtual timer not mapped to PPI ID 28, id %d",
-                                                                    intid);
-           val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
-           return;
+        if (intid != 26) {
+            val_print(ACS_PRINT_DEBUG,
+                  "\n       NS EL2 physical timer not mapped to PPI id 26, INTID: %d ", intid);
+            val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
+            return;
         }
     }
     /*Check if interrupt is in PPI INTID range*/
     if ((intid < 16 || intid > 31) && (!val_gic_is_valid_eppi(intid))) {
         val_print(ACS_PRINT_DEBUG,
-                    "\n       NS EL2 virtual timer not mapped to PPI base range, INTID: %d   ",
-                    intid);
+            "\n       NS EL2 physical timer not mapped to PPI base range, INTID: %d   ", intid);
         val_set_status(index, RESULT_FAIL(TEST_NUM, 2));
         return;
     }
 
-    if (val_gic_install_isr(intid, isr_vir)) {
+    if (val_gic_install_isr(intid, isr_phy)) {
         val_print(ACS_PRINT_ERR, "\n       GIC Install Handler Failed...", 0);
         val_set_status(index, RESULT_FAIL(TEST_NUM, 3));
         return;
     }
 
-    val_timer_set_vir_el2(timer_expire_val);
+    val_timer_set_phy_el2(timer_expire_val);
     while ((--timeout > 0) && (IS_RESULT_PENDING(val_get_status(index)))) {
         ;
     }
 
     if (timeout == 0) {
         val_print(ACS_PRINT_ERR,
-            "\n       NS EL2 Virtual timer interrupt %d not received", intid);
+            "\n       EL2-Phy timer interrupt not received on INTID: %d   ", intid);
         val_set_status(index, RESULT_FAIL(TEST_NUM, 4));
     }
     return;
 }
 
 uint32_t
-hyp_g001_entry(uint32_t num_pe)
+hyp_g002_entry(uint32_t num_pe)
 {
 
     uint32_t status = ACS_STATUS_FAIL;

--- a/test_pool/gic/hypervisor/test_hyp_g003.c
+++ b/test_pool/gic/hypervisor/test_hyp_g003.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2021, 2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,22 +23,29 @@
 #include "val/include/bsa_acs_gic.h"
 #include "val/include/bsa_acs_gic_support.h"
 
-#define TEST_NUM   (ACS_GIC_HYP_TEST_NUM_BASE + 1)
+#define TEST_NUM   (ACS_GIC_HYP_TEST_NUM_BASE + 3)
 #define TEST_RULE  "B_PPI_02"
-#define TEST_DESC  "Check NS EL2-Virt timer PPI Assignment"
+#define TEST_DESC  "Check GIC Maintenance PPI Assignment  "
 
 static uint32_t intid;
 
-/*Interrupt handler for the hypervisor virtual timer interrupt*/
+/* Interrupt handler for the GIC Maintenance interrupt*/
 static
 void
-isr_vir()
+isr_mnt()
 {
+    uint32_t data;
     uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
-    /* We received our interrupt, so disable timer from generating further interrupts */
-    val_timer_set_vir_el2(0);
-    val_print(ACS_PRINT_INFO, "\n       Received interrupt    ", 0);
+
+    /* We received our interrupt, so disable Maintenance
+     *interrupt from generating further interrupts */
+    data = val_gic_reg_read(ICH_HCR_EL2);
+    /*unset ICH_HCR_EL2 bits [2:0] to disable the interrupt*/
+    data &= ~0x7;
+    val_gic_reg_write(ICH_HCR_EL2, data);
+
     val_set_status(index, RESULT_PASS(TEST_NUM, 1));
+    val_print(ACS_PRINT_INFO, "\n       Received GIC maintenance interrupt ", 0);
     val_gic_end_of_interrupt(intid);
 }
 
@@ -47,10 +54,9 @@ void
 payload()
 {
 
-    /*Check CNTHV interrupt received*/
+    /*Check GIC Maintenance interrupt received*/
     uint32_t data;
     uint32_t timeout = TIMEOUT_LARGE;
-    uint64_t timer_expire_val = 100;
     uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
     if (val_pe_reg_read(CurrentEL) == AARCH64_EL1) {
@@ -60,27 +66,15 @@ payload()
         return;
     }
 
-    /*Check non-secure EL2 virtual timer*/
+    /*Check GIC maintenance interrupt*/
     val_set_status(index, RESULT_PENDING(TEST_NUM));
-
-    /* This test is run only when ARM v8.1 Virtualized Host Extensions are supported */
-    data = val_pe_reg_read(ID_AA64MMFR1_EL1);
-
-    /* Check for EL2 virtual timer interrupt, if PE supports 8.1 or greater.
-     * ID_AA64MMFR1_EL1 VH, bits [11:8] should be 0x1 */
-    if (!((data >> 8) & 0xF)) {
-        val_print(ACS_PRINT_DEBUG, "\n       v8.1 VHE not supported on this PE ", 0);
-        val_set_status(index, RESULT_SKIP(TEST_NUM, 2));
-        return;
-    }
-
-    /*Get EL2 virtual timer interrupt ID*/
-    intid = val_timer_get_info(TIMER_INFO_VIR_EL2_INTID, 0);
-    /*Recommended EL2 virtual timer interrupt ID is 28 as per SBSA*/
+    /*Get GIC maintenance interrupt ID*/
+    intid = val_pe_get_gmain_gsiv(index);
+    /*Recommended GIC maintenance interrupt ID is 25 as per SBSA*/
     if (g_build_sbsa) {
-        if (intid != 28) {
-           val_print(ACS_PRINT_ERR, "\n       NS EL2 virtual timer not mapped to PPI ID 28, id %d",
-                                                                    intid);
+        if (intid != 25) {
+           val_print(ACS_PRINT_ERR,
+                     "\n       GIC Maintenance interrupt not mapped to PPI ID 25, id %d", intid);
            val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
            return;
         }
@@ -88,33 +82,38 @@ payload()
     /*Check if interrupt is in PPI INTID range*/
     if ((intid < 16 || intid > 31) && (!val_gic_is_valid_eppi(intid))) {
         val_print(ACS_PRINT_DEBUG,
-                    "\n       NS EL2 virtual timer not mapped to PPI base range, INTID: %d   ",
-                    intid);
+            "\n       GIC Maintenance interrupt not mapped to PPI base range,"
+            "\n       INTID: %d   ", intid);
         val_set_status(index, RESULT_FAIL(TEST_NUM, 2));
         return;
     }
 
-    if (val_gic_install_isr(intid, isr_vir)) {
+    if (val_gic_install_isr(intid, isr_mnt)) {
         val_print(ACS_PRINT_ERR, "\n       GIC Install Handler Failed...", 0);
         val_set_status(index, RESULT_FAIL(TEST_NUM, 3));
         return;
     }
 
-    val_timer_set_vir_el2(timer_expire_val);
+    /*Write to GIC registers which will generate Maintenance interrupt*/
+    data = val_gic_reg_read(ICH_HCR_EL2);
+    /*set ICH_HCR_EL2 bits [2:0] to enable the interrupt*/
+    data |= 0x7;
+    val_gic_reg_write(ICH_HCR_EL2, data);
+
     while ((--timeout > 0) && (IS_RESULT_PENDING(val_get_status(index)))) {
         ;
     }
 
     if (timeout == 0) {
-        val_print(ACS_PRINT_ERR,
-            "\n       NS EL2 Virtual timer interrupt %d not received", intid);
+        val_print(ACS_PRINT_ERR, "\n       Interrupt not received within timeout", 0);
         val_set_status(index, RESULT_FAIL(TEST_NUM, 4));
+        return;
     }
     return;
 }
 
 uint32_t
-hyp_g001_entry(uint32_t num_pe)
+hyp_g003_entry(uint32_t num_pe)
 {
 
     uint32_t status = ACS_STATUS_FAIL;

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -1,5 +1,5 @@
 ## @file
-#  Copyright (c) 2016-2022 Arm Limited or its affiliates. All rights reserved.
+#  Copyright (c) 2016-2023 Arm Limited or its affiliates. All rights reserved.
 #  SPDX-License-Identifier : Apache-2.0
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,6 +69,8 @@
   ../test_pool/gic/operating_system/test_os_its003.c
   ../test_pool/gic/operating_system/test_os_its004.c
   ../test_pool/gic/hypervisor/test_hyp_g001.c
+  ../test_pool/gic/hypervisor/test_hyp_g002.c
+  ../test_pool/gic/hypervisor/test_hyp_g003.c
   ../test_pool/timer/operating_system/test_os_t001.c
   ../test_pool/timer/operating_system/test_os_t002.c
   ../test_pool/timer/operating_system/test_os_t003.c

--- a/val/include/bsa_acs_gic.h
+++ b/val/include/bsa_acs_gic.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018,2021 Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2018,2021, 2023 Arm Limited and Contributors. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Redistribution and use in source and binary forms, with or without
@@ -95,6 +95,10 @@ uint32_t
 os_g006_entry(uint32_t num_pe);
 uint32_t
 hyp_g001_entry(uint32_t num_pe);
+uint32_t
+hyp_g002_entry(uint32_t num_pe);
+uint32_t
+hyp_g003_entry(uint32_t num_pe);
 
 uint32_t
 val_get_max_intid(void);

--- a/val/src/acs_gic.c
+++ b/val/src/acs_gic.c
@@ -82,6 +82,8 @@ val_gic_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
   if (g_sw_view[G_SW_HYP]) {
       val_print(ACS_PRINT_ERR, "\nHypervisor View:\n", 0);
       status |= hyp_g001_entry(num_pe);
+      status |= hyp_g002_entry(num_pe);
+      status |= hyp_g003_entry(num_pe);
   }
 
   /* Run GICv2m only if GIC Version is v2m. */


### PR DESCRIPTION
Fix  #94 

- updated the GIC hypervisor test B_PPI_02 into three individual tests to check NS EL2-Virt, NS EL2-Phy and GIC Maintenance interrupts
- Minor formatting changes

Signed-off-by: Balaji Gontumukkala <balaji.gontumukkala@arm.com>