### PR TITLE
Split GIC test 206 into multiple tests handling own interrupt func

### DIFF
--- a/baremetal_app/BsaAcs.inf
+++ b/baremetal_app/BsaAcs.inf
@@ -60,6 +60,7 @@
   ../test_pool/gic/operating_system/test_os_g004.c
   ../test_pool/gic/operating_system/test_os_g005.c
   ../test_pool/gic/operating_system/test_os_g006.c
+  ../test_pool/gic/operating_system/test_os_g007.c
   ../test_pool/gic/operating_system/test_os_v2m001.c
   ../test_pool/gic/operating_system/test_os_v2m002.c
   ../test_pool/gic/operating_system/test_os_v2m003.c

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -59,6 +59,7 @@
   ../test_pool/gic/operating_system/test_os_g004.c
   ../test_pool/gic/operating_system/test_os_g005.c
   ../test_pool/gic/operating_system/test_os_g006.c
+  ../test_pool/gic/operating_system/test_os_g007.c
   ../test_pool/gic/operating_system/test_os_v2m001.c
   ../test_pool/gic/operating_system/test_os_v2m002.c
   ../test_pool/gic/operating_system/test_os_v2m003.c

--- a/val/include/bsa_acs_gic.h
+++ b/val/include/bsa_acs_gic.h
@@ -1,33 +1,19 @@
 /** @file
- * Copyright (c) 2016-2018,2021, 2023 Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2018, 2021, 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
- * Redistributions of source code must retain the above copyright notice, this
- * list of conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * Neither the name of ARM nor the names of its contributors may be used
- * to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
 
 #ifndef __BSA_ACS_GIC_H__
 #define __BSA_ACS_GIC_H__
@@ -93,6 +79,8 @@ uint32_t
 os_g005_entry(uint32_t num_pe);
 uint32_t
 os_g006_entry(uint32_t num_pe);
+uint32_t
+os_g007_entry(uint32_t num_pe);
 uint32_t
 hyp_g001_entry(uint32_t num_pe);
 uint32_t

--- a/val/src/acs_gic.c
+++ b/val/src/acs_gic.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -77,6 +77,7 @@ val_gic_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 
       status |= os_g005_entry(num_pe);
       status |= os_g006_entry(num_pe);
+      status |= os_g007_entry(num_pe);
   }
 
   if (g_sw_view[G_SW_HYP]) {


### PR DESCRIPTION

 - divided 206 GIC PPI test into two tests inorder to isolate the checks and interrupt handling.