### PR TITLE
Added cache-invalidate operation

### DIFF
--- a/val/src/acs_pe_infra.c
+++ b/val/src/acs_pe_infra.c
@@ -174,6 +174,9 @@ val_pe_get_index_mpid(uint64_t mpid)
   entry = g_pe_info_table->pe_info;
 
   while (i > 0) {
+    val_data_cache_ops_by_va((addr_t)&entry->mpidr, INVALIDATE);
+    val_data_cache_ops_by_va((addr_t)&entry->pe_num, INVALIDATE);
+
     if (entry->mpidr == mpid) {
       return entry->pe_num;
     }


### PR DESCRIPTION
Issue ARM-software/sbsa-acs#348 : Added cache-invalidate operation
 - Secondary cores directly read g_pe_info_table->pe_info ->mpidr/pe_num without cache-invalidate operation in val_pe_get_index_mpid().