### PR TITLE
 PSCI service call conduit changes + Use F/W interrupt handlers for edk2 + DT systems

### DIFF
--- a/platform/pal_uefi_acpi/include/pal_uefi.h
+++ b/platform/pal_uefi_acpi/include/pal_uefi.h
@@ -79,6 +79,14 @@ typedef struct {
 #define bsa_print(verbose, string, ...) if(verbose >= g_print_level) \
                                             Print(string, ##__VA_ARGS__)
 
+/**
+  Conduits for service calls (SMC vs HVC).
+**/
+#define CONDUIT_SMC       0
+#define CONDUIT_HVC       1
+#define CONDUIT_UNKNOWN  -1
+#define CONDUIT_NONE     -2
+
 typedef struct {
   UINT32 num_of_pe;
 }PE_INFO_HDR;

--- a/platform/pal_uefi_acpi/src/AArch64/ArmSmc.S
+++ b/platform/pal_uefi_acpi/src/AArch64/ArmSmc.S
@@ -1,5 +1,5 @@
 #/** @file
-# Copyright (c) 2016-2018, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2016-2018, 2023, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,11 +19,19 @@
 .text
 .align 3
 
+GCC_ASM_IMPORT(gPsciConduit)
+.equ CONDUIT_SMC,        0
+.equ CONDUIT_HVC,        1
+.equ INVALID_PARAMETER, -3
+
 GCC_ASM_EXPORT(ArmCallSmc)
 
 ASM_PFX(ArmCallSmc):
   // Push x0 on the stack - The stack must always be quad-word aligned
   str   x0, [sp, #-16]!
+
+  // Load the conduit into x10
+  mov   x10, x1
 
   // Load the SMC arguments values into the appropriate registers
   ldp   x6, x7, [x0, #48]
@@ -31,8 +39,25 @@ ASM_PFX(ArmCallSmc):
   ldp   x2, x3, [x0, #16]
   ldp   x0, x1, [x0, #0]
 
-  smc   #0
+  // Check whether the conduit is SMC or HVC
+  cmp   x10, CONDUIT_SMC
+  beq   conduit_smc
+  cmp   x10, CONDUIT_HVC
+  beq   conduit_hvc
 
+conduit_invalid:
+  mov   x0, INVALID_PARAMETER
+  b     finish
+
+conduit_smc:
+  smc   #0
+  b     finish
+
+conduit_hvc:
+  hvc   #0
+  b     finish
+
+finish:
   // Pop the ARM_SMC_ARGS structure address from the stack into x9
   ldr   x9, [sp], #16
 

--- a/platform/pal_uefi_acpi/src/pal_acpi.c
+++ b/platform/pal_uefi_acpi/src/pal_acpi.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2020, 2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2020, 2021, 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -269,4 +269,37 @@ pal_get_iort_ptr()
 
   return 0;
 
+}
+
+/**
+  @brief   Iterate through the tables pointed by XSDT and return FADT Table address
+  @param   None
+  @return  64-bit address of FADT table
+  @retval  0:  FADT table could not be found
+**/
+UINT64
+pal_get_fadt_ptr (
+  VOID
+  )
+{
+  EFI_ACPI_DESCRIPTION_HEADER   *Xsdt;
+  UINT64                        *Entry64;
+  UINT32                        Entry64Num;
+  UINT32                        Idx;
+
+  Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
+  if (Xsdt == NULL) {
+      bsa_print(ACS_PRINT_ERR, L" XSDT not found \n");
+      return 0;
+  }
+
+  Entry64 = (UINT64 *)(Xsdt + 1);
+  Entry64Num = (Xsdt->Length - sizeof (EFI_ACPI_DESCRIPTION_HEADER)) >> 3;
+  for (Idx = 0; Idx < Entry64Num; Idx++) {
+    if (*(UINT32 *)(UINTN)(Entry64[Idx]) == EFI_ACPI_6_1_FIXED_ACPI_DESCRIPTION_TABLE_SIGNATURE) {
+      return (UINT64)(Entry64[Idx]);
+    }
+  }
+
+  return 0;
 }

--- a/platform/pal_uefi_acpi/src/pal_pe.c
+++ b/platform/pal_uefi_acpi/src/pal_pe.c
@@ -29,17 +29,54 @@ static   EFI_ACPI_6_1_MULTIPLE_APIC_DESCRIPTION_TABLE_HEADER *gMadtHdr;
 UINT8   *gSecondaryPeStack;
 UINT64  gMpidrMax;
 static UINT32 g_num_pe;
+extern INT32 gPsciConduit;
 
 #define SIZE_STACK_SECONDARY_PE  0x100		//256 bytes per core
 #define UPDATE_AFF_MAX(src,dest,mask)  ((dest & mask) > (src & mask) ? (dest & mask) : (src & mask))
 
 UINT64
 pal_get_madt_ptr();
-VOID
-ArmCallSmc (
-  IN OUT ARM_SMC_ARGS *Args
+
+UINT64
+pal_get_fadt_ptr (
+  VOID
   );
 
+VOID
+ArmCallSmc (
+  IN OUT ARM_SMC_ARGS *Args,
+  IN     INT32        Conduit
+  );
+
+/**
+  @brief   Queries the FADT ACPI table to check whether PSCI is implemented and,
+           if so, using which conduit (HVC or SMC).
+
+  @retval  CONDUIT_UNKNOWN:       The FADT table could not be discovered.
+  @retval  CONDUIT_NONE:          PSCI is not implemented
+  @retval  CONDUIT_SMC:           PSCI is implemented and uses SMC as
+                                  the conduit.
+  @retval  CONDUIT_HVC:           PSCI is implemented and uses HVC as
+                                  the conduit.
+**/
+INT32
+pal_psci_get_conduit (
+  VOID
+  )
+{
+  EFI_ACPI_6_1_FIXED_ACPI_DESCRIPTION_TABLE  *Fadt;
+
+  Fadt = (EFI_ACPI_6_1_FIXED_ACPI_DESCRIPTION_TABLE *)pal_get_fadt_ptr ();
+  if (!Fadt) {
+    return CONDUIT_UNKNOWN;
+  } else if (!(Fadt->ArmBootArch & EFI_ACPI_6_1_ARM_PSCI_COMPLIANT)) {
+    return CONDUIT_NONE;
+  } else if (Fadt->ArmBootArch & EFI_ACPI_6_1_ARM_PSCI_USE_HVC) {
+    return CONDUIT_HVC;
+  } else {
+    return CONDUIT_SMC;
+  }
+}
 
 /**
   @brief   Return the base address of the region allocated for Stack use for the Secondary
@@ -225,13 +262,14 @@ pal_pe_install_esr(UINT32 ExceptionType,  VOID (*esr)(UINT64, VOID *))
           for both input and output values.
 
   @param  Argumets to pass to the EL3 firmware
+  @param  Conduit  SMC or HVC
 
   @return  None
 **/
 VOID
-pal_pe_call_smc(ARM_SMC_ARGS *ArmSmcArgs)
+pal_pe_call_smc(ARM_SMC_ARGS *ArmSmcArgs, INT32 Conduit)
 {
-  ArmCallSmc (ArmSmcArgs);
+  ArmCallSmc (ArmSmcArgs, Conduit);
 }
 
 VOID
@@ -249,7 +287,7 @@ VOID
 pal_pe_execute_payload(ARM_SMC_ARGS *ArmSmcArgs)
 {
   ArmSmcArgs->Arg2 = (UINT64)ModuleEntryPoint;
-  pal_pe_call_smc(ArmSmcArgs);
+  pal_pe_call_smc(ArmSmcArgs, gPsciConduit);
 }
 
 /**

--- a/platform/pal_uefi_dt/include/pal_dt_spec.h
+++ b/platform/pal_uefi_dt/include/pal_dt_spec.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,6 +31,9 @@
 #define PROPERTY_MASK_PE_AFF3  0xFF  /* Affinity bits 3 mask MPIDR_EL1[39:32] */
 #define PROPERTY_MASK_PE_AFF0_AFF2  0xFFFFFF  /* Affinity bits 0, 1, 2 mask MPIDR_EL1[23:0] */
 #define PMU_COMPATIBLE_STR_LEN      24
+
+/* PSCI related */
+#define PSCI_COMPATIBLE_STR_LEN 15
 
 /*  WD related */
 /* Interrupt Flags for WD*/

--- a/platform/pal_uefi_dt/include/pal_uefi.h
+++ b/platform/pal_uefi_dt/include/pal_uefi.h
@@ -79,6 +79,14 @@ typedef struct {
 #define bsa_print(verbose, string, ...) if(verbose >= g_print_level) \
                                             Print(string, ##__VA_ARGS__)
 
+/**
+  Conduits for service calls (SMC vs HVC).
+**/
+#define CONDUIT_SMC       0
+#define CONDUIT_HVC       1
+#define CONDUIT_UNKNOWN  -1
+#define CONDUIT_NONE     -2
+
 typedef struct {
   UINT32 num_of_pe;
 }PE_INFO_HDR;

--- a/platform/pal_uefi_dt/src/AArch64/ArmSmc.S
+++ b/platform/pal_uefi_dt/src/AArch64/ArmSmc.S
@@ -1,5 +1,5 @@
 #/** @file
-# Copyright (c) 2016-2018, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2016-2018, 2023, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,11 +19,19 @@
 .text
 .align 3
 
+GCC_ASM_IMPORT(gPsciConduit)
+.equ CONDUIT_SMC,        0
+.equ CONDUIT_HVC,        1
+.equ INVALID_PARAMETER, -3
+
 GCC_ASM_EXPORT(ArmCallSmc)
 
 ASM_PFX(ArmCallSmc):
   // Push x0 on the stack - The stack must always be quad-word aligned
   str   x0, [sp, #-16]!
+
+  // Load the conduit into x10
+  mov   x10, x1
 
   // Load the SMC arguments values into the appropriate registers
   ldp   x6, x7, [x0, #48]
@@ -31,8 +39,25 @@ ASM_PFX(ArmCallSmc):
   ldp   x2, x3, [x0, #16]
   ldp   x0, x1, [x0, #0]
 
-  smc   #0
+  // Check whether the conduit is SMC or HVC
+  cmp   x10, CONDUIT_SMC
+  beq   conduit_smc
+  cmp   x10, CONDUIT_HVC
+  beq   conduit_hvc
 
+conduit_invalid:
+  mov   x0, INVALID_PARAMETER
+  b     finish
+
+conduit_smc:
+  smc   #0
+  b     finish
+
+conduit_hvc:
+  hvc   #0
+  b     finish
+
+finish:
   // Pop the ARM_SMC_ARGS structure address from the stack into x9
   ldr   x9, [sp], #16
 

--- a/platform/pal_uefi_dt/src/pal_dt.c
+++ b/platform/pal_uefi_dt/src/pal_dt.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2020, 2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2020, 2021, 2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,7 @@
 #include "Include/Guid/Acpi.h"
 #include <Protocol/AcpiTable.h>
 #include "Include/IndustryStandard/Acpi61.h"
+#include <Protocol/HardwareInterrupt.h>
 
 #include "include/pal_uefi.h"
 #include "include/pal_dt.h"
@@ -42,7 +43,19 @@
 UINT32
 pal_target_is_dt()
 {
-  return 1;
+  EFI_STATUS  Status;
+  EFI_HARDWARE_INTERRUPT_PROTOCOL *Interrupt = NULL;
+
+  // Find the interrupt controller protocol.
+  Status = gBS->LocateProtocol (&gHardwareInterruptProtocolGuid, NULL, (VOID **)&Interrupt);
+  if (EFI_ERROR(Status)) {
+      bsa_print(ACS_PRINT_INFO, L"  Using ACS interrupt API's \n");
+      return 1; /* Not able to locate HW Interrupt Protocol, use ACS interrupt handlers API */
+  }
+  else {
+      bsa_print(ACS_PRINT_INFO, L"  Using F/W interrupt API's \n");
+      return 0; /* Use F/W interrupt handlers */
+  }
 }
 
 /**

--- a/platform/pal_uefi_dt/src/pal_dt_debug.c
+++ b/platform/pal_uefi_dt/src/pal_dt_debug.c
@@ -45,6 +45,7 @@ dt_dump_pe_table(PE_INFO_TABLE *PeTable)
     bsa_print(ACS_PRINT_DEBUG, L" MPIDR       :%llx\n", PeTable->pe_info[Index].mpidr);
 //    bsa_print(ACS_PRINT_DEBUG, L"    ATTR     :%x\n", PeTable->pe_info[Index].attr);
     bsa_print(ACS_PRINT_DEBUG, L" PMU GSIV    :%x\n", PeTable->pe_info[Index].pmu_gsiv);
+    bsa_print(ACS_PRINT_DEBUG, L" GIC MAINT GSIV    :%x\n", PeTable->pe_info[Index].gmain_gsiv);
     Index++;
   }
   bsa_print(ACS_PRINT_DEBUG, L" ************************************* \n");

--- a/platform/pal_uefi_dt/src/pal_gic.c
+++ b/platform/pal_uefi_dt/src/pal_gic.c
@@ -415,7 +415,7 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
   GIC_INFO_ENTRY           *GicEntry = NULL;
   UINT64 dt_ptr, cpuif_base, cpuif_length;
   UINT32 *Preg_val, *Prdregions_val;
-  UINT32 num_of_pe, num_of_rd, Index = 0;
+  UINT32 num_of_pe, num_of_rd = 0, Index = 0;
   int prop_len, i;
   int addr_cell, size_cell;
   int offset, parent_offset, num_gic_interfaces;
@@ -567,6 +567,9 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
       }
   } else
     bsa_print(ACS_PRINT_WARN, L"  GIC CPUIF not present\n");
+
+  bsa_print(ACS_PRINT_INFO, L"  Number of gic interface %d\n", num_gic_interfaces);
+  bsa_print(ACS_PRINT_INFO, L"  Number of RD %d\n", num_of_rd);
 
   num_gic_interfaces -= (num_of_rd + 1);
   bsa_print(ACS_PRINT_INFO, L"  Number of gic interface %d\n", num_gic_interfaces);

--- a/platform/pal_uefi_dt/src/pal_misc.c
+++ b/platform/pal_uefi_dt/src/pal_misc.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2020, 2021-2022 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -95,6 +95,15 @@ void pal_dump_dtb(void);
 /**  PE Test related Definitions **/
 
 /**
+  @brief Conduits for service calls (SMC vs HVC).
+**/
+#define CONDUIT_SMC       0
+#define CONDUIT_HVC       1
+#define CONDUIT_UNKNOWN  -1
+#define CONDUIT_NONE     -2
+int32_t pal_psci_get_conduit(void);
+
+/**
   @brief  number of PEs discovered
 **/
 typedef struct {
@@ -145,7 +154,7 @@ typedef struct {
   uint64_t  Arg7;
 } ARM_SMC_ARGS;
 
-void pal_pe_call_smc(ARM_SMC_ARGS *args);
+void pal_pe_call_smc(ARM_SMC_ARGS *args, int32_t conduit);
 void pal_pe_execute_payload(ARM_SMC_ARGS *args);
 uint32_t pal_pe_install_esr(uint32_t exception_type, void (*esr)(uint64_t, void *));
 /* ********** PE INFO END **********/

--- a/val/src/acs_pe_infra.c
+++ b/val/src/acs_pe_infra.c
@@ -21,6 +21,8 @@
 #include "include/bsa_std_smc.h"
 #include "sys_arch_src/gic/bsa_exception.h"
 
+int32_t gPsciConduit;
+
 /**
   @brief   Pointer to the memory location of the PE Information table
 **/
@@ -42,6 +44,19 @@ ARM_SMC_ARGS g_smc_args;
 uint32_t
 val_pe_create_info_table(uint64_t *pe_info_table)
 {
+  gPsciConduit = pal_psci_get_conduit();
+  if (gPsciConduit == CONDUIT_UNKNOWN) {
+      val_print(ACS_PRINT_WARN, " FADT not found, assuming SMC as PSCI conduit\n", 0);
+      gPsciConduit = CONDUIT_SMC;
+  } else if (gPsciConduit == CONDUIT_NONE) {
+      val_print(ACS_PRINT_WARN, " PSCI not supported, assuming SMC as conduit for tests\n"
+                                " Multi-PE and wakeup tests likely to fail\n", 0);
+      gPsciConduit = CONDUIT_SMC;
+  } else if (gPsciConduit == CONDUIT_HVC) {
+      val_print(ACS_PRINT_INFO, " Using HVC as PSCI conduit\n", 0);
+  } else {
+      val_print(ACS_PRINT_INFO, " Using SMC as PSCI conduit\n", 0);
+  }
 
   val_print(ACS_PRINT_INFO, " Creating PE INFO table\n", 0);
 
@@ -191,7 +206,7 @@ val_test_entry(void)
   // We have completed our TEST code. So, switch off the PE now
   smc_args.Arg0 = ARM_SMC_ID_PSCI_CPU_OFF;
   smc_args.Arg1 = val_pe_get_mpid();
-  pal_pe_call_smc(&smc_args);
+  pal_pe_call_smc(&smc_args, gPsciConduit);
 }
 
 

--- a/val/src/acs_wakeup.c
+++ b/val/src/acs_wakeup.c
@@ -22,6 +22,8 @@
 
 #include "include/bsa_acs_wakeup.h"
 
+extern int32_t gPsciConduit;
+
 /**
   @brief   This API executes all the wakeup tests sequentially
            1. Caller       -  Application layer.
@@ -80,13 +82,13 @@ if (g_build_sbsa) {
 
   @return PSCI Version
 **/
-uint32_t val_get_psci_ver(void)
+static uint32_t val_get_psci_ver(void)
 {
   ARM_SMC_ARGS smc_args;
 
   smc_args.Arg0 = ARM_SMC_ID_PSCI_VERSION;
 
-  pal_pe_call_smc(&smc_args);
+  pal_pe_call_smc(&smc_args, gPsciConduit);
 
   val_print(ACS_PRINT_DEBUG, "\n       PSCI VERSION = %X", smc_args.Arg0);
 
@@ -100,14 +102,14 @@ uint32_t val_get_psci_ver(void)
 
   @return PSCI features
 **/
-uint32_t val_get_psci_features(uint64_t psci_func_id)
+static uint32_t val_get_psci_features(uint64_t psci_func_id)
 {
   ARM_SMC_ARGS smc_args;
 
   smc_args.Arg0 = ARM_SMC_ID_PSCI_FEATURES;
   smc_args.Arg1 = psci_func_id;
 
-  pal_pe_call_smc(&smc_args);
+  pal_pe_call_smc(&smc_args, gPsciConduit);
 
   val_print(ACS_PRINT_DEBUG, "\n       PSCI FEATURS = %d", smc_args.Arg0);
 
@@ -146,7 +148,7 @@ val_suspend_pe(uint64_t entry, uint32_t context_id)
   smc_args.Arg1 = power_state;
   smc_args.Arg2 = entry;
   smc_args.Arg3 = context_id;
-  pal_pe_call_smc(&smc_args);
+  pal_pe_call_smc(&smc_args, gPsciConduit);
 
   return smc_args.Arg0;
 }


### PR DESCRIPTION
PSCI service call conduit changes

- PSCI can use either HVC or SMC as the conduit method, for ACPI based systems FADT acpi table will give the method to be used.
- For DT based systems, psci node will convey the information

Use F/W interrupt handlers for edk2 + DT systems.

- Some systems like RPI4 support both ACPI and DT on top of edk2. For such systems when using in edk2+DT mode, the interrupt handlers API will be supported by F/W.  In such cases no need to use ACS interrupt handlers.
- But for systems working in u-boot+DT mode, ACS interrupt handlers are needed.

