### PR TITLE
Test 205 system timer timeout moved to sys counter base

### DIFF
--- a/test_pool/gic/hypervisor/test_hyp_g001.c
+++ b/test_pool/gic/hypervisor/test_hyp_g001.c
@@ -37,7 +37,7 @@ isr_vir()
     uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
     /* We received our interrupt, so disable timer from generating further interrupts */
     val_timer_set_vir_el2(0);
-    val_print(ACS_PRINT_INFO, "\n       Received interrupt    ", 0);
+    val_print(ACS_PRINT_INFO, "\n       Received vir el2 interrupt    ", 0);
     val_set_status(index, RESULT_PASS(TEST_NUM, 1));
     val_gic_end_of_interrupt(intid);
 }

--- a/test_pool/gic/hypervisor/test_hyp_g002.c
+++ b/test_pool/gic/hypervisor/test_hyp_g002.c
@@ -37,7 +37,7 @@ isr_phy()
     uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
     /* We received our interrupt, so disable timer from generating further interrupts */
     val_timer_set_phy_el2(0);
-    val_print(ACS_PRINT_INFO, "\n       Received interrupt     ", 0);
+    val_print(ACS_PRINT_INFO, "\n       Received phy el2 interrupt     ", 0);
     val_set_status(index, RESULT_PASS(TEST_NUM, 1));
     val_gic_end_of_interrupt(intid);
 }

--- a/test_pool/gic/operating_system/test_os_g006.c
+++ b/test_pool/gic/operating_system/test_os_g006.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2021, 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test_pool/gic/operating_system/test_os_g006.c
+++ b/test_pool/gic/operating_system/test_os_g006.c
@@ -32,7 +32,7 @@ void
 isr_phy()
 {
   val_timer_set_phy_el1(0);
-  val_print(ACS_PRINT_INFO, "\n       Received interrupt   ", 0);
+  val_print(ACS_PRINT_INFO, "\n       Received phy el1 interrupt   ", 0);
   val_set_status(0, RESULT_PASS(TEST_NUM, 1));
   val_gic_end_of_interrupt(intid);
 }
@@ -42,7 +42,7 @@ void
 isr_vir()
 {
   val_timer_set_vir_el1(0);
-  val_print(ACS_PRINT_INFO, "\n       Received interrupt   ", 0);
+  val_print(ACS_PRINT_INFO, "\n       Received vir el1 interrupt   ", 0);
   val_set_status(0, RESULT_PASS(TEST_NUM, 1));
   val_gic_end_of_interrupt(intid);
 }

--- a/test_pool/pcie/operating_system/test_os_p009.c
+++ b/test_pool/pcie/operating_system/test_os_p009.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2022, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test_pool/timer/operating_system/test_os_t004.c
+++ b/test_pool/timer/operating_system/test_os_t004.c
@@ -34,7 +34,7 @@ isr()
 {
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
-  val_print(ACS_PRINT_INFO, "\n       Received interrupt   ", 0);
+  val_print(ACS_PRINT_INFO, "\n       Received sys timer interrupt   ", 0);
   val_timer_disable_system_timer((addr_t)cnt_base_n);
   val_set_status(index, RESULT_PASS(TEST_NUM, 1));
   val_gic_end_of_interrupt(intid);

--- a/test_pool/timer/operating_system/test_os_t004.c
+++ b/test_pool/timer/operating_system/test_os_t004.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018,2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018,2021, 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test_pool/timer/operating_system/test_os_t005.c
+++ b/test_pool/timer/operating_system/test_os_t005.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION

Fix for #133
 
  * Moved system timer and failsafe timer timeout to system counter base
  * debug changes to print which timer interrupt is received
  * backmerge of pcie bug fix
  * added el0 phy timer (failsafe) handler in test