### PR TITLE
Removing limitation on -t -m options

### DIFF
--- a/baremetal_app/BsaAcsMain.c
+++ b/baremetal_app/BsaAcsMain.c
@@ -38,6 +38,8 @@ uint32_t  g_wakeup_timeout;
 
 uint32_t  g_sw_view[3] = {1, 1, 1}; //Operating System, Hypervisor, Platform Security
 uint32_t  *g_skip_test_num;
+uint32_t  *g_execute_tests;
+uint32_t  *g_execute_modules;
 uint32_t  g_build_sbsa = 0;
 
 uint32_t
@@ -167,7 +169,19 @@ ShellAppMainbsa(
   void                 *branch_label;
 
   g_skip_test_num = &g_skip_array[0];
+
+  /* Check if there is a user override to run specific tests*/
+  if (g_num_tests) {
+      g_execute_tests   = &g_test_array[0];
+  }
+
+  /* Check if there is a user override to run specific modules*/
+  if (g_num_modules) {
+      g_execute_modules = &g_module_array[0];
+  }
+
   g_print_level = PLATFORM_OVERRIDE_PRINT_LEVEL;
+
   if (g_print_level < ACS_PRINT_INFO)
   {
       val_print(ACS_PRINT_ERR, "Print Level %d is not supported.\n", g_print_level);

--- a/platform/pal_baremetal/FVP/RDN2/include/platform_override_fvp.h
+++ b/platform/pal_baremetal/FVP/RDN2/include/platform_override_fvp.h
@@ -24,6 +24,10 @@
 
 extern uint32_t g_skip_array[];
 extern uint32_t g_num_skip;
+extern uint32_t g_test_array[];
+extern uint32_t g_num_tests;
+extern uint32_t g_module_array[];
+extern uint32_t g_num_modules;
 
 /* Settings */
 #define PLATFORM_OVERRIDE_PRINT_LEVEL  0x3     //The permissible levels are 1,2,3,4 and 5

--- a/platform/pal_baremetal/FVP/RDN2/src/platform_cfg_fvp.c
+++ b/platform/pal_baremetal/FVP/RDN2/src/platform_cfg_fvp.c
@@ -19,15 +19,15 @@
 #include "include/platform_override_struct.h"
 
 /*
-    To run a single module:
-      - Overwrite SINGLE_MODULE_SENTINEL with Module test base.
-      - All module test bases can be found in val/include/bsa_acs_common.h
-      - For example, if g_single_module = 0, only PE tests will be run while skipping other modules.
+    To run a specific modules:
+      - Give the module base numbers in the g_module_array.
+      - All module base numbers can be found in val/include/bsa_acs_common.h
+      - Example - if g_module_array = {0}, only PE tests will be run while skipping other modules
 
-    To run a single test:
-      - Overwrite SINGLE_TEST_SENTINEL with test number.
+    To run a specific tests:
+      - Give the test numbers in the g_test_array.
       - Test numbers can be found in test_pool/<module>/test.c.
-      - For example, if g_single_test = 801, only first test in PCIe will be run.
+      - For example, if g_test_array = {801}, only first test in PCIe will be run.
         All other tests in all other modules will be skipped.
       - If g_single_module is also given, then single test + tests under single module will be run.
 
@@ -35,13 +35,15 @@
       - Give test numbers or module test bases as the entries of g_skip_array.
       - This will only skip the tests or modules given in the array and runs all other tests.
 
-    Tests run = Single test + Tests under single module - Tests under skip array
+    Tests run = g_test_array + g_module_array - Tests under skip array
 */
-uint32_t  g_skip_array[]  = {10000, 10000, 10000, 10000};
-uint32_t  g_single_test   = SINGLE_TEST_SENTINEL;
-uint32_t  g_single_module = SINGLE_MODULE_SENTINEL;
+uint32_t  g_skip_array[]   = {10000, 10000, 10000, 10000};
+uint32_t  g_test_array[]   = {};
+uint32_t  g_module_array[] = {};
 
-uint32_t  g_num_skip      = sizeof(g_skip_array)/sizeof(g_skip_array[0]);
+uint32_t  g_num_skip         = sizeof(g_skip_array)/sizeof(g_skip_array[0]);
+uint32_t  g_num_tests        = sizeof(g_test_array)/sizeof(g_test_array[0]);
+uint32_t  g_num_modules      = sizeof(g_module_array)/sizeof(g_module_array[0]);
 
 
 PE_INFO_TABLE platform_pe_cfg = {

--- a/val/include/bsa_acs_cfg.h
+++ b/val/include/bsa_acs_cfg.h
@@ -28,8 +28,10 @@ extern uint32_t g_bsa_tests_fail;
 extern uint64_t g_stack_pointer;
 extern uint64_t g_exception_ret_addr;
 extern uint64_t g_ret_addr;
-extern uint32_t g_single_test;
-extern uint32_t g_single_module;
+extern uint32_t *g_execute_tests;
+extern uint32_t g_num_tests;
+extern uint32_t *g_execute_modules;
+extern uint32_t g_num_modules;
 extern uint32_t g_build_sbsa;
 extern uint32_t g_curr_module;
 

--- a/val/include/bsa_acs_common.h
+++ b/val/include/bsa_acs_common.h
@@ -117,6 +117,9 @@ void
 val_mmio_write64(addr_t addr, uint64_t data);
 
 uint32_t
+val_check_skip_module(uint32_t module_base);
+
+uint32_t
 val_initialize_test(uint32_t test_num, char8_t * desc, uint32_t num_pe);
 
 uint32_t

--- a/val/src/acs_exerciser.c
+++ b/val/src/acs_exerciser.c
@@ -437,8 +437,6 @@ val_exerciser_execute_tests(uint32_t *g_sw_view)
   uint32_t num_instances;
   uint32_t instance, num_smmu;
 
-  status = ACS_STATUS_PASS;
-
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_EXERCISER_TEST_NUM_BASE) {
           val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Exerciser tests \n", 0);
@@ -446,12 +444,10 @@ val_exerciser_execute_tests(uint32_t *g_sw_view)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != ACS_EXERCISER_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-         (g_single_test - ACS_EXERCISER_TEST_NUM_BASE > 100 ||
-          g_single_test - ACS_EXERCISER_TEST_NUM_BASE < 0))) {
-    val_print(ACS_PRINT_TEST, "\n      USER Override - Skipping all Exerciser tests ", 0);
-    val_print(ACS_PRINT_TEST, "\n      (Running only a single module) \n", 0);
+  /* Check if there are any tests to be executed in current module with user override options*/
+  status = val_check_skip_module(ACS_EXERCISER_TEST_NUM_BASE);
+  if (status) {
+    val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Exerciser tests \n", 0);
     return ACS_STATUS_SKIP;
   }
 
@@ -482,6 +478,8 @@ val_exerciser_execute_tests(uint32_t *g_sw_view)
   val_gic_its_configure();
 
   val_print_test_start("Exerciser");
+  status = ACS_STATUS_PASS;
+
   g_curr_module = 1 << EXERCISER_MODULE;
 
   if (g_sw_view[G_SW_OS]) {

--- a/val/src/acs_gic.c
+++ b/val/src/acs_gic.c
@@ -45,12 +45,10 @@ val_gic_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != ACS_GIC_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-         (g_single_test - ACS_GIC_TEST_NUM_BASE > 100 ||
-          g_single_test - ACS_GIC_TEST_NUM_BASE < 0))) {
-      val_print(ACS_PRINT_TEST, "\n      USER Override - Skipping all GIC tests ", 0);
-      val_print(ACS_PRINT_TEST, "\n      (Running only a single module) \n", 0);
+  /* Check if there are any tests to be executed in current module with user override options*/
+  status = val_check_skip_module(ACS_GIC_TEST_NUM_BASE);
+  if (status) {
+      val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all GIC tests \n", 0);
       return ACS_STATUS_SKIP;
   }
 

--- a/val/src/acs_memory.c
+++ b/val/src/acs_memory.c
@@ -44,12 +44,10 @@ val_memory_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != ACS_MEMORY_MAP_TEST_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-         (g_single_test - ACS_MEMORY_MAP_TEST_BASE > 100 ||
-          g_single_test - ACS_MEMORY_MAP_TEST_BASE < 0))) {
-      val_print(ACS_PRINT_TEST, "\n      USER Override - Skipping all Memory Map tests ", 0);
-      val_print(ACS_PRINT_TEST, "\n      (Running only a single module) \n", 0);
+  /* Check if there are any tests to be executed in current module with user override options*/
+  status = val_check_skip_module(ACS_MEMORY_MAP_TEST_BASE);
+  if (status) {
+      val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Memory tests \n", 0);
       return ACS_STATUS_SKIP;
   }
 

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -296,27 +296,24 @@ val_pcie_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
   uint32_t status, i;
   uint32_t num_ecam = 0;
 
-  status = ACS_STATUS_PASS;
-
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_PCIE_TEST_NUM_BASE) {
           val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all PCIe tests \n", 0);
           return ACS_STATUS_SKIP;
       }
   }
-   if (pcie_bdf_table_list_flag == 1) {
-    val_print(ACS_PRINT_WARN, "\n     *** Created device list with valid bdf doesn't match \
-                    with the platform pcie device hierarchy, Skipping PCIE tests *** \n", 0);
-    return ACS_STATUS_SKIP;
+
+  /* Check if there are any tests to be executed in current module with user override options*/
+  status = val_check_skip_module(ACS_PCIE_TEST_NUM_BASE);
+  if (status) {
+      val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all PCIe tests \n", 0);
+      return ACS_STATUS_SKIP;
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != ACS_PCIE_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-         (g_single_test - ACS_PCIE_TEST_NUM_BASE > 100 ||
-          g_single_test - ACS_PCIE_TEST_NUM_BASE < 0))) {
-    val_print(ACS_PRINT_TEST, "\n      USER Override - Skipping all PCIE tests ", 0);
-    val_print(ACS_PRINT_TEST, "\n      (Running only a single module)\n", 0);
-    return ACS_STATUS_SKIP;
+  if (pcie_bdf_table_list_flag == 1) {
+      val_print(ACS_PRINT_WARN, "\n     *** Created device list with valid bdf doesn't match \
+                    with the platform pcie device hierarchy, Skipping PCIE tests *** \n", 0);
+      return ACS_STATUS_SKIP;
   }
 
   num_ecam = (uint32_t)val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0);
@@ -326,6 +323,8 @@ val_pcie_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
   }
 
   val_print_test_start("PCIe");
+  status = ACS_STATUS_PASS;
+
   g_curr_module = 1 << PCIE_MODULE;
 
   if (g_sw_view[G_SW_OS]) {

--- a/val/src/acs_pe.c
+++ b/val/src/acs_pe.c
@@ -51,12 +51,11 @@ val_pe_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != ACS_PE_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-       (g_single_test - ACS_PE_TEST_NUM_BASE > 100))) {
-    val_print(ACS_PRINT_TEST, "\n      USER Override - Skipping all PE tests ", 0);
-    val_print(ACS_PRINT_TEST, "\n      (Running only a single module) \n", 0);
-    return ACS_STATUS_SKIP;
+  /* Check if there are any tests to be executed in current module with user override options*/
+  status = val_check_skip_module(ACS_PE_TEST_NUM_BASE);
+  if (status) {
+      val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all PE tests \n", 0);
+      return ACS_STATUS_SKIP;
   }
 
   status = ACS_STATUS_PASS;

--- a/val/src/acs_peripherals.c
+++ b/val/src/acs_peripherals.c
@@ -37,8 +37,6 @@ val_peripheral_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 
   uint32_t status, i;
 
-  status = ACS_STATUS_PASS;
-
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_PER_TEST_NUM_BASE) {
           val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Peripheral tests \n", 0);
@@ -46,16 +44,16 @@ val_peripheral_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != ACS_PER_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-         (g_single_test - ACS_PER_TEST_NUM_BASE > 100 ||
-          g_single_test - ACS_PER_TEST_NUM_BASE < 0))) {
-    val_print(ACS_PRINT_TEST, "\n      USER Override - Skipping all Peripheral tests ", 0);
-    val_print(ACS_PRINT_TEST, "\n      (Running only a single module)\n", 0);
-    return ACS_STATUS_SKIP;
+  /* Check if there are any tests to be executed in current module with user override options*/
+  status = val_check_skip_module(ACS_PER_TEST_NUM_BASE);
+  if (status) {
+      val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Peripheral tests \n", 0);
+      return ACS_STATUS_SKIP;
   }
 
   val_print_test_start("Peripheral");
+  status = ACS_STATUS_PASS;
+
   g_curr_module = 1 << PERIPHERAL_MODULE;
 
   if (g_sw_view[G_SW_OS]) {

--- a/val/src/acs_smmu.c
+++ b/val/src/acs_smmu.c
@@ -59,8 +59,6 @@ val_smmu_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
   uint32_t num_smmu;
   uint32_t ver_smmu;
 
-  status = ACS_STATUS_PASS;
-
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_SMMU_TEST_NUM_BASE) {
           val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all SMMU tests \n", 0);
@@ -68,13 +66,11 @@ val_smmu_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != ACS_SMMU_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-         (g_single_test - ACS_SMMU_TEST_NUM_BASE > 100 ||
-          g_single_test - ACS_SMMU_TEST_NUM_BASE < 0))) {
-    val_print(ACS_PRINT_TEST, "\n      USER Override - Skipping all SMMU tests ", 0);
-    val_print(ACS_PRINT_TEST, "\n      (Running only a single module)\n", 0);
-    return ACS_STATUS_SKIP;
+  /* Check if there are any tests to be executed in current module with user override options*/
+  status = val_check_skip_module(ACS_SMMU_TEST_NUM_BASE);
+  if (status) {
+      val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all SMMU tests \n", 0);
+      return ACS_STATUS_SKIP;
   }
 
   num_smmu = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
@@ -84,6 +80,8 @@ val_smmu_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
   }
 
   val_print_test_start("SMMU");
+  status = ACS_STATUS_PASS;
+
   g_curr_module = 1 << SMMU_MODULE;
 
   ver_smmu = val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, 0);

--- a/val/src/acs_timer.c
+++ b/val/src/acs_timer.c
@@ -37,8 +37,6 @@ val_timer_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 {
   uint32_t status, i;
 
-  status = ACS_STATUS_PASS;
-
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_TIMER_TEST_NUM_BASE) {
           val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Timer tests \n", 0);
@@ -46,16 +44,16 @@ val_timer_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != ACS_TIMER_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-         (g_single_test - ACS_TIMER_TEST_NUM_BASE > 100 ||
-          g_single_test - ACS_TIMER_TEST_NUM_BASE < 0))) {
-    val_print(ACS_PRINT_TEST, "\n      USER Override - Skipping all Timer tests ", 0);
-    val_print(ACS_PRINT_TEST, "\n      (Running only a single module)\n", 0);
-    return ACS_STATUS_SKIP;
+  /* Check if there are any tests to be executed in current module with user override options*/
+  status = val_check_skip_module(ACS_TIMER_TEST_NUM_BASE);
+  if (status) {
+      val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Timer tests \n", 0);
+      return ACS_STATUS_SKIP;
   }
 
   val_print_test_start("Timer");
+  status = ACS_STATUS_PASS;
+
   g_curr_module = 1 << TIMER_MODULE;
 
   if (g_sw_view[G_SW_OS]) {

--- a/val/src/acs_wakeup.c
+++ b/val/src/acs_wakeup.c
@@ -37,8 +37,6 @@ val_wakeup_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 {
   uint32_t status, i;
 
-  status = ACS_STATUS_PASS;
-
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_WAKEUP_TEST_NUM_BASE) {
           val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Wakeup tests \n", 0);
@@ -46,16 +44,16 @@ val_wakeup_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != ACS_WAKEUP_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-         (g_single_test - ACS_WAKEUP_TEST_NUM_BASE > 100 ||
-          g_single_test - ACS_WAKEUP_TEST_NUM_BASE < 0))) {
-    val_print(ACS_PRINT_TEST, "\n      USER Override - Skipping all Wakeup tests ", 0);
-    val_print(ACS_PRINT_TEST, "\n      (Running only a single module)\n", 0);
-    return ACS_STATUS_SKIP;
+  /* Check if there are any tests to be executed in current module with user override options*/
+  status = val_check_skip_module(ACS_WAKEUP_TEST_NUM_BASE);
+  if (status) {
+      val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Wakeup tests \n", 0);
+      return ACS_STATUS_SKIP;
   }
 
   val_print_test_start("Wakeup semantic");
+  status = ACS_STATUS_PASS;
+
   g_curr_module = 1 << WAKEUP_MODULE;
 
   if (g_sw_view[G_SW_OS]) {

--- a/val/src/acs_wd.c
+++ b/val/src/acs_wd.c
@@ -36,8 +36,6 @@ val_wd_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 {
   uint32_t status, i;
 
-  status = ACS_STATUS_PASS;
-
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_WD_TEST_NUM_BASE) {
           val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Watchdog tests \n", 0);
@@ -45,13 +43,11 @@ val_wd_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
       }
   }
 
-  if (g_single_module != SINGLE_MODULE_SENTINEL && g_single_module != ACS_WD_TEST_NUM_BASE &&
-       (g_single_test == SINGLE_MODULE_SENTINEL ||
-         (g_single_test - ACS_WD_TEST_NUM_BASE > 100 ||
-          g_single_test - ACS_WD_TEST_NUM_BASE < 0))) {
-    val_print(ACS_PRINT_TEST, "\n      USER Override - Skipping all Watchdog tests ", 0);
-    val_print(ACS_PRINT_TEST, "\n      (Running only a single module)\n", 0);
-    return ACS_STATUS_SKIP;
+  /* Check if there are any tests to be executed in current module with user override options*/
+  status = val_check_skip_module(ACS_WD_TEST_NUM_BASE);
+  if (status) {
+      val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Watchdog tests \n", 0);
+      return ACS_STATUS_SKIP;
   }
 
 if (!g_build_sbsa) { /* For SBSA compliance WD is mandatory */
@@ -63,6 +59,8 @@ if (!g_build_sbsa) { /* For SBSA compliance WD is mandatory */
 }
 
   val_print_test_start("Watchdog");
+  status = ACS_STATUS_PASS;
+
   g_curr_module = 1 << WD_MODULE;
 
   if (g_sw_view[G_SW_OS]) {


### PR DESCRIPTION
 - Added a VAL API that returns if the module should be skipped based on any tests to be run using user override options.
 - Users can now give any number of parameters to -t and -m options which allows them to run any specific tests/modules without any limitations.
 - Made necessary infra changes to baremetal also.