### PR TITLE
For SBSA complaince, NS watchdog is mandatory

### DIFF
--- a/test_pool/watchdog/operating_system/test_os_w001.c
+++ b/test_pool/watchdog/operating_system/test_os_w001.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018,2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018,2021, 2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +21,7 @@
 #include "val/include/bsa_acs_wd.h"
 
 #define TEST_NUM   (ACS_WD_TEST_NUM_BASE + 1)
-#define TEST_RULE  "B_WD_01, B_WD_02"
+#define TEST_RULE  "B_WD_01, B_WD_02, S_L3WD_01"
 #define TEST_DESC  "Non Secure Watchdog Access            "
 
 static
@@ -29,65 +29,71 @@ void
 payload()
 {
 
-  uint64_t ctrl_base;
-  uint64_t refresh_base;
-  uint64_t wd_num = val_wd_get_info(0, WD_INFO_COUNT);
-  uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
-  uint32_t data, ns_wdg = 0;
+    uint64_t ctrl_base;
+    uint64_t refresh_base;
+    uint64_t wd_num = val_wd_get_info(0, WD_INFO_COUNT);
+    uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+    uint32_t data, ns_wdg = 0;
 
-  val_print(ACS_PRINT_DEBUG,
+    val_print(ACS_PRINT_DEBUG,
             "\n       Found %d watchdogs in table             ",
             wd_num);
 
-  if (wd_num == 0) {
-if (g_build_sbsa)
-      val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
-else
-      val_set_status(index, RESULT_SKIP(TEST_NUM, 1));
-  return;
-  }
+    if (wd_num == 0) {
+        if (g_build_sbsa)
+            val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
+        else
+            val_set_status(index, RESULT_SKIP(TEST_NUM, 1));
+        return;
+    }
 
-  do {
-      wd_num--; //array index starts from 0, so subtract 1 from count
+    do {
 
-      if (val_wd_get_info(wd_num, WD_INFO_ISSECURE))
-          continue;    //Skip Secure watchdog
+        wd_num--;  /*array index starts from 0, so subtract 1 from count*/
 
-      ns_wdg++;
-      refresh_base = val_wd_get_info(wd_num, WD_INFO_REFRESH_BASE);
-      val_print(ACS_PRINT_INFO, "\n       Watchdog Refresh base is %llx ", refresh_base);
-      ctrl_base    = val_wd_get_info(wd_num, WD_INFO_CTRL_BASE);
-      val_print(ACS_PRINT_INFO, "\n       Watchdog CTRL base is  %llx      ", ctrl_base);
+        if (val_wd_get_info(wd_num, WD_INFO_ISSECURE))
+            continue; /*Skip Secure watchdog*/
 
-      data = val_mmio_read(ctrl_base);
-      //Control register bits 31:3 are reserved 0
-      if(data >> WD_CSR_RSRV_SHIFT) {
-          val_set_status(index, RESULT_FAIL(TEST_NUM, 2));
-          return;
-      }
+        ns_wdg++;
+        refresh_base = val_wd_get_info(wd_num, WD_INFO_REFRESH_BASE);
+        val_print(ACS_PRINT_INFO, "\n       Watchdog Refresh base is %llx ", refresh_base);
+        ctrl_base    = val_wd_get_info(wd_num, WD_INFO_CTRL_BASE);
+        val_print(ACS_PRINT_INFO, "\n       Watchdog CTRL base is  %llx      ", ctrl_base);
 
-      data = val_mmio_read(refresh_base);
-      //refresh frame offset 0 must return 0 on reads.
-      if(data) {
-          val_set_status(index, RESULT_FAIL(TEST_NUM, 3));
-          return;
-      }
+        data = val_mmio_read(ctrl_base);
+        /*Control register bits 31:3 are reserved 0*/
+        if (data >> WD_CSR_RSRV_SHIFT) {
+            val_set_status(index, RESULT_FAIL(TEST_NUM, 2));
+            return;
+        }
 
-      /* WOR.Upper word  [31:16] is reserved & must be zero */
-      data = val_mmio_read(ctrl_base + WD_OR_UPPER_WORD_OFFSET);
-      if(data >> WD_OR_RSRV_SHIFT) {
-          val_set_status(index, RESULT_FAIL(TEST_NUM, 4));
-          return;
-      }
-  } while(wd_num);
+        data = val_mmio_read(refresh_base);
+        /*refresh frame offset 0 must return 0 on reads.*/
+        if (data) {
+            val_set_status(index, RESULT_FAIL(TEST_NUM, 3));
+            return;
+        }
 
-  if(!ns_wdg) {
-      val_print(ACS_PRINT_WARN, "\n       No non-secure Watchdogs reported", 0);
-      val_set_status(index, RESULT_SKIP(TEST_NUM, 3));
-      return;
-  }
+        /* WOR.Upper word  [31:16] is reserved & must be zero */
+        data = val_mmio_read(ctrl_base + WD_OR_UPPER_WORD_OFFSET);
+        if (data >> WD_OR_RSRV_SHIFT) {
+            val_set_status(index, RESULT_FAIL(TEST_NUM, 4));
+            return;
+        }
+    } while (wd_num);
 
-  val_set_status(index, RESULT_PASS(TEST_NUM, 1));
+    if (!ns_wdg) {
+        if (g_build_sbsa) {
+            val_print(ACS_PRINT_ERR, "\n       No non-secure Watchdogs reported", 0);
+            val_set_status(index, RESULT_FAIL(TEST_NUM, 5));
+        } else {
+            val_print(ACS_PRINT_WARN, "\n       No non-secure Watchdogs reported", 0);
+            val_set_status(index, RESULT_SKIP(TEST_NUM, 3));
+        }
+        return;
+    }
+
+    val_set_status(index, RESULT_PASS(TEST_NUM, 1));
 
 }
 
@@ -95,19 +101,19 @@ uint32_t
 os_w001_entry(uint32_t num_pe)
 {
 
-  uint32_t status = ACS_STATUS_FAIL;
+    uint32_t status = ACS_STATUS_FAIL;
 
-  num_pe = 1;  //This Timer test is run on single processor
+    num_pe = 1; /*This Timer test is run on single processor*/
 
-  status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
+    status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
 
-  if (status != ACS_STATUS_SKIP)
-    val_run_test_payload(TEST_NUM, num_pe, payload, 0);
+    if (status != ACS_STATUS_SKIP)
+        val_run_test_payload(TEST_NUM, num_pe, payload, 0);
 
-  /* get the result from all PE and check for failure */
-  status = val_check_for_error(TEST_NUM, num_pe, TEST_RULE);
+    /* get the result from all PE and check for failure */
+    status = val_check_for_error(TEST_NUM, num_pe, TEST_RULE);
 
-  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
-  return status;
+    val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+    return status;
 
 }

--- a/test_pool/watchdog/operating_system/test_os_w002.c
+++ b/test_pool/watchdog/operating_system/test_os_w002.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018,2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018,2021, 2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,7 @@
 #include "val/include/bsa_acs_wd.h"
 
 #define TEST_NUM   (ACS_WD_TEST_NUM_BASE + 2)
-#define TEST_RULE  "B_WD_03"
+#define TEST_RULE  "B_WD_03, S_L3WD_01"
 #define TEST_DESC  "Check Watchdog WS0 interrupt          "
 
 static uint32_t int_id;
@@ -32,11 +32,11 @@ static
 void
 isr()
 {
-  uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
-  val_wd_set_ws0(wd_num, 0);
-  val_print(ACS_PRINT_DEBUG, "\n       Received WS0 interrupt                ", 0);
-  val_set_status(index, RESULT_PASS(TEST_NUM, 1));
-  val_gic_end_of_interrupt(int_id);
+    uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+    val_wd_set_ws0(wd_num, 0);
+    val_print(ACS_PRINT_DEBUG, "\n       Received WS0 interrupt                ", 0);
+    val_set_status(index, RESULT_PASS(TEST_NUM, 1));
+    val_gic_end_of_interrupt(int_id);
 }
 
 
@@ -45,67 +45,72 @@ void
 payload()
 {
 
-  uint32_t status, timeout, ns_wdg = 0;
-  uint64_t timer_expire_ticks = 1;
-  uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
-  wd_num = val_wd_get_info(0, WD_INFO_COUNT);
+    uint32_t status, timeout, ns_wdg = 0;
+    uint64_t timer_expire_ticks = 1;
+    uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+    wd_num = val_wd_get_info(0, WD_INFO_COUNT);
 
-  if (wd_num == 0) {
-      val_print(ACS_PRINT_DEBUG, "\n       No Watchdogs reported          %d  ", wd_num);
-if (g_build_sbsa)
-      val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
-else
-      val_set_status(index, RESULT_SKIP(TEST_NUM, 1));
-  return;
-  }
+    if (wd_num == 0) {
+        val_print(ACS_PRINT_DEBUG, "\n       No Watchdogs reported          %d  ", wd_num);
+        if (g_build_sbsa)
+            val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
+        else
+            val_set_status(index, RESULT_SKIP(TEST_NUM, 1));
+        return;
+    }
 
-  do {
-      wd_num--;         //array index starts from 0, so subtract 1 from count
+    do {
+        wd_num--; /*array index starts from 0, so subtract 1 from count*/
 
-      if (val_wd_get_info(wd_num, WD_INFO_ISSECURE))
-          continue;    //Skip Secure watchdog
+        if (val_wd_get_info(wd_num, WD_INFO_ISSECURE))
+            continue;    /*Skip Secure watchdog*/
 
-      ns_wdg++;
-      timeout = val_get_counter_frequency() * 2;
-      val_set_status(index, RESULT_PENDING(TEST_NUM));     // Set the initial result to pending
+        ns_wdg++;
+        timeout = val_get_counter_frequency() * 2;
+        val_set_status(index, RESULT_PENDING(TEST_NUM));     /* Set the initial result to pending*/
 
-      int_id       = val_wd_get_info(wd_num, WD_INFO_GSIV);
-      val_print(ACS_PRINT_DEBUG, "\n       WS0 Interrupt id  %d        ", int_id);
+        int_id       = val_wd_get_info(wd_num, WD_INFO_GSIV);
+        val_print(ACS_PRINT_DEBUG, "\n       WS0 Interrupt id  %d        ", int_id);
 
-      if (val_gic_install_isr(int_id, isr)) {
-          val_print(ACS_PRINT_ERR, "\n       GIC Install Handler Failed...", 0);
-          val_set_status(index, RESULT_FAIL(TEST_NUM, 2));
-          return;
-      }
+        if (val_gic_install_isr(int_id, isr)) {
+            val_print(ACS_PRINT_ERR, "\n       GIC Install Handler Failed...", 0);
+            val_set_status(index, RESULT_FAIL(TEST_NUM, 2));
+            return;
+        }
 
-      /* Set Interrupt Type Edge/Level Trigger */
-      if (val_wd_get_info(wd_num, WD_INFO_IS_EDGE))
-          val_gic_set_intr_trigger(int_id, INTR_TRIGGER_INFO_EDGE_RISING);
-      else
-          val_gic_set_intr_trigger(int_id, INTR_TRIGGER_INFO_LEVEL_HIGH);
+        /* Set Interrupt Type Edge/Level Trigger */
+        if (val_wd_get_info(wd_num, WD_INFO_IS_EDGE))
+            val_gic_set_intr_trigger(int_id, INTR_TRIGGER_INFO_EDGE_RISING);
+        else
+            val_gic_set_intr_trigger(int_id, INTR_TRIGGER_INFO_LEVEL_HIGH);
 
-      status = val_wd_set_ws0(wd_num, timer_expire_ticks);
-      if (status) {
-          val_print(ACS_PRINT_ERR, "\n       Setting watchdog timeout failed", 0);
-          val_set_status(index, RESULT_FAIL(TEST_NUM, 3));
-          return;
-      }
+        status = val_wd_set_ws0(wd_num, timer_expire_ticks);
+        if (status) {
+            val_print(ACS_PRINT_ERR, "\n       Setting watchdog timeout failed", 0);
+            val_set_status(index, RESULT_FAIL(TEST_NUM, 3));
+            return;
+        }
 
-      while ((--timeout > 0) && (IS_RESULT_PENDING(val_get_status(index))));
+        while ((--timeout > 0) && (IS_RESULT_PENDING(val_get_status(index))));
 
-      if (timeout == 0) {
-          val_print(ACS_PRINT_ERR, "\n       WS0 Interrupt not received on %d   ", int_id);
-          val_set_status(index, RESULT_FAIL(TEST_NUM, 4));
-          return;
-      }
+        if (timeout == 0) {
+            val_print(ACS_PRINT_ERR, "\n       WS0 Interrupt not received on %d   ", int_id);
+            val_set_status(index, RESULT_FAIL(TEST_NUM, 4));
+            return;
+        }
 
-  } while(wd_num);
+    } while (wd_num);
 
-  if(!ns_wdg) {
-      val_print(ACS_PRINT_WARN, "\n       No non-secure Watchdogs reported", 0);
-      val_set_status(index, RESULT_SKIP(TEST_NUM, 3));
-      return;
-  }
+    if (!ns_wdg) {
+        if (g_build_sbsa) {
+            val_print(ACS_PRINT_ERR, "\n       No non-secure Watchdogs reported", 0);
+            val_set_status(index, RESULT_FAIL(TEST_NUM, 5));
+        } else {
+            val_print(ACS_PRINT_WARN, "\n       No non-secure Watchdogs reported", 0);
+            val_set_status(index, RESULT_SKIP(TEST_NUM, 3));
+        }
+        return;
+    }
 
 }
 
@@ -113,19 +118,19 @@ uint32_t
 os_w002_entry(uint32_t num_pe)
 {
 
-  uint32_t status = ACS_STATUS_FAIL;
+    uint32_t status = ACS_STATUS_FAIL;
 
-  num_pe = 1;  //This Timer test is run on single processor
+    num_pe = 1;  /*This Timer test is run on single processor*/
 
-  status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
+    status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
 
-  if (status != ACS_STATUS_SKIP)
-    val_run_test_payload(TEST_NUM, num_pe, payload, 0);
+    if (status != ACS_STATUS_SKIP)
+        val_run_test_payload(TEST_NUM, num_pe, payload, 0);
 
-  /* get the result from all PE and check for failure */
-  status = val_check_for_error(TEST_NUM, num_pe, TEST_RULE);
+    /* get the result from all PE and check for failure */
+    status = val_check_for_error(TEST_NUM, num_pe, TEST_RULE);
 
-  val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
-  return status;
+    val_report_status(0, BSA_ACS_END(TEST_NUM), NULL);
+    return status;
 
 }


### PR DESCRIPTION
 - Changed BSA watchdog test 701 & 702 to fail if no non-secure watchdog timer is found for BSA run for SBSA.
 -  Minor Formatting changes