### PR TITLE
 Allow ACS to support fixed offset translation scheme

### DIFF
--- a/platform/pal_baremetal/src/pal_pcie.c
+++ b/platform/pal_baremetal/src/pal_pcie.c
@@ -670,3 +670,36 @@ pal_pcie_mem_get_offset(uint32_t type)
   }
 
 }
+
+/**
+    @brief   Reads 32-bit data from BAR space pointed by Bus,
+             Device, Function and register offset.
+
+    @param   Bdf     - BDF value for the device
+    @param   address - BAR memory address
+    @param   *data   - 32 bit value at BAR address
+    @return  success/failure
+**/
+uint32_t
+pal_pcie_bar_mem_read(uint32_t Bdf, uint64_t address, uint32_t *data)
+{
+  *data = pal_mmio_read(address);
+   return 0;
+}
+
+/**
+    @brief   Write 32-bit data to BAR space pointed by Bus,
+             Device, Function and register offset.
+
+    @param   Bdf     - BDF value for the device
+    @param   address - BAR memory address
+    @param   data    - 32 bit value to writw BAR address
+    @return  success/failure
+**/
+
+uint32_t
+pal_pcie_bar_mem_write(uint32_t Bdf, uint64_t address, uint32_t data)
+{
+   pal_mmio_write(address, data);
+   return 0;
+}

--- a/platform/pal_uefi_acpi/BsaPalLib.inf
+++ b/platform/pal_uefi_acpi/BsaPalLib.inf
@@ -65,6 +65,7 @@
   gEfiCpuArchProtocolGuid                       ## CONSUMES
   gEfiPciIoProtocolGuid                         ## CONSUMES
   gHardwareInterrupt2ProtocolGuid               ## CONSUMES
+  gEfiPciRootBridgeIoProtocolGuid               ## CONSUMES
 
 [Guids]
   gEfiAcpi20TableGuid

--- a/platform/pal_uefi_acpi/src/pal_pcie.c
+++ b/platform/pal_uefi_acpi/src/pal_pcie.c
@@ -28,6 +28,7 @@
 #include "Include/IndustryStandard/Pci.h"
 #include "Include/IndustryStandard/Pci22.h"
 #include <Protocol/PciIo.h>
+#include <Protocol/PciRootBridgeIo.h>
 
 #include "../include/platform_override.h"
 #include "include/pal_uefi.h"
@@ -214,6 +215,95 @@ pal_pcie_io_write_cfg(UINT32 Bdf, UINT32 offset, UINT32 data)
       }
     }
   }
+}
+
+/**
+    @brief   Reads 32-bit data from BAR space pointed by Bus,
+             Device, Function and register offset, using UEFI PciRootBridgeIoProtocol
+
+    @param   Bdf     - BDF value for the device
+    @param   address - BAR memory address
+    @param   *data   - 32 bit value at BAR address
+    @return  success/failure
+**/
+UINT32
+pal_pcie_bar_mem_read(UINT32 Bdf, UINT64 address, UINT32 *data)
+{
+
+  EFI_STATUS                       Status;
+  EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL  *Pci;
+  UINTN                            HandleCount;
+  EFI_HANDLE                       *HandleBuffer;
+  UINT32                           Index;
+  UINT32                           InputSeg;
+
+
+  Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciRootBridgeIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
+  if (EFI_ERROR (Status)) {
+    bsa_print(ACS_PRINT_INFO,L" No Root Bridge found in the system\n");
+    return PCIE_NO_MAPPING;
+  }
+
+  InputSeg = PCIE_EXTRACT_BDF_SEG(Bdf);
+
+  for (Index = 0; Index < HandleCount; Index++) {
+    Status = gBS->HandleProtocol (HandleBuffer[Index], &gEfiPciRootBridgeIoProtocolGuid, (VOID **)&Pci);
+    if (!EFI_ERROR (Status)) {
+      if (Pci->SegmentNumber == InputSeg) {
+          Status = Pci->Mem.Read (Pci, EfiPciIoWidthUint32, address, 1, data);
+          if (!EFI_ERROR (Status))
+            return 0;
+          else
+            return PCIE_NO_MAPPING;
+      }
+    }
+  }
+  return PCIE_NO_MAPPING;
+}
+
+/**
+    @brief   Write 32-bit data to BAR space pointed by Bus,
+             Device, Function and register offset, using UEFI PciRootBridgeIoProtocol
+
+    @param   Bdf     - BDF value for the device
+    @param   address - BAR memory address
+    @param   data    - 32 bit value to writw BAR address
+    @return  success/failure
+**/
+
+UINT32
+pal_pcie_bar_mem_write(UINT32 Bdf, UINT64 address, UINT32 data)
+{
+
+  EFI_STATUS                       Status;
+  EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL  *Pci;
+  UINTN                            HandleCount;
+  EFI_HANDLE                       *HandleBuffer;
+  UINT32                           Index;
+  UINT32                           InputSeg;
+
+
+  Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciRootBridgeIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
+  if (EFI_ERROR (Status)) {
+    bsa_print(ACS_PRINT_INFO,L" No Root Bridge found in the system\n");
+    return PCIE_NO_MAPPING;
+  }
+
+  InputSeg = PCIE_EXTRACT_BDF_SEG(Bdf);
+
+  for (Index = 0; Index < HandleCount; Index++) {
+    Status = gBS->HandleProtocol (HandleBuffer[Index], &gEfiPciRootBridgeIoProtocolGuid, (VOID **)&Pci);
+    if (!EFI_ERROR (Status)) {
+      if (Pci->SegmentNumber == InputSeg) {
+          Status = Pci->Mem.Write (Pci, EfiPciIoWidthUint32, address, 1, &data);
+          if (!EFI_ERROR (Status))
+            return 0;
+          else
+            return PCIE_NO_MAPPING;
+      }
+    }
+  }
+  return PCIE_NO_MAPPING;
 }
 
 /**

--- a/platform/pal_uefi_dt/BsaPalLib.inf
+++ b/platform/pal_uefi_dt/BsaPalLib.inf
@@ -67,6 +67,7 @@
   gEfiCpuArchProtocolGuid                       ## CONSUMES
   gEfiPciIoProtocolGuid                         ## CONSUMES
   gHardwareInterrupt2ProtocolGuid               ## CONSUMES
+  gEfiPciRootBridgeIoProtocolGuid               ## CONSUMES
 
 [Guids]
   gEfiAcpi20TableGuid

--- a/platform/pal_uefi_dt/src/pal_pcie.c
+++ b/platform/pal_uefi_dt/src/pal_pcie.c
@@ -28,6 +28,7 @@
 #include "Include/IndustryStandard/Pci.h"
 #include "Include/IndustryStandard/Pci22.h"
 #include <Protocol/PciIo.h>
+#include <Protocol/PciRootBridgeIo.h>
 
 #include <Include/libfdt.h>
 #include "../include/platform_override.h"
@@ -209,6 +210,95 @@ pal_pcie_io_write_cfg(UINT32 Bdf, UINT32 offset, UINT32 data)
       }
     }
   }
+}
+
+/**
+    @brief   Reads 32-bit data from BAR space pointed by Bus,
+             Device, Function and register offset, using UEFI PciRootBridgeIoProtocol
+
+    @param   Bdf     - BDF value for the device
+    @param   address - BAR memory address
+    @param   *data   - 32 bit value at BAR address
+    @return  success/failure
+**/
+UINT32
+pal_pcie_bar_mem_read(UINT32 Bdf, UINT64 address, UINT32 *data)
+{
+
+  EFI_STATUS                       Status;
+  EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL  *Pci;
+  UINTN                            HandleCount;
+  EFI_HANDLE                       *HandleBuffer;
+  UINT32                           Index;
+  UINT32                           InputSeg;
+
+
+  Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciRootBridgeIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
+  if (EFI_ERROR (Status)) {
+    bsa_print(ACS_PRINT_INFO,L" No Root Bridge found in the system\n");
+    return PCIE_NO_MAPPING;
+  }
+
+  InputSeg = PCIE_EXTRACT_BDF_SEG(Bdf);
+
+  for (Index = 0; Index < HandleCount; Index++) {
+    Status = gBS->HandleProtocol (HandleBuffer[Index], &gEfiPciRootBridgeIoProtocolGuid, (VOID **)&Pci);
+    if (!EFI_ERROR (Status)) {
+      if (Pci->SegmentNumber == InputSeg) {
+          Status = Pci->Mem.Read (Pci, EfiPciIoWidthUint32, address, 1, data);
+          if (!EFI_ERROR (Status))
+            return 0;
+          else
+            return PCIE_NO_MAPPING;
+      }
+    }
+  }
+  return PCIE_NO_MAPPING;
+}
+
+/**
+    @brief   Write 32-bit data to BAR space pointed by Bus,
+             Device, Function and register offset, using UEFI PciRootBridgeIoProtocol
+
+    @param   Bdf     - BDF value for the device
+    @param   address - BAR memory address
+    @param   data    - 32 bit value to writw BAR address
+    @return  success/failure
+**/
+
+UINT32
+pal_pcie_bar_mem_write(UINT32 Bdf, UINT64 address, UINT32 data)
+{
+
+  EFI_STATUS                       Status;
+  EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL  *Pci;
+  UINTN                            HandleCount;
+  EFI_HANDLE                       *HandleBuffer;
+  UINT32                           Index;
+  UINT32                           InputSeg;
+
+
+  Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciRootBridgeIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
+  if (EFI_ERROR (Status)) {
+    bsa_print(ACS_PRINT_INFO,L" No Root Bridge found in the system\n");
+    return PCIE_NO_MAPPING;
+  }
+
+  InputSeg = PCIE_EXTRACT_BDF_SEG(Bdf);
+
+  for (Index = 0; Index < HandleCount; Index++) {
+    Status = gBS->HandleProtocol (HandleBuffer[Index], &gEfiPciRootBridgeIoProtocolGuid, (VOID **)&Pci);
+    if (!EFI_ERROR (Status)) {
+      if (Pci->SegmentNumber == InputSeg) {
+          Status = Pci->Mem.Write (Pci, EfiPciIoWidthUint32, address, 1, &data);
+          if (!EFI_ERROR (Status))
+            return 0;
+          else
+            return PCIE_NO_MAPPING;
+      }
+    }
+  }
+  return PCIE_NO_MAPPING;
 }
 
 /**

--- a/test_pool/pcie/operating_system/test_os_p004.c
+++ b/test_pool/pcie/operating_system/test_os_p004.c
@@ -180,7 +180,7 @@ payload(void)
         /* If test runs for atleast an endpoint */
         test_skip = 0;
 
-        /* Check_1: Accessing address in range of P memory
+        /* Check_1: Accessing address in range of NP memory
          * must not cause any exception or data abort
          *
          * Write known value to an address which is in range
@@ -188,9 +188,10 @@ payload(void)
          * Read the same
          */
 
-        old_value = (*(volatile uint32_t *)(mem_base + mem_offset));
-        *(volatile uint32_t *)(mem_base + mem_offset) = KNOWN_DATA;
-        read_value = (*(volatile uint32_t *)(mem_base + mem_offset));
+        val_pcie_bar_mem_read(bdf, mem_base + mem_offset, &old_value);
+        val_pcie_bar_mem_write(bdf, mem_base + mem_offset, KNOWN_DATA);
+        val_pcie_bar_mem_read(bdf, mem_base + mem_offset, &read_value);
+
 
         if ((old_value != read_value && read_value == PCIE_UNKNOWN_RESPONSE) ||
              val_pcie_is_urd(bdf)) {
@@ -226,7 +227,7 @@ payload(void)
            val_pcie_write_cfg(bdf, TYPE1_NP_MEM, mem_base);
            val_pcie_read_cfg(bdf, TYPE1_NP_MEM, &read_value);
 
-           value = (*(volatile uint32_t *)(new_mem_lim + MEM_OFFSET_SMALL));
+           val_pcie_bar_mem_read(bdf, new_mem_lim + MEM_OFFSET_SMALL, &value);
            val_print(ACS_PRINT_DEBUG, "  Value read is 0x%llx", value);
            if (value != PCIE_UNKNOWN_RESPONSE)
            {

--- a/test_pool/pcie/operating_system/test_os_p005.c
+++ b/test_pool/pcie/operating_system/test_os_p005.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020, 2022-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -200,9 +200,9 @@ payload(void)
             return;
         }
 
-        old_value = (*(volatile addr_t *)(mem_base + mem_offset));
-        *(volatile addr_t *)(mem_base + mem_offset) = KNOWN_DATA;
-        read_value = (*(volatile addr_t *)(mem_base + mem_offset));
+        val_pcie_bar_mem_read(bdf, mem_base + mem_offset, &old_value);
+        val_pcie_bar_mem_write(bdf, mem_base + mem_offset, KNOWN_DATA);
+        val_pcie_bar_mem_read(bdf, mem_base + mem_offset, &read_value);
 
         if ((old_value != read_value && read_value == PCIE_UNKNOWN_RESPONSE) ||
              val_pcie_is_urd(bdf)) {
@@ -258,7 +258,7 @@ payload(void)
            updated_mem_base |= (mem_base_upper << P_MEM_BU_SHIFT);
            updated_mem_lim |= (mem_lim_upper << P_MEM_LU_SHIFT);
 
-           value = (*(volatile uint32_t *)(new_mem_lim + MEM_OFFSET_SMALL));
+           val_pcie_bar_mem_read(bdf, new_mem_lim + MEM_OFFSET_SMALL, &value);
            val_print(ACS_PRINT_DEBUG, "       Value read is 0x%llx", value);
            if (value != PCIE_UNKNOWN_RESPONSE)
            {

--- a/val/include/bsa_acs_pcie.h
+++ b/val/include/bsa_acs_pcie.h
@@ -157,6 +157,8 @@ uint32_t val_pcie_read_cfg(uint32_t bdf, uint32_t offset, uint32_t *data);
 uint32_t val_get_msi_vectors (uint32_t bdf, PERIPHERAL_VECTOR_LIST **mvector);
 uint64_t val_pcie_get_bdf_config_addr(uint32_t bdf);
 
+uint32_t val_pcie_bar_mem_read(uint32_t bdf, uint64_t address, uint32_t *data);
+uint32_t val_pcie_bar_mem_write(uint32_t bdf, uint64_t address, uint32_t data);
 
 typedef enum {
   PCIE_INFO_NUM_ECAM = 1,

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -393,6 +393,8 @@ uint32_t pal_pcie_check_device_list(void);
 uint32_t pal_pcie_check_device_valid(uint32_t bdf);
 uint32_t pal_pcie_mem_get_offset(uint32_t type);
 
+uint32_t pal_pcie_bar_mem_read(uint32_t bdf, uint64_t address, uint32_t *data);
+uint32_t pal_pcie_bar_mem_write(uint32_t bdf, uint64_t address, uint32_t data);
 /**
   @brief  Instance of SMMU INFO block
 **/

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -181,6 +181,36 @@ val_pcie_io_write_cfg(uint32_t bdf, uint32_t offset, uint32_t data)
 }
 
 /**
+    @brief   Write 32-bit data to BAR space pointed by Bus,
+             Device, Function and register offset using UEFI PciIoProtocol interface.
+
+    @param   Bdf     - BDF value for the device
+    @param   address - BAR memory address
+    @param   data    - 32 bit value to writw BAR address
+    @return  success/failure
+**/
+uint32_t
+val_pcie_bar_mem_write(uint32_t bdf, uint64_t offset, uint32_t data)
+{
+    return pal_pcie_bar_mem_write(bdf, offset, data);
+}
+
+/**
+    @brief   Reads 32-bit data from BAR space pointed by Bus,
+             Device, Function and register offset using UEFI PciIoProtocol interface.
+
+    @param   Bdf     - BDF value for the device
+    @param   address - BAR memory address
+    @param   *data   - 32 bit value at BAR address
+    @return  success/failure
+**/
+uint32_t
+val_pcie_bar_mem_read(uint32_t bdf, uint64_t offset, uint32_t *data)
+{
+    return pal_pcie_bar_mem_read(bdf, offset, data);
+}
+
+/**
   @brief   This API  returns function config space addr.
            1. Caller       -  Test Suite
            2. Prerequisite -  val_pcie_create_info_table


### PR DESCRIPTION
- A fixed offset translation scheme is implemented to establish a connection between the physical address space of the PE and the PCI memory. This scheme enables the mirroring of a PE physical address space window above 4GB into the PCI memory space below 4GB. To achieve this, the PHB must support the translation method (_TRA) to convert the address from the PE's perspective, particularly when the MMIO32 BAR exceeds 4GB. In UEFI, the EFI_PCI_IO_PROTOCOL handles this translation, which is utilized by the modified ACS to incorporate the PCIIO protocol and leverage UEFI's offset translation mechanism.

- Fixes https://github.com/ARM-software/bsa-acs/issues/26