### PR TITLE
use of verb "must" in place "should" to express requirements

### DIFF
--- a/test_pool/exerciser/operating_system/test_os_e001.c
+++ b/test_pool/exerciser/operating_system/test_os_e001.c
@@ -175,7 +175,7 @@ check_transaction_blocking (uint32_t req_instance, uint32_t req_rp_bdf, uint64_t
   val_pcie_clear_sig_target_abort(req_rp_bdf);
 
   /* Transaction with Address Type other than default(0x0)
-   * Should result into Transaction blocking.
+   * must result into Transaction blocking.
    */
   val_exerciser_set_param(CFG_TXN_ATTRIBUTES, TXN_ADDR_TYPE, AT_RESERVED, req_instance);
   val_exerciser_set_param(DMA_ATTRIBUTES, (uint64_t)bar_base, 1, req_instance);

--- a/test_pool/exerciser/operating_system/test_os_e002.c
+++ b/test_pool/exerciser/operating_system/test_os_e002.c
@@ -192,7 +192,7 @@ check_redirected_req_validation (uint32_t req_instance, uint32_t req_rp_bdf, uin
   pgt_descriptor_t pgt_desc;
 
   /* Sequence 1 : No Write Permission, Trigger a DMA Write to bar address
-   * It should Result into ACS Violation
+   * It must Result into ACS Violation
    */
 
   /* Create VA-PA Mapping in SMMU with PGT permissions as Read Only */
@@ -222,10 +222,10 @@ check_redirected_req_validation (uint32_t req_instance, uint32_t req_rp_bdf, uin
   val_pcie_clear_device_status_error(req_rp_bdf);
   val_pcie_clear_sig_target_abort(req_rp_bdf);
 
-  /* DMA Should fail because Write permission not given */
+  /* DMA must fail because Write permission not given */
   if (val_exerciser_ops(START_DMA, EDMA_FROM_DEVICE, req_instance) == 0) {
       val_print(ACS_PRINT_DEBUG,
-                "\n       Seq1:DMA Write Should not happen For : %4x", req_instance);
+                "\n       Seq1:DMA Write must not happen For : %4x", req_instance);
       goto test_fail;
   }
 
@@ -247,7 +247,7 @@ check_redirected_req_validation (uint32_t req_instance, uint32_t req_rp_bdf, uin
      val_smmu_disable(instance);
 
   /* Sequence 2 : Read Write Permission, Trigger a DMA Write to bar address
-   * It should NOT Result into ACS Violation
+   * It must NOT Result into ACS Violation
    */
 
   /* Create VA-PA Mapping in SMMU with PGT permissions as Read Write */
@@ -266,9 +266,9 @@ check_redirected_req_validation (uint32_t req_instance, uint32_t req_rp_bdf, uin
   val_pcie_clear_device_status_error(req_rp_bdf);
   val_pcie_clear_sig_target_abort(req_rp_bdf);
 
-  /* DMA Should fail not because Write permission given */
+  /* DMA must fail not because Write permission given */
   if (val_exerciser_ops(START_DMA, EDMA_FROM_DEVICE, req_instance) != 0) {
-      val_print(ACS_PRINT_DEBUG, "\n       Seq2:DMA Write Should happen For : %4x", req_instance);
+      val_print(ACS_PRINT_DEBUG, "\n       Seq2:DMA Write must happen For : %4x", req_instance);
       goto test_fail;
   }
 

--- a/test_pool/exerciser/operating_system/test_os_e004.c
+++ b/test_pool/exerciser/operating_system/test_os_e004.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021, 2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -148,7 +148,7 @@ payload (void)
     while ((--timeout > 0) && irq_pending)
         {};
 
-    /* Interrupt should not be generated */
+    /* Interrupt must not be generated */
     if (irq_pending == 0) {
         val_print(ACS_PRINT_ERR,
             "\n       Interrupt triggered from PE for bdf : 0x%x, ", e_bdf);

--- a/test_pool/exerciser/operating_system/test_os_e007.c
+++ b/test_pool/exerciser/operating_system/test_os_e007.c
@@ -18,14 +18,14 @@
  * outer shareable by the PE page tables. CPU Write to this region with
  * new data and ensure that the new data is cached in the CPU caches.
  * Read the same data locations from the Exerciser with NS=0. The
- * exerciser should get the latest data (hardware enforced cache coherency
+ * exerciser must get the latest data (hardware enforced cache coherency
  * expected).
  *
  * Second test sequence - Initialize a main memory region marked as WB,
  * outer shareable by the PE page tables. CPU reads these locations and
  * ensures that the data is cached in its caches. Exerciser Writes to
  * this region with new data and with NS=0. CPU reads the same data
- * locations. The CPU should get the latest data (hardware enforced
+ * locations. The CPU must get the latest data (hardware enforced
  * cache coherency expected).
  *
  * The above cases verify exerciser dma data check (both read and write)

--- a/test_pool/exerciser/operating_system/test_os_e008.c
+++ b/test_pool/exerciser/operating_system/test_os_e008.c
@@ -19,7 +19,7 @@
  * outer shareable by the PE page tables. CPU Write to this region with
  * new data. Perform actions to maintain  software coherency.
  * Read the same data locations from the Exerciser with NS=1. The
- * exerciser should get the latest data. The exerciser updates the
+ * exerciser must get the latest data. The exerciser updates the
  * location with newest data. PE reads the location and must get NEWEST VAL.
  */
 

--- a/test_pool/exerciser/operating_system/test_os_e009.c
+++ b/test_pool/exerciser/operating_system/test_os_e009.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020, 2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -152,7 +152,7 @@ payload(void)
 
       /*
        * Generate a config request from PE to the Subordinate bus
-       * of the exerciser. Exerciser should see this request as a
+       * of the exerciser. Exerciser must see this request as a
        * Type 1 Request.
        */
       status = val_exerciser_ops(START_TXN_MONITOR, CFG_READ, instance);

--- a/test_pool/exerciser/operating_system/test_os_e010.c
+++ b/test_pool/exerciser/operating_system/test_os_e010.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020, 2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,7 +66,7 @@ payload(void)
 
       /*
        * Generate a config request from PE to the Secondary bus
-       * of the exerciser's root port. Exerciser should see this
+       * of the exerciser's root port. Exerciser must see this
        * request as a Type 0 Request.
        */
       status = val_exerciser_ops(START_TXN_MONITOR, CFG_READ, instance);

--- a/test_pool/exerciser/operating_system/test_os_e011.c
+++ b/test_pool/exerciser/operating_system/test_os_e011.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -160,7 +160,7 @@ payload (void)
       while ((--timeout > 0) && irq_pending)
           {};
 
-      /* Interrupt should not be generated */
+      /* Interrupt must not be generated */
       if (timeout == 0) {
           val_print(ACS_PRINT_ERR,
               "\n       Interrupt trigger failed int_id : 0x%x", base_lpi_id + instance);

--- a/test_pool/exerciser/operating_system/test_os_e012.c
+++ b/test_pool/exerciser/operating_system/test_os_e012.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -154,7 +154,7 @@ payload (void)
     while ((--timeout > 0) && irq_pending)
         {};
 
-    /* Interrupt should not be generated */
+    /* Interrupt must not be generated */
     if (irq_pending == 0) {
         val_print(ACS_PRINT_ERR,
             "\n       Interrupt triggered for int_id : 0x%x, ", base_lpi_id + instance);

--- a/test_pool/exerciser/operating_system/test_os_e013.c
+++ b/test_pool/exerciser/operating_system/test_os_e013.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021, 2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -194,7 +194,7 @@ payload (void)
     while ((--timeout > 0) && irq_pending)
         {};
 
-    /* Interrupt should not be generated */
+    /* Interrupt must not be generated */
     if (irq_pending == 0) {
         val_print(ACS_PRINT_ERR,
             "\n       Interrupt triggered from diff exerciser : 0x%x, ", req_bdf);

--- a/test_pool/exerciser/operating_system/test_os_e014.c
+++ b/test_pool/exerciser/operating_system/test_os_e014.c
@@ -24,7 +24,7 @@
 
 #define TEST_NUM   (ACS_EXERCISER_TEST_NUM_BASE + 14)
 #define TEST_RULE  "PCI_PP_02"
-#define TEST_DESC  "P2P transactions should not deadlock  "
+#define TEST_DESC  "P2P transactions must not deadlock  "
 
 uint32_t
 get_target_exer_bdf(uint32_t req_rp_bdf, uint32_t *tgt_e_bdf,
@@ -101,7 +101,7 @@ uint32_t
 check_p2p_transaction(uint32_t req_instance, uint32_t req_rp_bdf,
                                                uint64_t bar_base)
 {
-  /* P2P transaction should fail */
+  /* P2P transaction must fail */
   val_exerciser_set_param(DMA_ATTRIBUTES, (uint64_t)bar_base, 1, req_instance);
   val_exerciser_ops(START_DMA, EDMA_TO_DEVICE, req_instance);
 

--- a/test_pool/exerciser/operating_system/test_os_e015.c
+++ b/test_pool/exerciser/operating_system/test_os_e015.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2021-2022, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2022, 2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -106,7 +106,7 @@ payload(void)
 
       /*
        * Generate a config request from PE to the Secondary bus
-       * of the exerciser's root port. Exerciser should see this
+       * of the exerciser's root port. Exerciser must see this
        * request as a Type 0 Request.
        */
       for (dev_num = 0; dev_num < PCIE_MAX_DEV; dev_num++)
@@ -145,7 +145,7 @@ payload(void)
 
       /*
        * Generate a config request from PE to the Secondary bus
-       * of the exerciser's root port. Exerciser should see this
+       * of the exerciser's root port. Exerciser must see this
        * request as a Type 1 Request.
        */
       for (dev_num = 0; dev_num < PCIE_MAX_DEV; dev_num++)

--- a/test_pool/gic/hypervisor/test_hyp_g001.c
+++ b/test_pool/gic/hypervisor/test_hyp_g001.c
@@ -67,7 +67,7 @@ payload()
     data = val_pe_reg_read(ID_AA64MMFR1_EL1);
 
     /* Check for EL2 virtual timer interrupt, if PE supports 8.1 or greater.
-     * ID_AA64MMFR1_EL1 VH, bits [11:8] should be 0x1 */
+     * ID_AA64MMFR1_EL1 VH, bits [11:8] must be 0x1 */
     if (!((data >> 8) & 0xF)) {
         val_print(ACS_PRINT_DEBUG, "\n       v8.1 VHE not supported on this PE ", 0);
         val_set_status(index, RESULT_SKIP(TEST_NUM, 2));

--- a/test_pool/gic/operating_system/test_os_v2m003.c
+++ b/test_pool/gic/operating_system/test_os_v2m003.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -87,7 +87,7 @@ payload()
       return;
     }
 
-    /* Part 2 : SETSPI Should Support 16 Bit Access. */
+    /* Part 2 : SETSPI must Support 16 Bit Access. */
     /* Generate the Interrupt by writing the int_id to SETSPI_NS Register */
     val_mmio_write16(frame_base + GICv2m_MSI_SETSPI, int_id);
 

--- a/test_pool/gic/operating_system/test_os_v2m004.c
+++ b/test_pool/gic/operating_system/test_os_v2m004.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -75,7 +75,7 @@ payload()
       return;
     }
 
-    /* Part 1 : Generate SPI using GICD Regsiters, It should Not generate the MSI/SPI */
+    /* Part 1 : Generate SPI using GICD Regsiters, It must Not generate the MSI/SPI */
 
     /* Follwing code calculates the GICD_ISPENDR offset for int_id.
      * Every ISPENDR register add the pending state for 32 Interrupts hence reg_offset
@@ -96,7 +96,7 @@ payload()
       return;
     }
 
-    /* Part 2 : SETSPI Should Generate the SPI. */
+    /* Part 2 : SETSPI must Generate the SPI. */
     /* Generate the Interrupt by writing the int_id to SETSPI_NS Register */
     val_mmio_write(frame_base + GICv2m_MSI_SETSPI, int_id);
 

--- a/test_pool/memory_map/operating_system/test_os_m002.c
+++ b/test_pool/memory_map/operating_system/test_os_m002.c
@@ -71,7 +71,7 @@ payload()
           goto normal_mem_test;
       }
 
-      /* Access should not cause a deadlock */
+      /* Access must not cause a deadlock */
       original_value = *((volatile addr_t*)addr);
       *((volatile addr_t*)addr) = original_value;
       while (timeout--)
@@ -97,7 +97,7 @@ normal_mem_test:
           return;
       }
 
-      /* Access should not cause a deadlock */
+      /* Access must not cause a deadlock */
       original_value = *((volatile addr_t*)addr);
       *((volatile addr_t*)addr) = original_value;
       while (timeout--)

--- a/test_pool/pcie/operating_system/test_os_p002.c
+++ b/test_pool/pcie/operating_system/test_os_p002.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021,2022 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -137,7 +137,7 @@ payload(void)
                else{
                   val_pcie_read_cfg(bdf, PCIE_ECAP_START, &data);
 
-                  /* Returned data should be FF's, otherwise the test should fail */
+                  /* Returned data must be FF's, otherwise the test must fail */
                   if (data != PCIE_UNKNOWN_RESPONSE) {
                      val_print(ACS_PRINT_ERR, "\n      Incorrect data for Bdf 0x%x    ", bdf);
                      val_set_status(index, RESULT_FAIL(TEST_NUM,
@@ -147,7 +147,7 @@ payload(void)
 
                   val_pcie_read_cfg(bdf, PCIE_ECAP_END, &data);
 
-                  /* Returned data should be FF's, otherwise the test should fail */
+                  /* Returned data must be FF's, otherwise the test must fail */
                   if (data != PCIE_UNKNOWN_RESPONSE) {
                      val_print(ACS_PRINT_ERR, "\n      Incorrect data for Bdf 0x%x    ", bdf);
                      val_set_status(index, RESULT_FAIL(TEST_NUM,

--- a/test_pool/pcie/operating_system/test_os_p004.c
+++ b/test_pool/pcie/operating_system/test_os_p004.c
@@ -181,10 +181,10 @@ payload(void)
         test_skip = 0;
 
         /* Check_1: Accessing address in range of P memory
-         * should not cause any exception or data abort
+         * must not cause any exception or data abort
          *
          * Write known value to an address which is in range
-         * Base + offset should always be in the range.
+         * Base + offset must always be in the range.
          * Read the same
          */
 
@@ -211,7 +211,7 @@ payload(void)
             continue;
         }
 
-        /**Check_2: Accessing out of NP memory limit range should return 0xFFFFFFFF
+        /**Check_2: Accessing out of NP memory limit range must return 0xFFFFFFFF
          *
          * If the limit exceeds 1MB then modify the range to be 1MB
          * and access out of the limit set

--- a/test_pool/pcie/operating_system/test_os_p005.c
+++ b/test_pool/pcie/operating_system/test_os_p005.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020, 2022 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022-2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -183,10 +183,10 @@ payload(void)
         test_skip = 0;
 
         /* Check_1: Accessing address in range of P memory
-         * should not cause any exception or data abort
+         * must not cause any exception or data abort
          *
          * Write known value to an address which is in range
-         * Base + offset should always be in the range.
+         * Base + offset must always be in the range.
          * Read the same
         */
         mem_offset = val_pcie_mem_get_offset(MEM_OFFSET_MEDIUM);
@@ -223,7 +223,7 @@ payload(void)
             continue;
         }
 
-        /**Check_2: Accessing out of P memory limit range should return 0xFFFFFFFF
+        /**Check_2: Accessing out of P memory limit range must return 0xFFFFFFFF
          *
          * If the limit exceeds 1MB then modify the range to be 1MB
          * and access out of the limit set

--- a/test_pool/pcie/operating_system/test_os_p008.c
+++ b/test_pool/pcie/operating_system/test_os_p008.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -86,7 +86,7 @@ payload(void)
       val_print(ACS_PRINT_INFO, "\n       Maximum bus value is 0x%x", bus_index);
       bus_index += 1;
 
-      /* Bus value should not exceed 255 */
+      /* Bus value must not exceed 255 */
       if (bus_index > end_bus) {
           val_print(ACS_PRINT_DEBUG, "\n       Bus index exceeded END_BUS Number", 0);
           val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 2));

--- a/test_pool/pcie/operating_system/test_os_p035.c
+++ b/test_pool/pcie/operating_system/test_os_p035.c
@@ -154,7 +154,7 @@ payload(void)
           /* If test runs for atleast an endpoint */
           test_skip = 0;
 
-          /* Vendor Id should not be 0xFF after max FLR period */
+          /* Vendor Id must not be 0xFF after max FLR period */
           val_pcie_read_cfg(bdf, 0, &reg_value);
           if ((reg_value & TYPE01_VIDR_MASK) == TYPE01_VIDR_MASK)
           {

--- a/test_pool/pe/operating_system/test_os_c013.c
+++ b/test_pool/pe/operating_system/test_os_c013.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018,2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021, 2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,7 @@ payload()
 
   data = val_pe_reg_read(ID_AA64ISAR0_EL1);
 
-  if ((data >> 16) & 0xF) //bits 19:16 are CRC32 and should not be zero
+  if ((data >> 16) & 0xF) //bits 19:16 are CRC32 and must not be zero
         val_set_status(index, RESULT_PASS(TEST_NUM, 1));
   else
         val_set_status(index, RESULT_FAIL(TEST_NUM, 1));

--- a/test_pool/peripherals/operating_system/test_os_d004.c
+++ b/test_pool/peripherals/operating_system/test_os_d004.c
@@ -66,7 +66,7 @@ payload(void)
           if (!(MEM_NORMAL_WB_IN_OUT(attr) && MEM_SH_INNER(sh)))
           {
               val_print(ACS_PRINT_INFO,
-                       "\n       DMA controler %d: IO Coherent DMA memory should"
+                       "\n       DMA controler %d: IO Coherent DMA memory must"
                        " be inner/outer writeback, inner shareable\n",
                        target_dev_index);
               val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
@@ -90,7 +90,7 @@ payload(void)
                 MEM_DEVICE(attr)))
           {
               val_print(ACS_PRINT_INFO,
-              "\n       DMA controler %d: DMA memory should be inner/outer writeback inner "
+              "\n       DMA controler %d: DMA memory must be inner/outer writeback inner "
               "shareable, inner/outer non-cacheable, or device type\n",
               target_dev_index);
               val_set_status(index, RESULT_FAIL(TEST_NUM, 2));

--- a/test_pool/smmu/operating_system/test_os_i002.c
+++ b/test_pool/smmu/operating_system/test_os_i002.c
@@ -67,7 +67,7 @@ payload()
        * then TGran4 == 0x1 or TGran4_2 == 0x3*/
       if ((VAL_EXTRACT_BITS(data_pe_mmfr0, 28, 31) == 0x1) ||
           (VAL_EXTRACT_BITS(data_pe_mmfr0, 40, 43) == 0x3)) {
-          /*PE FEAT_LPA2 is implemeted, SMMU should support 4KB granule size and 52-bit
+          /*PE FEAT_LPA2 is implemeted, SMMU must support 4KB granule size and 52-bit
            * addressing. i.e data_oas == 0x6*/
           if ((is_smmu_4k != 1) && (data_oas != 0x6)) {
               val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
@@ -82,7 +82,7 @@ payload()
        * then TGran16 == 0x2 or TGran16_2 == 0x3 */
       if ((VAL_EXTRACT_BITS(data_pe_mmfr0, 20, 23) == 0x2) ||
           (VAL_EXTRACT_BITS(data_pe_mmfr0, 32, 35) == 0x3)) {
-          /*PE FEAT_LPA2 is implemeted, SMMU should support 16KB granule size and 52-bit
+          /*PE FEAT_LPA2 is implemeted, SMMU must support 16KB granule size and 52-bit
            * addressing. i.e data_oas == 0x6*/
           if ((is_smmu_16k != 1) && (data_oas != 0x6)) {
               val_set_status(index, RESULT_FAIL(TEST_NUM, 2));

--- a/test_pool/timer/operating_system/test_os_t003.c
+++ b/test_pool/timer/operating_system/test_os_t003.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018,2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021, 2023 Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -86,12 +86,12 @@ payload()
       data1 = val_mmio_read64(cnt_base_n + CNTPCT_LOWER);
       val_print(ACS_PRINT_DEBUG, "\n       CNTPCT Read value = 0x%llx       ", data1);
 
-      // Writes to Read-Only registers should be ignore
+      // Writes to Read-Only registers must be ignored
       val_mmio_write64(cnt_base_n + CNTPCT_LOWER, (data1 - ARBIT_VALUE));
 
       if (val_mmio_read64(cnt_base_n + CNTPCT_LOWER) < data1) {
           val_set_status(index, RESULT_FAIL(TEST_NUM, 2));
-          val_print(ACS_PRINT_DEBUG, "\n       CNTBaseN: CNTPCT reg should be read-only ", 0);
+          val_print(ACS_PRINT_DEBUG, "\n       CNTBaseN: CNTPCT reg must be read-only ", 0);
           return;
       }
 
@@ -99,12 +99,12 @@ payload()
       data1 = val_mmio_read64(cnt_base_n + CNTVCT_LOWER);
       val_print(ACS_PRINT_DEBUG, "\n       CNTVCT Read value = 0x%llx       ", data1);
 
-      // Writes to Read-Only registers should be ignore
+      // Writes to Read-Only registers must be ignored
       val_mmio_write64(cnt_base_n + CNTVCT_LOWER, (data1 - ARBIT_VALUE));
 
       if (val_mmio_read64(cnt_base_n + CNTVCT_LOWER) < data1) {
           val_set_status(index, RESULT_FAIL(TEST_NUM, 3));
-          val_print(ACS_PRINT_DEBUG, "\n       CNTBaseN: CNTVCT reg should be read-only ", 0);
+          val_print(ACS_PRINT_DEBUG, "\n       CNTBaseN: CNTVCT reg must be read-only ", 0);
           return;
       }
 
@@ -113,12 +113,12 @@ payload()
       val_print(ACS_PRINT_DEBUG, "\n       CNTFRQ Read value = 0x%x         ",
                                                                         data);
 
-      // Writes to Read-Only registers should be ignore
+      // Writes to Read-Only registers must be ignored
       val_mmio_write(cnt_base_n + CNTBaseN_CNTFRQ, (data - ARBIT_VALUE));
 
       if (val_mmio_read(cnt_base_n + CNTBaseN_CNTFRQ) != data) {
           val_set_status(index, RESULT_FAIL(TEST_NUM, 4));
-          val_print(ACS_PRINT_DEBUG, "\n       CNTBaseN: CNTFRQ reg should be read-only ", 0);
+          val_print(ACS_PRINT_DEBUG, "\n       CNTBaseN: CNTFRQ reg must be read-only ", 0);
           return;
       }
 


### PR DESCRIPTION
- "must" carries a stronger sense of obligation or necessity than "should" hence using it for prints conveying non-compilance to mandatory rules.