### PR TITLE
Added API to print module header

### DIFF
--- a/baremetal_app/BsaAcsMain.c
+++ b/baremetal_app/BsaAcsMain.c
@@ -220,34 +220,34 @@ ShellAppMainbsa(
   val_pe_context_save(AA64ReadSp(), (uint64_t)branch_label);
   val_pe_initialize_default_exception_handler(val_pe_default_esr);
 
-  val_print(ACS_PRINT_TEST, "\n      ***  Starting PE tests ***  ", 0);
+  /***  Starting PE tests             ***/
   Status = val_pe_execute_tests(val_pe_get_num(), g_sw_view);
 
-  val_print(ACS_PRINT_TEST, "\n      ***  Starting Memory Map tests ***  ", 0);
-  val_memory_execute_tests(val_pe_get_num(), g_sw_view);
+  /***  Starting Memory Map tests     ***/
+  Status |= val_memory_execute_tests(val_pe_get_num(), g_sw_view);
 
-  val_print(ACS_PRINT_TEST, "\n      ***  Starting GIC tests ***  ", 0);
+  /***  Starting GIC tests            ***/
   Status |= val_gic_execute_tests(val_pe_get_num(), g_sw_view);
 
-  val_print(ACS_PRINT_TEST, "\n      *** Starting System MMU tests ***  ", 0);
+  /***  Starting System MMU tests     ***/
   Status |= val_smmu_execute_tests(val_pe_get_num(), g_sw_view);
 
-  val_print(ACS_PRINT_TEST, "\n      *** Starting Timer tests ***  ", 0);
+  /***  Starting Timer tests          ***/
   Status |= val_timer_execute_tests(val_pe_get_num(), g_sw_view);
 
-  val_print(ACS_PRINT_TEST, "\n      *** Starting Wakeup semantic tests ***  ", 0);
+  /***  Starting Wakeup semantic tests ***/
   Status |= val_wakeup_execute_tests(val_pe_get_num(), g_sw_view);
 
-  val_print(ACS_PRINT_TEST, "\n      *** Starting Peripheral tests ***  ", 0);
+  /***  Starting Peripheral tests     ***/
   Status |= val_peripheral_execute_tests(val_pe_get_num(), g_sw_view);
 
-  val_print(ACS_PRINT_TEST, "\n      *** Starting Watchdog tests ***  ", 0);
+  /***  Starting Watchdog tests       ***/
   Status |= val_wd_execute_tests(val_pe_get_num(), g_sw_view);
 
-  val_print(ACS_PRINT_TEST, "\n      *** Starting PCIe tests ***  ", 0);
+  /***  Starting PCIe tests           ***/
   Status |= val_pcie_execute_tests(val_pe_get_num(), g_sw_view);
 
-  val_print(ACS_PRINT_TEST, "\n      *** Starting PCIe Exerciser tests ***  ", 0);
+  /***  Starting PCIe Exerciser tests ***/
   Status |= val_exerciser_execute_tests(g_sw_view);
 
 print_test_status:

--- a/uefi_app/BsaAcsMain.c
+++ b/uefi_app/BsaAcsMain.c
@@ -521,34 +521,34 @@ ShellAppMain (
 
   FlushImage();
 
-  val_print(ACS_PRINT_TEST, "\n      ***  Starting PE tests ***  ", 0);
+  /***  Starting PE tests             ***/
   Status = val_pe_execute_tests(val_pe_get_num(), g_sw_view);
 
-  val_print(ACS_PRINT_TEST, "\n      ***  Starting Memory Map tests ***  ", 0);
-  val_memory_execute_tests(val_pe_get_num(), g_sw_view);
+  /***  Starting Memory Map tests     ***/
+  Status |= val_memory_execute_tests(val_pe_get_num(), g_sw_view);
 
-  val_print(ACS_PRINT_TEST, "\n      ***  Starting GIC tests ***  ", 0);
+  /***  Starting GIC tests            ***/
   Status |= val_gic_execute_tests(val_pe_get_num(), g_sw_view);
 
-  val_print(ACS_PRINT_TEST, "\n      *** Starting System MMU tests ***  ", 0);
+  /***  Starting System MMU tests     ***/
   Status |= val_smmu_execute_tests(val_pe_get_num(), g_sw_view);
 
-  val_print(ACS_PRINT_TEST, "\n      *** Starting Timer tests ***  ", 0);
+  /***  Starting Timer tests          ***/
   Status |= val_timer_execute_tests(val_pe_get_num(), g_sw_view);
 
-  val_print(ACS_PRINT_TEST, "\n      *** Starting Wakeup semantic tests ***  ", 0);
+  /***  Starting Wakeup semantic tests ***/
   Status |= val_wakeup_execute_tests(val_pe_get_num(), g_sw_view);
 
-  val_print(ACS_PRINT_TEST, "\n      *** Starting Peripheral tests ***  ", 0);
+  /***  Starting Peripheral tests     ***/
   Status |= val_peripheral_execute_tests(val_pe_get_num(), g_sw_view);
 
-  val_print(ACS_PRINT_TEST, "\n      *** Starting Watchdog tests ***  ", 0);
+  /***  Starting Watchdog tests       ***/
   Status |= val_wd_execute_tests(val_pe_get_num(), g_sw_view);
 
-  val_print(ACS_PRINT_TEST, "\n      *** Starting PCIe tests ***  ", 0);
+  /***  Starting PCIe tests           ***/
   Status |= val_pcie_execute_tests(val_pe_get_num(), g_sw_view);
 
-  val_print(ACS_PRINT_TEST, "\n      *** Starting PCIe Exerciser tests ***  ", 0);
+  /***  Starting PCIe Exerciser tests ***/
   Status |= val_exerciser_execute_tests(g_sw_view);
 
 print_test_status:

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -59,6 +59,7 @@ void val_free_shared_mem(void);
 void val_print(uint32_t level, char8_t *string, uint64_t data);
 void val_print_raw(uint64_t uart_addr, uint32_t level, char8_t *string,
                                                                 uint64_t data);
+void val_print_test_start(char8_t *string);
 void val_print_test_end(uint32_t status, char8_t *string);
 void val_set_test_data(uint32_t index, uint64_t addr, uint64_t test_data);
 void val_get_test_data(uint32_t index, uint64_t *data0, uint64_t *data1);

--- a/val/src/acs_exerciser.c
+++ b/val/src/acs_exerciser.c
@@ -481,6 +481,7 @@ val_exerciser_execute_tests(uint32_t *g_sw_view)
   val_print(ACS_PRINT_INFO, "  Initializing ITS\n", 0);
   val_gic_its_configure();
 
+  val_print_test_start("Exerciser");
   g_curr_module = 1 << EXERCISER_MODULE;
 
   if (g_sw_view[G_SW_OS]) {

--- a/val/src/acs_gic.c
+++ b/val/src/acs_gic.c
@@ -56,6 +56,7 @@ val_gic_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 
   status      = ACS_STATUS_PASS;
 
+  val_print_test_start("GIC");
   g_curr_module = 1 << GIC_MODULE;
 
   gic_version = val_gic_get_info(GIC_INFO_VERSION);
@@ -100,7 +101,7 @@ val_gic_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
       goto its_test;
   }
 
-  val_print(ACS_PRINT_ERR, "\n      *** Starting GICv2m tests ***\n", 0);
+  val_print_test_start("GICv2m");
   if (g_sw_view[G_SW_OS]) {
       val_print(ACS_PRINT_ERR, "\nOperating System View:\n", 0);
       status |= os_v2m001_entry(num_pe);
@@ -114,7 +115,8 @@ its_test:
       val_print(ACS_PRINT_DEBUG, "\n       No ITS, Skipping all DeviceID & ITS tests \n", 0);
       goto test_done;
   }
-  val_print(ACS_PRINT_ERR, "\n      *** Starting DeviceID generation and ITS tests ***\n", 0);
+
+  val_print_test_start("DeviceID generation and ITS");
   if (g_sw_view[G_SW_OS]) {
       val_print(ACS_PRINT_ERR, "\nOperating System View:\n", 0);
       status |= os_its001_entry(num_pe);

--- a/val/src/acs_memory.c
+++ b/val/src/acs_memory.c
@@ -56,6 +56,7 @@ val_memory_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 
   status = ACS_STATUS_PASS;
 
+  val_print_test_start("Memory Map");
   g_curr_module = 1 << MEM_MODULE;
 
   if (g_sw_view[G_SW_OS]) {

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -325,6 +325,7 @@ val_pcie_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
       return ACS_STATUS_SKIP;
   }
 
+  val_print_test_start("PCIe");
   g_curr_module = 1 << PCIE_MODULE;
 
   if (g_sw_view[G_SW_OS]) {

--- a/val/src/acs_pe.c
+++ b/val/src/acs_pe.c
@@ -61,6 +61,7 @@ val_pe_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 
   status = ACS_STATUS_PASS;
 
+  val_print_test_start("PE");
   g_curr_module = 1 << PE_MODULE;
 
   if (g_sw_view[G_SW_OS]) {

--- a/val/src/acs_peripherals.c
+++ b/val/src/acs_peripherals.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,6 +55,7 @@ val_peripheral_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
     return ACS_STATUS_SKIP;
   }
 
+  val_print_test_start("Peripheral");
   g_curr_module = 1 << PERIPHERAL_MODULE;
 
   if (g_sw_view[G_SW_OS]) {

--- a/val/src/acs_smmu.c
+++ b/val/src/acs_smmu.c
@@ -83,6 +83,7 @@ val_smmu_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
     return ACS_STATUS_SKIP;
   }
 
+  val_print_test_start("SMMU");
   g_curr_module = 1 << SMMU_MODULE;
 
   ver_smmu = val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, 0);

--- a/val/src/acs_test_infra.c
+++ b/val/src/acs_test_infra.c
@@ -42,6 +42,23 @@ val_print(uint32_t level, char8_t *string, uint64_t data)
 }
 
 /**
+  @brief  This API prints out module header to the output console.
+          1. Caller       - Application layer
+          2. Prerequisite - None.
+
+  @param string  formatted ASCII string
+
+  @return        None
+ **/
+void
+val_print_test_start(char8_t *string)
+{
+  pal_print("\n      *** Starting ", 0);
+  pal_print(string, 0);
+  pal_print(" tests ***  \n", 0);
+}
+
+/**
   @brief  This API calls PAL layer to print tests status
           to the output console.
           1. Caller       - Application layer

--- a/val/src/acs_timer.c
+++ b/val/src/acs_timer.c
@@ -55,6 +55,7 @@ val_timer_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
     return ACS_STATUS_SKIP;
   }
 
+  val_print_test_start("Timer");
   g_curr_module = 1 << TIMER_MODULE;
 
   if (g_sw_view[G_SW_OS]) {

--- a/val/src/acs_wakeup.c
+++ b/val/src/acs_wakeup.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,6 +55,7 @@ val_wakeup_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
     return ACS_STATUS_SKIP;
   }
 
+  val_print_test_start("Wakeup semantic");
   g_curr_module = 1 << WAKEUP_MODULE;
 
   if (g_sw_view[G_SW_OS]) {

--- a/val/src/acs_wd.c
+++ b/val/src/acs_wd.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -61,6 +61,8 @@ if (!g_build_sbsa) { /* For SBSA compliance WD is mandatory */
     return ACS_STATUS_SKIP;
   }
 }
+
+  val_print_test_start("Watchdog");
   g_curr_module = 1 << WD_MODULE;
 
   if (g_sw_view[G_SW_OS]) {


### PR DESCRIPTION
 - Added a VAL API that prints out module header.
 - Printing module header only if any test in the module is to be executed. Else skipping module headers as well.