### PR TITLE
Moved ITS Configure to avs_exerciser.c

### DIFF
--- a/baremetal_app/BsaAcsMain.c
+++ b/baremetal_app/BsaAcsMain.c
@@ -77,17 +77,6 @@ createGicInfoTable(
 
 }
 
-uint32_t
-configureGicIts(
-)
-{
-  uint32_t Status;
-
-  Status = val_gic_its_configure();
-
-  return Status;
-}
-
 void
 createTimerInfoTable(
 )
@@ -236,12 +225,6 @@ ShellAppMainbsa(
 
   val_print(ACS_PRINT_TEST, "\n      ***  Starting Memory Map tests ***  ", 0);
   val_memory_execute_tests(val_pe_get_num(), g_sw_view);
-
-  /*
-   * Configure Gic Redistributor and ITS to support
-   * Generation of LPIs.
-  */
-  configureGicIts();
 
   val_print(ACS_PRINT_TEST, "\n      ***  Starting GIC tests ***  ", 0);
   Status |= val_gic_execute_tests(val_pe_get_num(), g_sw_view);

--- a/uefi_app/BsaAcsMain.c
+++ b/uefi_app/BsaAcsMain.c
@@ -117,17 +117,6 @@ createGicInfoTable (
 }
 
 EFI_STATUS
-configureGicIts (
-)
-{
-  EFI_STATUS Status;
-
-  Status = val_gic_its_configure();
-
-  return Status;
-}
-
-EFI_STATUS
 createTimerInfoTable(
 )
 {
@@ -537,12 +526,6 @@ ShellAppMain (
 
   val_print(ACS_PRINT_TEST, "\n      ***  Starting Memory Map tests ***  ", 0);
   val_memory_execute_tests(val_pe_get_num(), g_sw_view);
-
-  /*
-   * Configure Gic Redistributor and ITS to support
-   * Generation of LPIs.
-  */
-  configureGicIts();
 
   val_print(ACS_PRINT_TEST, "\n      ***  Starting GIC tests ***  ", 0);
   Status |= val_gic_execute_tests(val_pe_get_num(), g_sw_view);

--- a/val/src/acs_exerciser.c
+++ b/val/src/acs_exerciser.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -477,6 +477,9 @@ val_exerciser_execute_tests(uint32_t *g_sw_view)
   /* Disable All SMMU's */
   for (instance = 0; instance < num_smmu; ++instance)
       val_smmu_disable(instance);
+
+  val_print(ACS_PRINT_INFO, "  Initializing ITS\n", 0);
+  val_gic_its_configure();
 
   g_curr_module = 1 << EXERCISER_MODULE;
 


### PR DESCRIPTION
 Rearranged ITS Setup Call
 - Calling val_gic_its_configure function from val_exerciser_execute_tests as this is being used only for exerciser tests. This reduces the overhead of allocating/setting up ITS.