### PR TITLE
During error Linux driver doesn't exit

### DIFF
--- a/linux_app/bsa-acs-app/bsa_drv_intf.c
+++ b/linux_app/bsa-acs-app/bsa_drv_intf.c
@@ -83,6 +83,7 @@ call_drv_init_test_env(unsigned int print_level)
 {
     FILE             *fd = NULL;
     bsa_drv_parms_t test_params;
+    int status = 0;
 
     fd = fopen("/proc/bsa", "rw+");
     if (NULL == fd)
@@ -99,9 +100,9 @@ call_drv_init_test_env(unsigned int print_level)
 
     fclose(fd);
 
-    call_drv_wait_for_completion();
+    status = call_drv_wait_for_completion();
 
-    return 0;
+    return status;
 }
 
 int


### PR DESCRIPTION
 - Added condition to check error for call_drv_wait_for_completion function return value