### PR TITLE
Skip SMMU v2 test on v3

### DIFF
--- a/val/src/acs_iovirt.c
+++ b/val/src/acs_iovirt.c
@@ -366,6 +366,7 @@ val_iovirt_get_device_info(uint32_t rid, uint32_t segment, uint32_t *device_id,
 void
 val_iovirt_create_info_table(uint64_t *iovirt_info_table)
 {
+  uint32_t i, smmu_ver;
 
   if (iovirt_info_table == NULL)
   {
@@ -381,6 +382,12 @@ val_iovirt_create_info_table(uint64_t *iovirt_info_table)
   g_num_smmus = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
   val_print(ACS_PRINT_TEST,
             " SMMU_INFO: Number of SMMU CTRL       :    %d \n", g_num_smmus);
+  for (i = 0; i < g_num_smmus; i++) {
+    smmu_ver = val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, i);
+    val_print(ACS_PRINT_TEST,
+            " SMMU_INFO: SMMU index %.2d ", i);
+    val_print(ACS_PRINT_TEST, "version     :    v%d \n", smmu_ver);
+  }
 }
 
 /**

--- a/val/src/acs_smmu.c
+++ b/val/src/acs_smmu.c
@@ -57,6 +57,7 @@ val_smmu_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 {
   uint32_t status, i;
   uint32_t num_smmu;
+  uint32_t ver_smmu;
 
   status = ACS_STATUS_PASS;
 
@@ -84,6 +85,7 @@ val_smmu_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 
   g_curr_module = 1 << SMMU_MODULE;
 
+  ver_smmu = val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, 0);
   if (g_sw_view[G_SW_OS]) {
        val_print(ACS_PRINT_ERR, "\nOperating System View:\n", 0);
        status |= os_i001_entry(num_pe);
@@ -96,7 +98,8 @@ val_smmu_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
        val_print(ACS_PRINT_ERR, "\nHypervisor View:\n", 0);
        status |= hyp_i001_entry(num_pe);
        status |= hyp_i002_entry(num_pe);
-       status |= hyp_i003_entry(num_pe);
+       if (ver_smmu == 2)
+           status |= hyp_i003_entry(num_pe);
        status |= hyp_i004_entry(num_pe);
   }
 


### PR DESCRIPTION
 Fix for #114 and #116 

- Skip SMMU v2 test 353 on smmu v3 systems
- Print Versions of all SMMU's in INFO prints