### PR TITLE
SMMU tests 602 & 603 alignment

### DIFF
--- a/test_pool/peripherals/operating_system/test_os_d003.c
+++ b/test_pool/peripherals/operating_system/test_os_d003.c
@@ -1,6 +1,6 @@
 
 /** @file
- * Copyright (c) 2016-2018, 2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021, 2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,6 @@
 
 #define TEST_NUM   (ACS_PER_TEST_NUM_BASE + 3)
 #define TEST_RULE  "B_PER_05"
-/*one space character is removed from TEST_DESC, to nullify a space written as part of the test */
 #define TEST_DESC  "Check Arm BSA UART register offsets   "
 #define TEST_NUM1  (ACS_PER_TEST_NUM_BASE + 4)
 #define TEST_RULE1 "B_PER_06, B_PER_07"
@@ -175,8 +174,6 @@ payload()
           validate_register_access(BSA_UARTFR, WIDTH_BIT8 | WIDTH_BIT16 | WIDTH_BIT32);
           validate_register_access(BSA_UARTRIS, WIDTH_BIT16 | WIDTH_BIT32);
           validate_register_access(BSA_UARTMIS, WIDTH_BIT16 | WIDTH_BIT32);
-          /* Writing bits 11:8 as F and writing space character (0x20) to UART data register */
-          uart_reg_write(BSA_UARTDR, WIDTH_BIT32, 0xF20);
 
           val_set_status(index, RESULT_PASS(TEST_NUM, 1));
       }
@@ -223,7 +220,8 @@ payload1()
               }
 
               uart_enable_txintr();
-              val_print_raw(l_uart_base, g_print_level, "\n    Test Message  ", 0);
+              val_print_raw(l_uart_base, g_print_level,
+                            "\n       Test Message                          ", 0);
 
               while ((--timeout > 0) && (IS_RESULT_PENDING(val_get_status(index)))) {
               };

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -58,7 +58,7 @@ val_pcie_read_cfg(uint32_t bdf, uint32_t offset, uint32_t *data)
   }
 
   if (g_pcie_info_table == NULL) {
-      val_print(ACS_PRINT_ERR, "\n       Read_PCIe_CFG: PCIE info table is not created", 0);
+      val_print(ACS_PRINT_ERR, "\n       PCIe_CFG_RD PCIE info table is not created", 0);
       return PCIE_NO_MAPPING;
   }
 
@@ -75,7 +75,7 @@ val_pcie_read_cfg(uint32_t bdf, uint32_t offset, uint32_t *data)
   }
 
   if (ecam_base == 0) {
-      val_print(ACS_PRINT_ERR, "\n       Read PCIe_CFG: ECAM Base is zero %x", bdf);
+      val_print(ACS_PRINT_ERR, "\n       PCIe_CFG_RD ECAM Base is zero %.8x", bdf);
       return PCIE_NO_MAPPING;
   }
 
@@ -151,7 +151,7 @@ val_pcie_write_cfg(uint32_t bdf, uint32_t offset, uint32_t data)
   }
 
   if (ecam_base == 0) {
-      val_print(ACS_PRINT_ERR, "\n       Write PCIe_CFG: ECAM Base is zero %x", bdf);
+      val_print(ACS_PRINT_ERR, "\n       PCIe_CFG_WR ECAM Base is zero %.8x", bdf);
       return;
   }
 


### PR DESCRIPTION
#116
 -  Minor prints reformatting in val_pcie_read_cfg and val_pcie_write_cfg functions to align with pass prints