### PR TITLE
Improved messaging for PCIe and Exerciser modules

### DIFF
--- a/test_pool/exerciser/operating_system/test_os_e001.c
+++ b/test_pool/exerciser/operating_system/test_os_e001.c
@@ -123,7 +123,8 @@ check_source_validation (uint32_t req_instance, uint32_t req_rp_bdf, uint64_t ba
   val_exerciser_set_param(DMA_ATTRIBUTES, (uint64_t)bar_base, 1, req_instance);
 
   if (val_exerciser_ops(START_DMA, EDMA_FROM_DEVICE, req_instance)) {
-      val_print(ACS_PRINT_ERR, "\nSrc Validation 1st DMA failure from exerciser %4x", req_instance);
+      val_print(ACS_PRINT_ERR,
+              "\n       Src Validation 1st DMA failure from exerciser 0x%4x", req_instance);
       return ACS_STATUS_FAIL;
   }
 
@@ -144,7 +145,8 @@ check_source_validation (uint32_t req_instance, uint32_t req_rp_bdf, uint64_t ba
   val_exerciser_set_param(DMA_ATTRIBUTES, (uint64_t)bar_base, 1, req_instance);
 
   if (!val_exerciser_ops(START_DMA, EDMA_FROM_DEVICE, req_instance)) {
-      val_print(ACS_PRINT_ERR, "\nSrc Validation 2nd DMA failure from exerciser %4x", req_instance);
+      val_print(ACS_PRINT_ERR,
+              "\n       Src Validation 2nd DMA failure from exerciser 0x%4x", req_instance);
       return ACS_STATUS_FAIL;
   }
 
@@ -179,7 +181,8 @@ check_transaction_blocking (uint32_t req_instance, uint32_t req_rp_bdf, uint64_t
   val_exerciser_set_param(DMA_ATTRIBUTES, (uint64_t)bar_base, 1, req_instance);
 
   if (!val_exerciser_ops(START_DMA, EDMA_FROM_DEVICE, req_instance)) {
-      val_print(ACS_PRINT_ERR, "\n Traxn blocking DMA failure from exerciser %4x", req_instance);
+      val_print(ACS_PRINT_ERR,
+                "\n       Traxn blocking DMA failure from exerciser 0x%4x", req_instance);
       return ACS_STATUS_FAIL;
   }
 
@@ -224,13 +227,14 @@ payload(void)
   /* Check If PCIe Hierarchy supports P2P. */
   if (val_pcie_p2p_support() == NOT_IMPLEMENTED) {
     val_print(ACS_PRINT_DEBUG, "\n       pal_pcie_p2p_support API is unimplemented ", 0);
-    val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 01));
+    val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
     return;
   }
 
   if (val_pcie_p2p_support())
   {
-    val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
+    val_print(ACS_PRINT_DEBUG, "\n       PCIe hierarchy does not support P2P ", 0);
+    val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 2));
     return;
   }
 
@@ -242,6 +246,7 @@ payload(void)
           continue;
 
       req_e_bdf = val_exerciser_get_bdf(instance);
+      val_print(ACS_PRINT_DEBUG, "\n       Requester exerciser BDF - 0x%x", req_e_bdf);
 
       /* Get RP of the exerciser */
       if (val_pcie_get_rootport(req_e_bdf, &req_rp_bdf))
@@ -263,6 +268,8 @@ payload(void)
          Break from the test if no such exerciser if found */
       if (get_target_exer_bdf(req_rp_bdf, &tgt_e_bdf, &tgt_rp_bdf, &bar_base))
           continue;
+
+      val_print(ACS_PRINT_DEBUG, "\n       Target exerciser BDF - 0x%x", tgt_e_bdf);
 
       /* Enable Source Validation & Transaction Blocking */
       val_pcie_read_cfg(tgt_rp_bdf, cap_base + ACSCR_OFFSET, &reg_value);
@@ -299,7 +306,7 @@ payload(void)
   }
 
   if (test_skip == 1)
-      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
+      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 3));
   else if (fail_cnt)
       val_set_status(pe_index, RESULT_FAIL(TEST_NUM, fail_cnt));
   else

--- a/test_pool/exerciser/operating_system/test_os_e002.c
+++ b/test_pool/exerciser/operating_system/test_os_e002.c
@@ -342,13 +342,14 @@ payload(void)
   /* Check If PCIe Hierarchy supports P2P. */
   if (val_pcie_p2p_support() == NOT_IMPLEMENTED) {
     val_print(ACS_PRINT_DEBUG, "\n       pal_pcie_p2p_support API is unimplemented ", 0);
-    val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 01));
+    val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
     return;
   }
 
   if (val_pcie_p2p_support())
   {
-    val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
+    val_print(ACS_PRINT_DEBUG, "\n       PCIe Heirarchy does not support P2P", 0);
+    val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 2));
     return;
   }
 
@@ -372,7 +373,8 @@ payload(void)
           continue;
 
       req_e_bdf = val_exerciser_get_bdf(instance);
-
+      val_print(ACS_PRINT_DEBUG, "\n       Requester exerciser BDF - 0x%x", req_e_bdf);
+      
       /* Get RP of the exerciser */
       if (val_pcie_get_rootport(req_e_bdf, &req_rp_bdf))
           continue;
@@ -453,7 +455,7 @@ payload(void)
   }
 
   if (test_skip == 1)
-      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
+      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 3));
   else if (fail_cnt)
       val_set_status(pe_index, RESULT_FAIL(TEST_NUM, fail_cnt));
   else

--- a/test_pool/exerciser/operating_system/test_os_e004.c
+++ b/test_pool/exerciser/operating_system/test_os_e004.c
@@ -90,6 +90,7 @@ payload (void)
 
     /* Get the exerciser BDF */
     e_bdf = val_exerciser_get_bdf(instance);
+    val_print(ACS_PRINT_DEBUG, "\n       Exerciser BDF - 0x%x", e_bdf);
 
     /* Search for MSI-X Capability */
     if (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) {

--- a/test_pool/exerciser/operating_system/test_os_e005.c
+++ b/test_pool/exerciser/operating_system/test_os_e005.c
@@ -167,6 +167,7 @@ payload(void)
 
     /* Get exerciser bdf */
     e_bdf = val_exerciser_get_bdf(instance);
+    val_print(ACS_PRINT_DEBUG, "\n       Exerciser BDF - 0x%x", e_bdf);
 
     /* Find SMMU node index for this pcie endpoint */
     master.smmu_index = val_iovirt_get_rc_smmu_index(PCIE_EXTRACT_BDF_SEG(e_bdf),
@@ -180,7 +181,7 @@ payload(void)
 
     if (smmu_ssid_bits < MIN_PASID_BITS || smmu_ssid_bits > MAX_PASID_BITS)
     {
-        val_print(ACS_PRINT_ERR, "SMMU substreamid support error %d\n", smmu_ssid_bits);
+        val_print(ACS_PRINT_ERR, "\n       SMMU substreamid support error %d", smmu_ssid_bits);
         goto test_fail;
     }
 
@@ -202,7 +203,8 @@ payload(void)
     }
     if (exerciser_ssid_bits < MIN_PASID_BITS)
     {
-        val_print(ACS_PRINT_ERR, "exerciser substreamid support error %d\n", exerciser_ssid_bits);
+        val_print(ACS_PRINT_ERR,
+                "\n       exerciser substreamid support error %d", exerciser_ssid_bits);
         goto test_fail;
     }
 
@@ -234,18 +236,27 @@ payload(void)
 
         /* Need to know input and output address sizes before creating page table */
         pgt_desc.ias = val_smmu_get_info(SMMU_IN_ADDR_SIZE, master.smmu_index);
-        if (pgt_desc.ias == 0)
+        if (pgt_desc.ias == 0) {
+            val_print(ACS_PRINT_ERR,
+                     "\n       Input address size 0 for SMMU %d", master.smmu_index);
             goto test_fail;
+        }
 
         pgt_desc.oas = val_smmu_get_info(SMMU_OUT_ADDR_SIZE, master.smmu_index);
-        if (pgt_desc.oas == 0)
+        if (pgt_desc.oas == 0) {
+            val_print(ACS_PRINT_ERR,
+                     "\n       Output address size 0 for SMMU %d", master.smmu_index);
             goto test_fail;
+        }
 
         /* set pgt_desc.pgt_base to NULL to create new translation table, val_pgt_create
            will update pgt_desc.pgt_base to point to created translation table */
         pgt_desc.pgt_base = (uint64_t) NULL;
-        if (val_pgt_create(mem_desc, &pgt_desc))
+        if (val_pgt_create(mem_desc, &pgt_desc)) {
+            val_print(ACS_PRINT_ERR,
+                     "\n       Unable to create page table with given attributes", 0);
             goto test_fail;
+        }
 
         pgt_base_pasid1 = pgt_desc.pgt_base;
 
@@ -323,8 +334,11 @@ payload(void)
     /* set pgt_desc.pgt_base to NULL to create new translation table, val_pgt_create
        will update pgt_desc.pgt_base to point to created translation table */
     pgt_desc.pgt_base = (uint64_t) NULL;
-    if (val_pgt_create(mem_desc, &pgt_desc))
-        goto test_fail;
+    if (val_pgt_create(mem_desc, &pgt_desc)) {
+            val_print(ACS_PRINT_ERR,
+                     "\n       Unable to create page table with given attributes", 0);
+            goto test_fail;
+        }
 
     pgt_base_pasid2 = pgt_desc.pgt_base;
 

--- a/test_pool/exerciser/operating_system/test_os_e006.c
+++ b/test_pool/exerciser/operating_system/test_os_e006.c
@@ -38,7 +38,7 @@ static void intr_handler(void)
 {
     if (e_intr_pending == 0)
     {
-        val_print(ACS_PRINT_ERR, "\n  Multiple interrupts received", 0);
+        val_print(ACS_PRINT_ERR, "\n       Multiple interrupts received", 0);
         test_fail++;
         return;
     }
@@ -61,7 +61,7 @@ static void intr_handler(void)
     /* Clear the interrupt pending state */
     e_intr_pending = 0;
 
-    val_print(ACS_PRINT_INFO, " \n  Received legacy interrupt %d", e_intr_line);
+    val_print(ACS_PRINT_INFO, " \n       Received legacy interrupt %d", e_intr_line);
 
 }
 
@@ -99,6 +99,7 @@ payload (void)
 
     /* Get the exerciser BDF */
     e_bdf = val_exerciser_get_bdf(instance);
+    val_print(ACS_PRINT_DEBUG, "\n       Exerciser BDF - 0x%x", e_bdf);
 
     /* Check if the PCI interrupt request pins is connected INTA#-through-INTD */
     val_pcie_read_cfg(e_bdf, PCIE_INTERRUPT_LINE, &e_intr_pin);

--- a/test_pool/exerciser/operating_system/test_os_e007.c
+++ b/test_pool/exerciser/operating_system/test_os_e007.c
@@ -173,6 +173,7 @@ payload (void)
 
     /* Get the exerciser BDF */
     e_bdf = val_exerciser_get_bdf(instance);
+    val_print(ACS_PRINT_DEBUG, "\n       Exerciser BDF - 0x%x", e_bdf);
 
     /* Find SMMU node index for this exerciser instance */
     smmu_index = val_iovirt_get_rc_smmu_index(PCIE_EXTRACT_BDF_SEG(e_bdf),

--- a/test_pool/exerciser/operating_system/test_os_e008.c
+++ b/test_pool/exerciser/operating_system/test_os_e008.c
@@ -177,6 +177,7 @@ payload (void)
 
     /* Get the exerciser BDF */
     e_bdf = val_exerciser_get_bdf(instance);
+    val_print(ACS_PRINT_DEBUG, "\n       Exerciser BDF - 0x%x", e_bdf);
 
     /* Find SMMU node index for this exerciser instance */
     smmu_index = val_iovirt_get_rc_smmu_index(PCIE_EXTRACT_BDF_SEG(e_bdf),

--- a/test_pool/exerciser/operating_system/test_os_e009.c
+++ b/test_pool/exerciser/operating_system/test_os_e009.c
@@ -112,10 +112,14 @@ payload(void)
           continue;
 
       e_bdf = val_exerciser_get_bdf(instance);
+      val_print(ACS_PRINT_DEBUG, "\n       Exerciser BDF - 0x%x", e_bdf);
 
       /* Check if exerciser is child of one of the rootports */
-      if (val_pcie_parent_is_rootport(e_bdf, &erp_bdf))
+      if (val_pcie_parent_is_rootport(e_bdf, &erp_bdf)) {
+          val_print(ACS_PRINT_DEBUG,
+              "\n       Exerciser not a downstream device to RP. Skipping 0x%x", e_bdf);
           continue;
+      }
 
       /* Find right sibling of the exerciser rootport */
       if (!get_rp_right_sibling(erp_bdf, &erp_rs_bdf))

--- a/test_pool/exerciser/operating_system/test_os_e010.c
+++ b/test_pool/exerciser/operating_system/test_os_e010.c
@@ -55,10 +55,15 @@ payload(void)
           continue;
 
       e_bdf = val_exerciser_get_bdf(instance);
+      val_print(ACS_PRINT_DEBUG, "\n       Exerciser BDF - 0x%x", e_bdf);
 
       /* Check if exerciser is child of one of the rootports */
-      if (val_pcie_parent_is_rootport(e_bdf, &erp_bdf))
+      if (val_pcie_parent_is_rootport(e_bdf, &erp_bdf)) {
+          val_print(ACS_PRINT_DEBUG,
+              "\n       Exerciser not a downstream device to RP. Skipping 0x%x", e_bdf);
           continue;
+      }
+
       /*
        * Generate a config request from PE to the Secondary bus
        * of the exerciser's root port. Exerciser should see this
@@ -67,6 +72,7 @@ payload(void)
       status = val_exerciser_ops(START_TXN_MONITOR, CFG_READ, instance);
       if (status == PCIE_CAP_NOT_FOUND)
       {
+          val_print(ACS_PRINT_DEBUG, "\n       Unable to start transaction monitoring", 0);
           val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 01));
           return;
       }
@@ -75,6 +81,7 @@ payload(void)
       status = val_exerciser_ops(STOP_TXN_MONITOR, CFG_READ, instance);
       if (status == PCIE_CAP_NOT_FOUND)
       {
+          val_print(ACS_PRINT_DEBUG, "\n       Unable to stop transaction monitoring", 0);
           val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 02));
           return;
       }

--- a/test_pool/exerciser/operating_system/test_os_e011.c
+++ b/test_pool/exerciser/operating_system/test_os_e011.c
@@ -87,10 +87,11 @@ payload (void)
 
     /* Get the exerciser BDF */
     e_bdf = val_exerciser_get_bdf(instance);
+    val_print(ACS_PRINT_DEBUG, "\n       Exerciser BDF - 0x%x", e_bdf);
 
     /* Search for MSI-X Capability */
     if (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) {
-      val_print(ACS_PRINT_INFO, "\n       No MSI-X Capability, Skipping for 0x%x", e_bdf);
+      val_print(ACS_PRINT_DEBUG, "\n       No MSI-X Capability, Skipping for 0x%x", e_bdf);
       continue;
     }
 
@@ -130,8 +131,7 @@ payload (void)
           continue;
       }
 
-      val_print(ACS_PRINT_DEBUG, "\n       ITS Check for ITS ID : %x        "
-                                    "      ", its_id);
+      val_print(ACS_PRINT_DEBUG, "\n       ITS Check for ITS ID : %x       ", its_id);
       status = val_gic_request_msi(e_bdf, device_id, its_id, base_lpi_id + instance, msi_index);
       if (status) {
           val_print(ACS_PRINT_ERR,

--- a/test_pool/exerciser/operating_system/test_os_e012.c
+++ b/test_pool/exerciser/operating_system/test_os_e012.c
@@ -89,6 +89,7 @@ payload (void)
 
     /* Get the exerciser BDF */
     e_bdf = val_exerciser_get_bdf(instance);
+    val_print(ACS_PRINT_DEBUG, "\n       Exerciser BDF - 0x%x", e_bdf);
 
     /* Search for MSI-X Capability */
     if (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) {

--- a/test_pool/exerciser/operating_system/test_os_e013.c
+++ b/test_pool/exerciser/operating_system/test_os_e013.c
@@ -132,6 +132,7 @@ payload (void)
 
     /* Get the exerciser BDF */
     e_bdf = val_exerciser_get_bdf(instance);
+    val_print(ACS_PRINT_DEBUG, "\n       Exerciser BDF - 0x%x", e_bdf);
 
     /* Search for MSI-X Capability */
     if (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) {

--- a/test_pool/exerciser/operating_system/test_os_e014.c
+++ b/test_pool/exerciser/operating_system/test_os_e014.c
@@ -143,6 +143,7 @@ payload(void)
           continue;
 
       req_e_bdf = val_exerciser_get_bdf(instance);
+      val_print(ACS_PRINT_DEBUG, "\n       Requester exerciser BDF - 0x%x", req_e_bdf);
 
       /* Get RP of the exerciser */
       if (val_pcie_get_rootport(req_e_bdf, &req_rp_bdf))
@@ -153,6 +154,7 @@ payload(void)
       if (get_target_exer_bdf(req_rp_bdf, &tgt_e_bdf, &tgt_rp_bdf, &bar_base))
           continue;
 
+      val_print(ACS_PRINT_DEBUG, "\n       Target exerciser BDF - 0x%x", tgt_e_bdf);
       test_skip = 0;
 
       /* Check if P2P transaction causes any deadlock */

--- a/test_pool/exerciser/operating_system/test_os_e015.c
+++ b/test_pool/exerciser/operating_system/test_os_e015.c
@@ -64,6 +64,7 @@ payload(void)
           continue;
 
       e_bdf = val_exerciser_get_bdf(instance);
+      val_print(ACS_PRINT_DEBUG, "\n       Exerciser BDF - 0x%x", e_bdf);
 
       /* ARI Capability not applicable for RCiEP */
       dp_type = val_pcie_device_port_type(e_bdf);
@@ -71,12 +72,15 @@ payload(void)
           continue;
 
       /* Check if exerciser is child of one of the rootports */
-      if (val_pcie_parent_is_rootport(e_bdf, &erp_bdf))
+      if (val_pcie_parent_is_rootport(e_bdf, &erp_bdf)) {
+          val_print(ACS_PRINT_DEBUG,
+              "\n       Exerciser not a downstream device to RP. Skipping 0x%x", e_bdf);
           continue;
+      }
 
       /* Enable the ARI forwarding enable bit in RP */
       if (val_pcie_find_capability(erp_bdf, PCIE_CAP, CID_PCIECS, &cap_base) != PCIE_SUCCESS) {
-          val_print(ACS_PRINT_INFO, "PCIe Express Capability not present ", 0);
+          val_print(ACS_PRINT_DEBUG, "\n       PCIe Express Capability not present ", 0);
           continue;
       }
       val_pcie_read_cfg(erp_bdf, cap_base + DCTL2R_OFFSET, &reg_value);
@@ -86,7 +90,7 @@ payload(void)
 
       /* Enable the ARI forwarding enable bit in Exerciser */
       if (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_PCIECS, &cap_base) != PCIE_SUCCESS) {
-          val_print(ACS_PRINT_INFO, "PCIe Express Capability not present ", 0);
+          val_print(ACS_PRINT_DEBUG, "\n       PCIe Express Capability not present ", 0);
           continue;
       }
       val_pcie_read_cfg(e_bdf, cap_base + DCTL2R_OFFSET, &reg_value);

--- a/test_pool/pcie/operating_system/test_os_p002.c
+++ b/test_pool/pcie/operating_system/test_os_p002.c
@@ -72,6 +72,7 @@ payload(void)
       val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
       return;
   }
+
   branch_to_test = &&exception_return;
 
   num_ecam = val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0);

--- a/test_pool/pcie/operating_system/test_os_p003.c
+++ b/test_pool/pcie/operating_system/test_os_p003.c
@@ -93,6 +93,8 @@ payload(void)
        * is same as its RootPort ECAM.
        */
       bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+      val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+
       dp_type = val_pcie_device_port_type(bdf);
       if (dp_type == EP || dp_type == iEP_EP ||
                dp_type == UP || dp_type == DP) {
@@ -100,15 +102,20 @@ payload(void)
           test_skip = 0;
 
           if (func_ecam_is_rp_ecam(bdf)) {
-              val_print(ACS_PRINT_ERR, "\n        bdf: 0x%x ", bdf);
+              val_print(ACS_PRINT_ERR, "\n       bdf: 0x%x ", bdf);
               val_print(ACS_PRINT_ERR, "dp_type: 0x%x ", dp_type);
+              val_print(ACS_PRINT_ERR, "\n       RP and EP does not share same ECAM region", 0);
               fail_cnt++;
           }
       }
   }
 
-  if (test_skip == 1)
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG,
+          "\n       No iEP_EP/ EP/ DP/ UP type device found. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
+  }
+
   else if (fail_cnt)
       val_set_status(pe_index, RESULT_FAIL(TEST_NUM, fail_cnt));
   else

--- a/test_pool/pcie/operating_system/test_os_p005.c
+++ b/test_pool/pcie/operating_system/test_os_p005.c
@@ -76,7 +76,7 @@ check_bdf_under_rp(uint32_t rp_bdf)
               if ((dev_seg == rp_seg) && ((dev_bus >= rp_sec_bus) && (dev_bus <= rp_sub_bus)))
               {
                   val_pcie_read_cfg(dev_bdf, TYPE01_RIDR, &reg_value);
-                  val_print(ACS_PRINT_DEBUG, "\n Class code is %x", reg_value);
+                  val_print(ACS_PRINT_DEBUG, "\n       Class code is 0x%x", reg_value);
                   base_cc = reg_value >> TYPE01_BCC_SHIFT;
                   if ((base_cc == CNTRL_CC) || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC))
                       return 1;
@@ -116,7 +116,7 @@ payload(void)
   status |= val_pe_install_esr(EXCEPT_AARCH64_SERROR, esr);
   if (status)
   {
-      val_print(ACS_PRINT_ERR, "\n      Failed in installing the exception handler", 0);
+      val_print(ACS_PRINT_ERR, "\n       Failed in installing the exception handler", 0);
       val_set_status(pe_index, RESULT_FAIL(TEST_NUM, 01));
       return;
   }
@@ -152,7 +152,7 @@ payload(void)
 
         /* Read Function's Memory Base Limit Register */
         val_pcie_read_cfg(bdf, TYPE1_P_MEM, &read_value);
-        val_print(ACS_PRINT_DEBUG, "\n  BDF is 0x%x", bdf);
+        val_print(ACS_PRINT_DEBUG, "\n       BDF is 0x%x", bdf);
         if (read_value == 0)
           continue;
 
@@ -170,12 +170,14 @@ payload(void)
         mem_base |= (mem_base_upper << P_MEM_BU_SHIFT);
         mem_lim |= (mem_lim_upper << P_MEM_LU_SHIFT);
 
-        val_print(ACS_PRINT_DEBUG, "\n   Memory base is 0x%llx", mem_base);
+        val_print(ACS_PRINT_DEBUG, "\n       Memory base is 0x%llx", mem_base);
         val_print(ACS_PRINT_DEBUG, " Memory lim is  0x%llx", mem_lim);
 
         /* If Memory Limit is programmed with value less the Base, then Skip.*/
-        if (mem_lim < mem_base)
-          continue;
+        if (mem_lim < mem_base) {
+            val_print(ACS_PRINT_DEBUG, "\n       Mem limit < Mem Base. Skipping Bdf - 0x%x", bdf);
+            continue;
+        }
 
         /* If test runs for atleast an endpoint */
         test_skip = 0;
@@ -191,8 +193,9 @@ payload(void)
 
         if ((mem_base + mem_offset) > mem_lim)
         {
-            val_print(ACS_PRINT_ERR, "\n Memory offset + base 0x%x ", mem_base + mem_offset);
-            val_print(ACS_PRINT_ERR, "exceeds the memory limit 0x%x", mem_lim);
+            val_print(ACS_PRINT_ERR,
+                    "\n        Memory offset + base 0x%llx", mem_base + mem_offset);
+            val_print(ACS_PRINT_ERR, " exceeds the memory limit 0x%llx", mem_lim);
             val_set_status(pe_index, RESULT_FAIL(TEST_NUM, 02));
             return;
         }
@@ -203,6 +206,9 @@ payload(void)
 
         if ((old_value != read_value && read_value == PCIE_UNKNOWN_RESPONSE) ||
              val_pcie_is_urd(bdf)) {
+          val_print(ACS_PRINT_DEBUG, "\n       Value written into memory - 0x%x", KNOWN_DATA);
+          val_print(ACS_PRINT_DEBUG, "\n       Value in memory after write - 0x%x", read_value);
+          val_print(ACS_PRINT_ERR, "\n       Memory access check failed for BDF  0x%x\n", bdf);
           val_set_status(pe_index, RESULT_FAIL(TEST_NUM, 02));
           val_pcie_clear_urd(bdf);
           return;
@@ -213,7 +219,7 @@ payload(void)
          **/
         if (check_bdf_under_rp(bdf))
         {
-            val_print(ACS_PRINT_DEBUG, "\n   Skipping for RP BDF %x", bdf);
+            val_print(ACS_PRINT_DEBUG, "\n       Skipping for RP BDF 0x%x", bdf);
             continue;
         }
 
@@ -226,7 +232,7 @@ payload(void)
 
         if ((mem_lim >> MEM_SHIFT) > (mem_base >> MEM_SHIFT))
         {
-           val_print(ACS_PRINT_DEBUG, "\n Entered Check_2 for bdf %x", bdf);
+           val_print(ACS_PRINT_DEBUG, "\n       Entered Check_2 for bdf 0x%x", bdf);
            new_mem_lim  = mem_base + MEM_OFFSET_LARGE;
            val_pcie_read_cfg(bdf, TYPE1_P_MEM, &new_value);
 
@@ -234,7 +240,7 @@ payload(void)
                val_pcie_write_cfg(bdf, TYPE1_P_MEM_LU, (mem_base >> 32));
 
            mem_base = ((uint32_t)mem_base) | ((uint32_t)mem_base >> 16);
-           val_print(ACS_PRINT_INFO, " mem_base new is 0x%llx", mem_base);
+           val_print(ACS_PRINT_INFO, "       mem_base new is 0x%llx", mem_base);
            val_pcie_write_cfg(bdf, TYPE1_P_MEM, mem_base);
 
            val_pcie_read_cfg(bdf, TYPE1_P_MEM, &read_value);
@@ -253,13 +259,14 @@ payload(void)
            updated_mem_lim |= (mem_lim_upper << P_MEM_LU_SHIFT);
 
            value = (*(volatile uint32_t *)(new_mem_lim + MEM_OFFSET_SMALL));
-           val_print(ACS_PRINT_DEBUG, "  Value read is 0x%llx", value);
+           val_print(ACS_PRINT_DEBUG, "       Value read is 0x%llx", value);
            if (value != PCIE_UNKNOWN_RESPONSE)
            {
-               val_print(ACS_PRINT_ERR, "\n Memory range for bdf 0x%x", bdf);
+               val_print(ACS_PRINT_ERR, "\n       Memory range for bdf 0x%x", bdf);
                val_print(ACS_PRINT_ERR, " is 0x%llx", updated_mem_base);
                val_print(ACS_PRINT_ERR, " 0x%llx", updated_mem_lim);
-               val_print(ACS_PRINT_ERR, "\n Out of range 0x%llx", (new_mem_lim + MEM_OFFSET_SMALL));
+               val_print(ACS_PRINT_ERR,
+                   "\n       Out of range 0x%llx", (new_mem_lim + MEM_OFFSET_SMALL));
                val_set_status(pe_index, RESULT_FAIL(TEST_NUM, 03));
            }
         }
@@ -277,15 +284,19 @@ exception_return:
          * So not checking for Read-Write Data mismatch.
         */
         if (IS_TEST_FAIL(val_get_status(pe_index))) {
-          val_print(ACS_PRINT_ERR, "\n     Failed exception on Memory Access For Bdf : 0x%x", bdf);
+          val_print(ACS_PRINT_ERR,
+              "\n       Failed exception on Memory Access For Bdf : 0x%x", bdf);
           val_pcie_clear_urd(bdf);
           return;
         }
       }
   }
 
-  if (test_skip == 1)
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG,
+        "\n       No RP/ iEP_RP type device found with valid Memory Base/Limit Reg.", 0);
       val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
+  }
   else
       val_set_status(pe_index, RESULT_PASS(TEST_NUM, 1));
 }

--- a/test_pool/pcie/operating_system/test_os_p008.c
+++ b/test_pool/pcie/operating_system/test_os_p008.c
@@ -83,13 +83,12 @@ payload(void)
 
       /* Get the least highest of max bus number */
       bus_index = (PCIE_EXTRACT_BDF_BUS(bdf) < end_bus) ? PCIE_EXTRACT_BDF_BUS(bdf):end_bus;
-      val_print(ACS_PRINT_INFO, "Maximum bus value is 0x%x", bus_index);
+      val_print(ACS_PRINT_INFO, "\n       Maximum bus value is 0x%x", bus_index);
       bus_index += 1;
 
       /* Bus value should not exceed 255 */
       if (bus_index > end_bus) {
-          val_print(ACS_PRINT_ERR, "\n       Bus index exceeded END_BUS Number",
-                                                                            0);
+          val_print(ACS_PRINT_DEBUG, "\n       Bus index exceeded END_BUS Number", 0);
           val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 2));
           return;
       }

--- a/test_pool/pcie/operating_system/test_os_p009.c
+++ b/test_pool/pcie/operating_system/test_os_p009.c
@@ -102,6 +102,7 @@ payload(void)
 
         // Only check for Root Ports
         if (dp_type == RP) {
+            val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
             if (check_pcie_cfg_space(bdf)) {
                 val_print(ACS_PRINT_ERR,
                     "\n       Invalid PCIe capability found on dev: %d", tbl_index);

--- a/test_pool/pcie/operating_system/test_os_p011.c
+++ b/test_pool/pcie/operating_system/test_os_p011.c
@@ -59,6 +59,7 @@ payload(void)
       if ((dp_type == RP) || (dp_type == iEP_RP)) {
 
         /* If test runs for atleast an endpoint */
+        val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
         test_skip = 0;
 
         /* Get the offset for bus number register in the config header which has
@@ -130,8 +131,10 @@ payload(void)
       }
   }
 
-  if (test_skip)
+  if (test_skip) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RP/ iEP_RP type device found. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
+  }
   if (test_fail)
       val_set_status(pe_index, RESULT_FAIL(TEST_NUM, 1));
   else

--- a/test_pool/pcie/operating_system/test_os_p017.c
+++ b/test_pool/pcie/operating_system/test_os_p017.c
@@ -76,6 +76,7 @@ payload(void)
               test_fails++;
               continue;
           }
+
           val_pcie_read_cfg(bdf, cap_base + ACSCR_OFFSET, &acs_data);
 
           /* Extract ACS directed translated p2p bit */
@@ -88,8 +89,11 @@ payload(void)
       }
   }
 
-  if (test_skip == 1)
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG,
+           "\n       No RP type device found with P2P and ATS Support. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
+  }
   else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(TEST_NUM, test_fails));
   else

--- a/test_pool/pcie/operating_system/test_os_p018.c
+++ b/test_pool/pcie/operating_system/test_os_p018.c
@@ -45,13 +45,14 @@ payload(void)
   /* Check If PCIe Hierarchy supports P2P */
   if (val_pcie_p2p_support() == NOT_IMPLEMENTED) {
     val_print(ACS_PRINT_DEBUG, "\n       pal_pcie_p2p_support API is unimplemented ", 0);
-    val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 01));
+    val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
     return;
   }
 
   if (val_pcie_p2p_support())
   {
-      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
+      val_print(ACS_PRINT_DEBUG, "\n       PCIe hierarchy does not support P2P. Skipping test", 0);
+      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 2));
       return;
   }
 
@@ -69,26 +70,27 @@ payload(void)
       {
           /* Test runs for atleast an endpoint */
           test_skip = 0;
+          val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
 
           /* It ACS Not Supported, Fail. */
           if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_ACS, &cap_base) != PCIE_SUCCESS) {
-              val_print(ACS_PRINT_ERR, "\n       BDF 0x%x: ACS Cap unsupported",
-                                                                bdf);
+              val_print(ACS_PRINT_ERR, "\n       BDF 0x%x: ACS Cap unsupported", bdf);
               test_fails++;
               continue;
           }
 
           /* If AER Not Supported, Fail. */
           if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_AER, &cap_base) != PCIE_SUCCESS) {
-              val_print(ACS_PRINT_DEBUG, "\n       BDF 0x%x: AER Cap "
-                                                        "unsupported", bdf);
+              val_print(ACS_PRINT_ERR, "\n       BDF 0x%x: AER Cap unsupported", bdf);
               test_fails++;
           }
       }
   }
 
-  if (test_skip == 1)
-      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 2));
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RP type device found. Skipping test", 0);
+      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 3));
+  }
   else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(TEST_NUM, test_fails));
   else

--- a/test_pool/pcie/operating_system/test_os_p019.c
+++ b/test_pool/pcie/operating_system/test_os_p019.c
@@ -47,6 +47,7 @@ payload(void)
   /* Check If PCIe Hierarchy supports P2P */
   if (val_pcie_p2p_support())
   {
+      val_print(ACS_PRINT_DEBUG, "\n       PCIe hierarchy does not support P2P. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
       return;
   }
@@ -65,6 +66,7 @@ payload(void)
       {
           /* Test runs for atleast an endpoint */
           test_skip = 0;
+          val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
 
           /* Read the ACS Capability */
           if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_ACS, &cap_base) != PCIE_SUCCESS) {
@@ -121,8 +123,10 @@ payload(void)
       }
   }
 
-  if (test_skip == 1)
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RP type device found. Skipping device", 0);
       val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 2));
+  }
   else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(TEST_NUM, test_fails));
   else

--- a/test_pool/pcie/operating_system/test_os_p031.c
+++ b/test_pool/pcie/operating_system/test_os_p031.c
@@ -47,6 +47,7 @@ payload(void)
   while (tbl_index < bdf_tbl_ptr->num_entries)
   {
       bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+      val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
 
       /* Read 32-bits from Cache Line Size register offset */
       val_pcie_read_cfg(bdf, TYPE01_CLSR, &reg_value);
@@ -64,7 +65,7 @@ payload(void)
       if (((reg_value & BIST_BC_MASK) == 0x00) &&
          (((reg_value & BIST_CC_MASK) != 0x00) || ((reg_value & BIST_SB_MASK) != 0x00)))
       {
-          val_print(ACS_PRINT_ERR, "\n        BDF 0x%x", bdf);
+          val_print(ACS_PRINT_ERR, "\n       BDF 0x%x", bdf);
           val_print(ACS_PRINT_ERR, " BIST Reg Value : %d", reg_value);
           test_fails++;
       }

--- a/test_pool/pcie/operating_system/test_os_p032.c
+++ b/test_pool/pcie/operating_system/test_os_p032.c
@@ -48,6 +48,7 @@ payload(void)
   while (tbl_index < bdf_tbl_ptr->num_entries)
   {
       bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+      val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
 
       /* Read 32-bits from Capabilities pointer register offset */
       val_pcie_read_cfg(bdf, TYPE01_CPR, &reg_value);
@@ -61,7 +62,7 @@ payload(void)
       /* Check Capabilities Pointer is not NULL and is between 40h and FCh */
       if (!((cap_ptr_value != 0x00) && ((cap_ptr_value >= 0x40) && (cap_ptr_value <= 0xFC))))
       {
-          val_print(ACS_PRINT_ERR, "\n        BDF 0x%x", bdf);
+          val_print(ACS_PRINT_ERR, "\n       BDF 0x%x", bdf);
           val_print(ACS_PRINT_ERR, " Cap Ptr Value: 0x%x", cap_ptr_value);
           test_fails++;
       }

--- a/test_pool/pcie/operating_system/test_os_p033.c
+++ b/test_pool/pcie/operating_system/test_os_p033.c
@@ -49,10 +49,11 @@ payload(void)
   while (tbl_index < bdf_tbl_ptr->num_entries)
   {
       bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+      val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
 
       /* Retrieve the addr of PCI express capability (10h) */
       if (val_pcie_find_capability(bdf, PCIE_CAP, CID_PCIECS, &cap_base) != PCIE_SUCCESS) {
-          val_print(ACS_PRINT_INFO, "PCIe Express Capability not present ", 0);
+          val_print(ACS_PRINT_INFO, "\n       PCIe Express Capability not present ", 0);
           continue;
       }
 
@@ -68,7 +69,7 @@ payload(void)
       /* Valid payload size between 000b (129-bytes) to 101b (4096 bytes) */
       if (!((max_payload_value >= 0x00) && (max_payload_value <= 0x05)))
       {
-          val_print(ACS_PRINT_ERR, "\n        BDF 0x%x", bdf);
+          val_print(ACS_PRINT_ERR, "\n       BDF 0x%x", bdf);
           val_print(ACS_PRINT_ERR, " Cap Ptr Value: 0x%x", max_payload_value);
           test_fails++;
       }

--- a/test_pool/pcie/operating_system/test_os_p035.c
+++ b/test_pool/pcie/operating_system/test_os_p035.c
@@ -100,9 +100,12 @@ payload(void)
       /* Check entry is  RCiEP or normal EP */
       if ((dp_type == RCiEP) || (dp_type == EP))
       {
+
+          val_print(ACS_PRINT_DEBUG, "\n       BDF 0x%x ", bdf);
+
           /* Read FLR capability bit value */
           if (val_pcie_find_capability(bdf, PCIE_CAP, CID_PCIECS, &cap_base) != PCIE_SUCCESS) {
-              val_print(ACS_PRINT_INFO, "PCIe Express Capability not present ", 0);
+              val_print(ACS_PRINT_DEBUG, "\n       PCIe Express Capability not present ", 0);
               continue;
           }
           val_pcie_read_cfg(bdf, cap_base + DCAPR_OFFSET, &reg_value);
@@ -119,15 +122,14 @@ payload(void)
           /* If memory allocation fail, fail the test */
           if (func_config_space == NULL)
           {
-              val_print(ACS_PRINT_ERR, "\n Memory allocation fail", 0);
+              val_print(ACS_PRINT_ERR, "\n       Memory allocation fail", 0);
               val_set_status(pe_index, RESULT_FAIL(TEST_NUM, test_fails));
               return;
           }
 
           /* Get function configuration space address */
           config_space_addr = val_pcie_get_bdf_config_addr(bdf);
-          val_print(ACS_PRINT_INFO, "\n    BDF 0x%x ", bdf);
-          val_print(ACS_PRINT_INFO, "config space addr 0x%x", config_space_addr);
+          val_print(ACS_PRINT_INFO, "  config space addr 0x%x", config_space_addr);
 
           /* Save the function config space to restore after FLR */
           for (idx = 0; idx < PCIE_CFG_SIZE / 4; idx++) {
@@ -156,7 +158,7 @@ payload(void)
           val_pcie_read_cfg(bdf, 0, &reg_value);
           if ((reg_value & TYPE01_VIDR_MASK) == TYPE01_VIDR_MASK)
           {
-              val_print(ACS_PRINT_ERR, "\n BDF 0x%x not present", bdf);
+              val_print(ACS_PRINT_ERR, "\n       BDF 0x%x not present", bdf);
               test_fails++;
               val_memory_free(func_config_space);
               continue;
@@ -174,8 +176,11 @@ payload(void)
       }
   }
 
-  if (test_skip == 1)
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG,
+        "\n       No RCiEP/ EP type device found with PCIe Express Cap support. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
+  }
   else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(TEST_NUM, test_fails));
   else

--- a/test_pool/pcie/operating_system/test_os_p036.c
+++ b/test_pool/pcie/operating_system/test_os_p036.c
@@ -61,6 +61,8 @@ payload(void)
       /* Check entry is Downstream port or RP */
       if ((dp_type == DP) || (dp_type == iEP_RP) || (dp_type == RP))
       {
+          val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+
           /* Read the secondary and subordinate bus number */
           val_pcie_read_cfg(bdf, TYPE1_PBN, &reg_value);
           sec_bus = ((reg_value >> SECBN_SHIFT) & SECBN_MASK);
@@ -82,7 +84,7 @@ payload(void)
 
           /* Disable the ARI forwarding enable bit */
           if (val_pcie_find_capability(bdf, PCIE_CAP, CID_PCIECS, &cap_base) != PCIE_SUCCESS) {
-              val_print(ACS_PRINT_INFO, "PCIe Express Capability not present ", 0);
+              val_print(ACS_PRINT_INFO, "  PCIe Express Capability not present ", 0);
               continue;
           }
 
@@ -100,7 +102,7 @@ payload(void)
           if (status || (reg_value == PCIE_UNKNOWN_RESPONSE))
           {
               test_fails++;
-              val_print(ACS_PRINT_ERR, "\n    Dev 0x%x found under", dev_bdf);
+              val_print(ACS_PRINT_ERR, "\n       Dev 0x%x found under", dev_bdf);
               val_print(ACS_PRINT_ERR, " RP bdf 0x%x", bdf);
           }
 
@@ -116,7 +118,7 @@ payload(void)
               if (reg_value != PCIE_UNKNOWN_RESPONSE)
               {
                   test_fails++;
-                  val_print(ACS_PRINT_ERR, "\n    Dev 0x%x found under", dev_bdf);
+                  val_print(ACS_PRINT_ERR, "\n       Dev 0x%x found under", dev_bdf);
                   val_print(ACS_PRINT_ERR, " RP bdf 0x%x", bdf);
               }
           }

--- a/test_pool/pcie/operating_system/test_os_p037.c
+++ b/test_pool/pcie/operating_system/test_os_p037.c
@@ -58,7 +58,7 @@ payload(void)
       dp_type = val_pcie_device_port_type(bdf);
       if ((dp_type == RP) || (dp_type == iEP_RP)) {
         /* Read Vendor ID of RP with ECAM based mechanism, and compare it with the */
-        val_print(ACS_PRINT_DEBUG, "\n    BDF 0x%x", bdf);
+        val_print(ACS_PRINT_DEBUG, "\n       BDF 0x%x", bdf);
         ecam_base = val_pcie_get_ecam_base(bdf);
 
         /* If test runs for atleast an endpoint */
@@ -81,14 +81,16 @@ payload(void)
 
         if (ecam_cc != pciio_proto_cc)
         {
-          val_print(ACS_PRINT_ERR, "\n        Config Txn Error : 0x%x ", bdf);
+          val_print(ACS_PRINT_ERR, "\n       Config Txn Error : 0x%x ", bdf);
           fail_cnt++;
         }
       }
   }
 
-  if (test_skip == 1)
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RP/ iEP_RP type device found. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 01));
+  }
   else if (fail_cnt)
       val_set_status(pe_index, RESULT_FAIL(TEST_NUM, fail_cnt));
   else

--- a/test_pool/pcie/operating_system/test_os_p038.c
+++ b/test_pool/pcie/operating_system/test_os_p038.c
@@ -95,8 +95,10 @@ payload(void)
       }
   }
 
-  if (test_skip == 1)
+  if (test_skip == 1) {
+      val_print(ACS_PRINT_DEBUG, "\n       No RP/ iEP_RP type device found. Skipping test", 0);
       val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 01));
+  }
   else if (test_fail)
       val_set_status(pe_index, RESULT_FAIL(TEST_NUM, test_fail));
   else

--- a/test_pool/pcie/operating_system/test_os_p039.c
+++ b/test_pool/pcie/operating_system/test_os_p039.c
@@ -56,7 +56,7 @@ payload(void)
       /* Check entry is endpoint */
       if (dp_type == EP)
       {
-         val_print(ACS_PRINT_DEBUG, "\n    BDF 0x%x", bdf);
+         val_print(ACS_PRINT_DEBUG, "\n       BDF 0x%x", bdf);
 
          val_pcie_read_cfg(bdf, TYPE01_ILR, &reg_value);
          int_pin = VAL_EXTRACT_BITS(reg_value, TYPE01_IPR_SHIFT, TYPE01_IPR_SHIFT + 7);
@@ -73,8 +73,10 @@ payload(void)
          /* If MSI or MSI-X not supported, but INTx supported test fails */
          if ((val_pcie_find_capability(bdf, PCIE_CAP, CID_MSI, &cap_base) == PCIE_CAP_NOT_FOUND)
           && (val_pcie_find_capability(bdf, PCIE_CAP, CID_MSIX, &cap_base) == PCIE_CAP_NOT_FOUND)
-           && ((int_pin >= 1) && (int_pin <= 4)))
-              test_fails++;
+           && ((int_pin >= 1) && (int_pin <= 4))) {
+            val_print(ACS_PRINT_ERR, "\n       INTx supported but MSI/MSI-X not supported", 0);
+            test_fails++;
+           }
       }
   }
 

--- a/test_pool/pcie/operating_system/test_os_p061.c
+++ b/test_pool/pcie/operating_system/test_os_p061.c
@@ -74,7 +74,7 @@ payload(void)
   status |= val_pe_install_esr(EXCEPT_AARCH64_SERROR, esr);
   if (status)
   {
-      val_print(ACS_PRINT_ERR, "\n      Failed in installing the exception handler", 0);
+      val_print(ACS_PRINT_ERR, "\n       Failed in installing the exception handler", 0);
       val_set_status(index, RESULT_FAIL(TEST_NUM, 01));
       return;
   }
@@ -104,19 +104,23 @@ next_bdf:
           if (bar_value == 0)
           {
               /** This BAR is not implemented **/
+              val_print(ACS_PRINT_DEBUG, "\n       BAR is not implemented for BDF 0x%x", bdf);
               tbl_index++;
               goto next_bdf;
           }
 
           /* Skip for IO address space */
           if (bar_value & 0x1) {
+              val_print(ACS_PRINT_DEBUG, "\n       BAR is used for IO address space request", 0);
+              val_print(ACS_PRINT_DEBUG, " for BDF 0x%x", bdf);
               tbl_index++;
               goto next_bdf;
           }
 
           if (BAR_REG(bar_value) == BAR_64_BIT)
           {
-              val_print(ACS_PRINT_INFO, "BAR supports 64-bit address decoding capability \n", 0);
+              val_print(ACS_PRINT_INFO,
+                  "\n       BAR supports 64-bit address decoding capability", 0);
               val_pcie_read_cfg(bdf, offset+4, &bar_value_1);
               base = bar_value_1;
 
@@ -139,7 +143,8 @@ next_bdf:
           }
 
           else {
-              val_print(ACS_PRINT_INFO, "The BAR supports 32-bit address decoding capability\n", 0);
+              val_print(ACS_PRINT_INFO,
+                  "\n       The BAR supports 32-bit address decoding capability", 0);
 
               /* BAR supports 32-bit address. Write all 1's
                * to BARn and identify the size requested
@@ -158,7 +163,7 @@ next_bdf:
 
           /* Check if bar supports the remap size */
           if (bar_size < 1024) {
-              val_print(ACS_PRINT_ERR, "Bar size less than remap requested size", 0);
+              val_print(ACS_PRINT_ERR, "\n       Bar size less than remap requested size", 0);
               goto next_bar;
           }
 

--- a/test_pool/pcie/operating_system/test_os_p062.c
+++ b/test_pool/pcie/operating_system/test_os_p062.c
@@ -43,7 +43,7 @@ payload(void)
   target_dev_index = val_dma_get_info(DMA_NUM_CTRL, 0);
 
   if (!target_dev_index) {
-      val_print(ACS_PRINT_TEST, "\n       No DMA controllers detected...    ", 0);
+      val_print(ACS_PRINT_DEBUG, "\n       No DMA controllers detected...    ", 0);
       val_set_status(index, RESULT_SKIP(TEST_NUM, 2));
       return;
   }

--- a/test_pool/pcie/operating_system/test_os_p064.c
+++ b/test_pool/pcie/operating_system/test_os_p064.c
@@ -36,7 +36,7 @@ payload(void)
   num_pcie_rc = val_iovirt_get_pcie_rc_info(NUM_PCIE_RC, 0);
 
   if (!num_pcie_rc) {
-     val_print(ACS_PRINT_WARN, "\n       Skip because no PCIe RC detected  ", 0);
+     val_print(ACS_PRINT_DEBUG, "\n       Skip because no PCIe RC detected  ", 0);
      val_set_status(index, RESULT_SKIP(TEST_NUM, 1));
      return;
   }
@@ -48,7 +48,8 @@ payload(void)
       if (mem_attr == INNER_SHAREABLE)
          val_set_status(index, RESULT_PASS(TEST_NUM, 1));
       else {
-         val_print(ACS_PRINT_ERR, "\n    Failed mem attribute check for PCIe RC %d", num_pcie_rc);
+         val_print(ACS_PRINT_ERR,
+                 "\n       Failed mem attribute check for PCIe RC %d", num_pcie_rc);
          val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
          return;
       }

--- a/test_pool/pcie/operating_system/test_os_p066.c
+++ b/test_pool/pcie/operating_system/test_os_p066.c
@@ -45,11 +45,14 @@ payload(void)
     while (tbl_index < bdf_tbl_ptr->num_entries)
     {
         dev_bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
+        val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", dev_bdf);
 
         dev_type = val_pcie_get_device_type(dev_bdf);
         /* Allow only type-1 headers and skip others */
-        if (dev_type != 3)
-            continue;
+        if (dev_type != 3) {
+          val_print(ACS_PRINT_DEBUG, "\n       Skipping Non Type-1 headers", 0);
+          continue;
+        }
 
         ret = val_pcie_read_cfg(dev_bdf, BAR0, &bar_data);
         if (bar_data) {

--- a/test_pool/pcie/operating_system/test_os_p067.c
+++ b/test_pool/pcie/operating_system/test_os_p067.c
@@ -126,6 +126,7 @@ payload (void)
   uint32_t test_skip = 1;
 
   if (!count) {
+     val_print(ACS_PRINT_DEBUG, "\n       No peripherals found. Skipping test", 0);
      val_set_status (index, RESULT_SKIP(TEST_NUM, 3));
      return;
   }
@@ -145,7 +146,7 @@ payload (void)
       /* Get BDF of a device */
       current_dev_bdf = val_peripheral_get_info (ANY_BDF, count - 1);
       if (current_dev_bdf) {
-        val_print (ACS_PRINT_INFO, "       Checking PCI device with BDF %4X\n", current_dev_bdf);
+        val_print (ACS_PRINT_DEBUG, "\n       Checking PCI device with BDF 0x%X", current_dev_bdf);
         /* Read MSI(X) vectors */
         if (val_get_msi_vectors (current_dev_bdf, &current_dev_mvec)) {
 

--- a/test_pool/pcie/operating_system/test_os_p068.c
+++ b/test_pool/pcie/operating_system/test_os_p068.c
@@ -34,6 +34,7 @@ static void payload(void)
   uint32_t index = val_pe_get_index_mpid (val_pe_get_mpid());
 
   num_per = val_peripheral_get_info(NUM_ALL, 0);
+
   /* For each peripheral check for PASID support */
   /* If PASID is supported, test the max number of PASIDs supported */
   for (num_per--; num_per >= 0; num_per--)
@@ -44,17 +45,20 @@ static void payload(void)
         skip = 0;
         if (max_pasids < MIN_PASID_SUPPORT)
         {
+           val_print(ACS_PRINT_ERR, "\n       Max PASID support less than 16 bits  ", 0);
            val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
            break;
         }
      }
   }
+
   if (num_per < 0)
   {
      /* For each SMMUv3 check for PASID support */
      /* If PASID is supported, test the max number of PASIDs supported */
+
      num_smmu = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
-          for (num_smmu--; num_smmu >= 0; num_smmu--)
+     for (num_smmu--; num_smmu >= 0; num_smmu--)
      {
          if (val_iovirt_get_smmu_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) == 3)
          {
@@ -64,6 +68,7 @@ static void payload(void)
                  skip = 0;
                  if (max_pasids < MIN_PASID_SUPPORT)
                  {
+                    val_print(ACS_PRINT_ERR, "\n      Max PASID support less than 16 bits  ", 0);
                     val_set_status(index, RESULT_FAIL(TEST_NUM, 2));
                     break;
                  }
@@ -71,6 +76,7 @@ static void payload(void)
          }
      }
   }
+
   if (num_smmu < 0) {
       if (skip)
           val_set_status(index, RESULT_SKIP(TEST_NUM, 3));


### PR DESCRIPTION
- Fix for issue #107
- Additional prints to identify which devices have been checked.
- Additional prints to identify the reason for a test skip/fail.