### PR TITLE
Unify test result info like in sbsa

### DIFF
--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2022, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,6 +59,7 @@ void val_free_shared_mem(void);
 void val_print(uint32_t level, char8_t *string, uint64_t data);
 void val_print_raw(uint64_t uart_addr, uint32_t level, char8_t *string,
                                                                 uint64_t data);
+void val_print_test_end(uint32_t status, char8_t *string);
 void val_set_test_data(uint32_t index, uint64_t addr, uint64_t test_data);
 void val_get_test_data(uint32_t index, uint64_t *data0, uint64_t *data1);
 uint32_t val_strncmp(char8_t *str1, char8_t *str2, uint32_t len);

--- a/val/src/acs_exerciser.c
+++ b/val/src/acs_exerciser.c
@@ -400,10 +400,7 @@ val_exerciser_execute_tests(uint32_t *g_sw_view)
 
   val_smmu_stop();
 
-  if (status != ACS_STATUS_PASS)
-    val_print(ACS_PRINT_TEST, "\n      *** One or more tests have Failed/Skipped.*** \n", 0);
-  else
-    val_print(ACS_PRINT_TEST, "\n       All Exerciser tests passed!! \n", 0);
+  val_print_test_end(status, "Exerciser");
 
   return status;
 }

--- a/val/src/acs_gic.c
+++ b/val/src/acs_gic.c
@@ -123,10 +123,7 @@ its_test:
   }
 
 test_done:
-  if (status != ACS_STATUS_PASS)
-    val_print(ACS_PRINT_TEST, "\n      *** One or more tests have Failed/Skipped.*** \n", 0);
-  else
-    val_print(ACS_PRINT_TEST, "\n       All GIC tests Passed!! \n", 0);
+  val_print_test_end(status, "GIC");
 
   return status;
 

--- a/val/src/acs_memory.c
+++ b/val/src/acs_memory.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2022, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -70,10 +70,7 @@ val_memory_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 
   }
 
-  if (status != ACS_STATUS_PASS)
-      val_print(ACS_PRINT_TEST, "\n      *** One or more tests have Failed/Skipped.*** \n", 0);
-  else
-      val_print(ACS_PRINT_TEST, "\n       All Memory tests have passed!! \n", 0);
+  val_print_test_end(status, "Memory");
 
   return status;
 }

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -355,10 +355,7 @@ val_pcie_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 
   }
 
-  if (status != ACS_STATUS_PASS)
-    val_print(ACS_PRINT_TEST, "\n      *** One or more tests have Failed/Skipped.*** \n", 0);
-  else
-    val_print(ACS_PRINT_TEST, "\n       All PCIe tests passed!! \n", 0);
+  val_print_test_end(status, "PCIe");
 
   return status;
 }

--- a/val/src/acs_pe.c
+++ b/val/src/acs_pe.c
@@ -96,10 +96,7 @@ if (!g_build_sbsa) { /* B_PE_15 is only in BSA checklist */
       status |= ps_c001_entry(num_pe);
   }
 
-  if (status != ACS_STATUS_PASS)
-      val_print(ACS_PRINT_TEST, "\n      *** One or more tests have Failed/Skipped.*** \n", 0);
-  else
-      val_print(ACS_PRINT_TEST, "\n       All PE tests have passed!! \n", 0);
+  val_print_test_end(status, "PE");
 
   return status;
 

--- a/val/src/acs_peripherals.c
+++ b/val/src/acs_peripherals.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2022 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,10 +69,7 @@ val_peripheral_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 #endif
   }
 
-  if (status != ACS_STATUS_PASS)
-    val_print(ACS_PRINT_TEST, "\n      *** One or more tests have Failed/Skipped.*** \n", 0);
-  else
-    val_print(ACS_PRINT_TEST, "\n       All Peripheral tests passed!! \n", 0);
+  val_print_test_end(status, "Peripheral");
 
   return status;
 }

--- a/val/src/acs_smmu.c
+++ b/val/src/acs_smmu.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2022 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -100,11 +100,7 @@ val_smmu_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
        status |= hyp_i004_entry(num_pe);
   }
 
-
-  if (status != ACS_STATUS_PASS)
-    val_print(ACS_PRINT_TEST, "\n      *** One or more tests have Failed/Skipped.*** \n", 0);
-  else
-    val_print(ACS_PRINT_TEST, "\n       All SMMU tests Passed!! \n", 0);
+  val_print_test_end(status, "SMMU");
 
   return status;
 }

--- a/val/src/acs_test_infra.c
+++ b/val/src/acs_test_infra.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2022, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,6 +38,37 @@ val_print(uint32_t level, char8_t *string, uint64_t data)
 
   if (level >= g_print_level)
       pal_print(string, data);
+
+}
+
+/**
+  @brief  This API calls PAL layer to print tests status
+          to the output console.
+          1. Caller       - Application layer
+          2. Prerequisite - None.
+
+  @param status the status of the tests
+  @param string formatted ASCII string
+
+  @return        None
+ **/
+void
+val_print_test_end(uint32_t status, char8_t *string)
+{
+  pal_print("\n      ", 0);
+
+  if (status != ACS_STATUS_PASS) {
+      pal_print("One or more ", 0);
+      pal_print(string, 0);
+      pal_print(" tests failed or were skipped.", 0);
+  }
+  else {
+      pal_print("All ", 0);
+      pal_print(string, 0);
+      pal_print(" tests passed.", 0);
+  }
+
+  pal_print("\n", 0);
 
 }
 

--- a/val/src/acs_timer.c
+++ b/val/src/acs_timer.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2019, 2021-2022 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019, 2021-2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,10 +66,7 @@ val_timer_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
       status |= os_t005_entry(num_pe);
   }
 
-  if (status != ACS_STATUS_PASS)
-    val_print(ACS_PRINT_TEST, "\n      *** One or more tests have Failed/Skipped.*** \n", 0);
-  else
-    val_print(ACS_PRINT_TEST, "\n       All Timer tests passed!! \n", 0);
+  val_print_test_end(status, "Timer");
 
   return status;
 }

--- a/val/src/acs_wakeup.c
+++ b/val/src/acs_wakeup.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2022 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,10 +67,7 @@ if (g_build_sbsa) {
 */
   }
 
-  if (status != ACS_STATUS_PASS)
-    val_print(ACS_PRINT_TEST, "\n      *** One or more tests have Failed/Skipped.*** \n", 0);
-  else
-    val_print(ACS_PRINT_TEST, "\n       All Wakeup tests passed!! \n", 0);
+  val_print_test_end(status, "Wakeup");
 
   return status;
 

--- a/val/src/acs_wd.c
+++ b/val/src/acs_wd.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2022 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,10 +69,7 @@ if (!g_build_sbsa) { /* For SBSA compliance WD is mandatory */
     status |= os_w002_entry(num_pe);
   }
 
-  if (status != ACS_STATUS_PASS)
-    val_print(ACS_PRINT_TEST, "\n      *** One or more tests have Failed/Skipped.*** \n", 0);
-  else
-    val_print(ACS_PRINT_TEST, "\n       All Watchdog tests passed!! \n", 0);
+  val_print_test_end(status, "Watchdog");
 
   return status;
 }


### PR DESCRIPTION
#93 
 - added val_print_test_end function in acs_test_infra.c
 - removed the conditions to check the status of tests and added val_print_test_end function to check tests status