### PR TITLE
Test 205 updated to derive correct GIC RD base as per PE MPIDR

### DIFF
--- a/platform/pal_uefi_acpi/include/pal_uefi.h
+++ b/platform/pal_uefi_acpi/include/pal_uefi.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2022, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -108,7 +108,8 @@ VOID     pal_pe_data_cache_ops_by_va(UINT64 addr, UINT32 type);
 typedef struct {
   UINT32   gic_version;
   UINT32   num_gicd;
-  UINT32   num_gicrd;
+  UINT32   num_gicc_rd;
+  UINT32   num_gicr_rd;
   UINT32   num_its;
   UINT32   num_msi_frame;
   UINT32   num_gich;

--- a/platform/pal_uefi_acpi/src/pal_gic.c
+++ b/platform/pal_uefi_acpi/src/pal_gic.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2021, 2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -60,7 +60,8 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
   GicEntry = GicTable->gic_info;
 
   GicTable->header.gic_version = 0;
-  GicTable->header.num_gicrd = 0;
+  GicTable->header.num_gicr_rd = 0;
+  GicTable->header.num_gicc_rd = 0;
   GicTable->header.num_gicd = 0;
   GicTable->header.num_its = 0;
   GicTable->header.num_msi_frame = 0;
@@ -93,8 +94,8 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_GICC_GICRD;
         GicEntry->base = Entry->GICRBaseAddress;
         GicEntry->length = 0;
-        bsa_print(ACS_PRINT_INFO, L"  GIC RD base %x \n", GicEntry->base);
-        GicTable->header.num_gicrd++;
+        bsa_print(ACS_PRINT_INFO, L"  GICC RD base %x \n", GicEntry->base);
+        GicTable->header.num_gicc_rd++;
         GicEntry++;
       }
 
@@ -120,8 +121,8 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_GICR_GICRD;
         GicEntry->base = ((EFI_ACPI_6_1_GICR_STRUCTURE *)Entry)->DiscoveryRangeBaseAddress;
         GicEntry->length = ((EFI_ACPI_6_1_GICR_STRUCTURE *)Entry)->DiscoveryRangeLength;
-        bsa_print(ACS_PRINT_INFO, L"  GIC RD base Structure %lx \n", GicEntry->base);
-        GicTable->header.num_gicrd++;
+        bsa_print(ACS_PRINT_INFO, L"  GICR RD base %lx \n", GicEntry->base);
+        GicTable->header.num_gicr_rd++;
         GicEntry++;
     }
 

--- a/platform/pal_uefi_dt/include/pal_uefi.h
+++ b/platform/pal_uefi_dt/include/pal_uefi.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2022, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -108,7 +108,8 @@ VOID     pal_pe_data_cache_ops_by_va(UINT64 addr, UINT32 type);
 typedef struct {
   UINT32   gic_version;
   UINT32   num_gicd;
-  UINT32   num_gicrd;
+  UINT32   num_gicc_rd;
+  UINT32   num_gicr_rd;
   UINT32   num_its;
   UINT32   num_msi_frame;
   UINT32   num_gich;

--- a/platform/pal_uefi_dt/src/pal_dt_debug.c
+++ b/platform/pal_uefi_dt/src/pal_dt_debug.c
@@ -70,7 +70,8 @@ dt_dump_gic_table(GIC_INFO_TABLE *GicTable)
   bsa_print(ACS_PRINT_DEBUG, L" ************GIC TABLE************ \n");
   bsa_print(ACS_PRINT_DEBUG, L" GIC version %d \n", GicTable->header.gic_version);
   bsa_print(ACS_PRINT_DEBUG, L" GIC num D %d \n", GicTable->header.num_gicd);
-  bsa_print(ACS_PRINT_DEBUG, L" GIC num RD %d \n", GicTable->header.num_gicrd);
+  bsa_print(ACS_PRINT_DEBUG, L" GIC num GICC RD %d \n", GicTable->header.num_gicc_rd);
+  bsa_print(ACS_PRINT_DEBUG, L" GIC num GICR RD %d \n", GicTable->header.num_gicr_rd);
 //  bsa_print(ACS_PRINT_DEBUG, L" GIC num ITS %d \n", GicTable->header.num_its);
 
   while (GicTable->gic_info[Index].type != 0xFF) {

--- a/platform/pal_uefi_dt/src/pal_gic.c
+++ b/platform/pal_uefi_dt/src/pal_gic.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2021, 2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -174,7 +174,8 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
 
   GicEntry = GicTable->gic_info;
   GicTable->header.gic_version = 0;
-  GicTable->header.num_gicrd = 0;
+  GicTable->header.num_gicc_rd = 0;
+  GicTable->header.num_gicr_rd = 0;
   GicTable->header.num_gicd = 0;
   GicTable->header.num_its = 0;
   GicTable->header.num_msi_frame = 0;
@@ -208,8 +209,8 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_GICC_GICRD;
         GicEntry->base = Entry->GICRBaseAddress;
         GicEntry->length = 0;
-        bsa_print(ACS_PRINT_INFO, L"  GIC RD base %x \n", GicEntry->base);
-        GicTable->header.num_gicrd++;
+        bsa_print(ACS_PRINT_INFO, L"  GICC RD base %x \n", GicEntry->base);
+        GicTable->header.num_gicc_rd++;
         GicEntry++;
       }
 
@@ -235,8 +236,8 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_GICR_GICRD;
         GicEntry->base = ((EFI_ACPI_6_1_GICR_STRUCTURE *)Entry)->DiscoveryRangeBaseAddress;
         GicEntry->length = ((EFI_ACPI_6_1_GICR_STRUCTURE *)Entry)->DiscoveryRangeLength;
-        bsa_print(ACS_PRINT_INFO, L"  GIC RD base Structure %x \n", GicEntry->base);
-        GicTable->header.num_gicrd++;
+        bsa_print(ACS_PRINT_INFO, L"  GICR RD base %x \n", GicEntry->base);
+        GicTable->header.num_gicr_rd++;
         GicEntry++;
     }
 
@@ -536,8 +537,8 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
           } else
               GicEntry->length = fdt32_to_cpu(Preg_val[Index++]);
 
-          bsa_print(ACS_PRINT_DEBUG, L"  GIC RD base %lx \n", GicEntry->base);
-          GicTable->header.num_gicrd++;
+          bsa_print(ACS_PRINT_DEBUG, L"  GICR RD base %lx \n", GicEntry->base);
+          GicTable->header.num_gicr_rd++;
           GicEntry++;
     }
   }

--- a/val/include/bsa_acs_gic.h
+++ b/val/include/bsa_acs_gic.h
@@ -107,7 +107,10 @@ addr_t
 val_get_gicd_base(void);
 
 addr_t
-val_get_gicr_base(uint32_t *rdbase_len);
+val_get_gicr_base(uint32_t *rdbase_len, uint32_t gicr_rd_index);
+
+addr_t
+val_gic_get_pe_rdbase(uint64_t mpidr);
 
 addr_t
 val_get_gich_base(void);

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2022, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -159,7 +159,8 @@ uint32_t pal_pe_install_esr(uint32_t exception_type, void (*esr)(uint64_t, void 
 typedef struct {
   uint32_t gic_version;
   uint32_t num_gicd;
-  uint32_t num_gicrd;
+  uint32_t num_gicc_rd;
+  uint32_t num_gicr_rd;
   uint32_t num_its;
   uint32_t num_msi_frame;
   uint32_t num_gich;

--- a/val/src/acs_gic.c
+++ b/val/src/acs_gic.c
@@ -297,7 +297,7 @@ val_gic_get_pe_rdbase(uint64_t mpidr)
   /* If System doesn't have GICR RD strcture, then use GICCC RD base */
   if (g_gic_info_table->header.num_gicr_rd == 0) {
       gicrd_base = val_get_gicr_base(&gicrd_baselen, 0);
-      val_print(ACS_PRINT_ERR, "       gicrd_base 0x%lx\n", gicrd_base);
+      val_print(ACS_PRINT_DEBUG, "       gicrd_base 0x%lx\n", gicrd_base);
 
       /* If information is present in GICC Structure */
       if (gicrd_baselen == 0)
@@ -313,8 +313,8 @@ val_gic_get_pe_rdbase(uint64_t mpidr)
   /* Use GICR RD base structure */
   while (gicr_rdindex < g_gic_info_table->header.num_gicr_rd) {
       gicrd_base = val_get_gicr_base(&gicrd_baselen, gicr_rdindex);
-      val_print(ACS_PRINT_ERR, "       gicr_rdindex %d", gicr_rdindex);
-      val_print(ACS_PRINT_ERR, "       gicrd_base 0x%lx\n", gicrd_base);
+      val_print(ACS_PRINT_DEBUG, "       gicr_rdindex %d", gicr_rdindex);
+      val_print(ACS_PRINT_DEBUG, "       gicrd_base 0x%lx\n", gicrd_base);
 
       pe_gicrd_base = gicrd_base;
       while (pe_gicrd_base < (gicrd_base + gicrd_baselen))

--- a/val/sys_arch_src/gic/v3/gic_v3.c
+++ b/val/sys_arch_src/gic/v3/gic_v3.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -120,7 +120,7 @@ WakeUpRD(void)
   uint64_t                cpuRd_base;
   uint32_t                tmp;
 
-  rd_base = val_get_gicr_base(&rdbase_len);
+  rd_base = val_get_gicr_base(&rdbase_len, 0);
   cpuRd_base = CurrentCpuRDBase(rd_base, rdbase_len);
   if (cpuRd_base == 0) {
     return;
@@ -145,7 +145,7 @@ uint64_t v3_get_pe_gicr_base(void)
   uint32_t                rdbase_len;
   uint64_t                rd_base;
 
-  rd_base = val_get_gicr_base(&rdbase_len);
+  rd_base = val_get_gicr_base(&rdbase_len, 0);
 
   return CurrentCpuRDBase(rd_base, rdbase_len);
 }
@@ -198,7 +198,7 @@ v3_DisableInterruptSource(uint32_t int_id)
   if (IsSpi(int_id)) {
       val_mmio_write(val_get_gicd_base() + GICD_ICENABLER + (4 * regOffset), 1 << regShift);
   } else {
-    rd_base = val_get_gicr_base(&rdbase_len);
+    rd_base = val_get_gicr_base(&rdbase_len, 0);
     cpuRd_base = CurrentCpuRDBase(rd_base, rdbase_len);
     if (cpuRd_base == 0) {
       return;
@@ -233,7 +233,7 @@ v3_EnableInterruptSource(uint32_t int_id)
   if (IsSpi(int_id)) {
       val_mmio_write(val_get_gicd_base() + GICD_ISENABLER + (4 * regOffset), 1 << regShift);
   } else {
-    rd_base = val_get_gicr_base(&rdbase_len);
+    rd_base = val_get_gicr_base(&rdbase_len, 0);
     cpuRd_base = CurrentCpuRDBase(rd_base, rdbase_len);
     if (cpuRd_base == 0) {
       return;
@@ -272,7 +272,7 @@ v3_SetInterruptPriority(uint32_t int_id, uint32_t priority)
                     (val_mmio_read(val_get_gicd_base() + GICD_IPRIORITYR + (4 * regOffset)) &
                      ~(0xff << regShift)) | priority << regShift);
   } else {
-    rd_base = val_get_gicr_base(&rdbase_len);
+    rd_base = val_get_gicr_base(&rdbase_len, 0);
     cpuRd_base = CurrentCpuRDBase(rd_base, rdbase_len);
     if (cpuRd_base == 0) {
       return;


### PR DESCRIPTION
Bug fix for #102 

 Test is currently using GIC RD base address for the SGI bits and
  not derving RD base per PE. For systems in which GIC RD base is not mapped
  to any valid PE cores, test is failing incorrectly

  Changes
   - GIC_INFO_HDR num_gicrd split into num_gicc_rd and num_gicr_rd
   - pal and val files changes to accomodate num_gicc_rd and num_gicr_rd
   - Change in val_get_gicr_base to take care of systems which have multiple GICR RD structure
   - function prototype changes for build success