### PR TITLE
EL1 timer skip debug option added

### DIFF
--- a/baremetal_app/BsaAcsMain.c
+++ b/baremetal_app/BsaAcsMain.c
@@ -41,6 +41,10 @@ uint32_t  *g_skip_test_num;
 uint32_t  *g_execute_tests;
 uint32_t  *g_execute_modules;
 uint32_t  g_build_sbsa = 0;
+/* VE systems run acs at EL1 and in some systems crash is observed during acess
+   of EL1 phy and virt timer, Below command line option is added only for debug
+   purpose to complete BSA run on these systems */
+uint32_t  g_el1physkip;
 
 uint32_t
 createPeInfoTable(

--- a/test_pool/power_wakeup/operating_system/test_os_u001.c
+++ b/test_pool/power_wakeup/operating_system/test_os_u001.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2019, 2021-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019, 2021-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -346,19 +346,21 @@ os_u001_entry(uint32_t num_pe)
 
   num_pe = 1;  //This Timer test is run on single processor
 
-    /* EL1 PHY */
-  status_test = val_initialize_test(TEST_NUM1, TEST_DESC1, num_pe);
-  if (status_test != ACS_STATUS_SKIP)
-      val_run_test_payload(TEST_NUM1, num_pe, payload1, 0);
-  status |= val_check_for_error(TEST_NUM1, num_pe, TEST_RULE1);
-  val_report_status(0, BSA_ACS_END(TEST_NUM1), NULL);
+  if (!g_el1physkip) {
+      /* EL1 PHY */
+      status_test = val_initialize_test(TEST_NUM1, TEST_DESC1, num_pe);
+      if (status_test != ACS_STATUS_SKIP)
+          val_run_test_payload(TEST_NUM1, num_pe, payload1, 0);
+      status |= val_check_for_error(TEST_NUM1, num_pe, TEST_RULE1);
+      val_report_status(0, BSA_ACS_END(TEST_NUM1), NULL);
 
-  /* EL1 VIR */
-  status_test = val_initialize_test(TEST_NUM2, TEST_DESC2, num_pe);
-  if (status_test != ACS_STATUS_SKIP)
-      val_run_test_payload(TEST_NUM2, num_pe, payload2, 0);
-  status |= val_check_for_error(TEST_NUM2, num_pe, TEST_RULE2);
-  val_report_status(0, BSA_ACS_END(TEST_NUM2), NULL);
+      /* EL1 VIR */
+      status_test = val_initialize_test(TEST_NUM2, TEST_DESC2, num_pe);
+      if (status_test != ACS_STATUS_SKIP)
+          val_run_test_payload(TEST_NUM2, num_pe, payload2, 0);
+      status |= val_check_for_error(TEST_NUM2, num_pe, TEST_RULE2);
+      val_report_status(0, BSA_ACS_END(TEST_NUM2), NULL);
+  }
 
   /* EL2 PHY */
   /* Run this test if current exception level is EL2 */

--- a/uefi_app/BsaAcsMain.c
+++ b/uefi_app/BsaAcsMain.c
@@ -51,6 +51,10 @@ UINT32  *g_execute_tests;
 UINT32  g_num_tests = 0;
 UINT32  *g_execute_modules;
 UINT32  g_num_modules = 0;
+/* VE systems run acs at EL1 and in some systems crash is observed during acess
+   of EL1 phy and virt timer, Below command line option is added only for debug
+   purpose to complete BSA run on these systems */
+UINT32  g_el1physkip = FALSE;
 
 SHELL_FILE_HANDLE g_bsa_log_file_handle;
 SHELL_FILE_HANDLE g_dtb_log_file_handle;
@@ -278,6 +282,7 @@ HelpMsg (
          "-rciep  Enable running pcie tests for RCiEP\n"
          "-iep    Enable running pcie tests for iEP\n"
          "-sbsa   Enable sbsa requirements for bsa binary\n"
+         "-el1physkip Skips EL1 register checks\n"
   );
 }
 
@@ -298,6 +303,7 @@ STATIC CONST SHELL_PARAM_ITEM ParamList[] = {
   {L"-dtb", TypeValue},  // -dtb  # Binary Flag to enable dtb dump
   {L"-sbsa", TypeFlag},  // -sbsa # Enable sbsa requirements for bsa binary\n"
   {L"-mmio", TypeFlag}, // -mmio # Enable pal_mmio prints
+  {L"-el1physkip", TypeFlag}, // -el1physkip # Skips EL1 register checks
   {NULL, TypeMax}
   };
 
@@ -547,6 +553,9 @@ ShellAppMain (
     g_pcie_cache_present = FALSE;
   }
 
+  if (ShellCommandLineGetFlag (ParamPackage, L"-el1physkip")) {
+    g_el1physkip = TRUE;
+  }
   //
   // Initialize global counters
   //

--- a/val/include/bsa_acs_cfg.h
+++ b/val/include/bsa_acs_cfg.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2022-2023 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2022-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,5 +34,6 @@ extern uint32_t *g_execute_modules;
 extern uint32_t g_num_modules;
 extern uint32_t g_build_sbsa;
 extern uint32_t g_curr_module;
+extern uint32_t g_el1physkip;
 
 #endif

--- a/val/src/acs_gic.c
+++ b/val/src/acs_gic.c
@@ -75,7 +75,9 @@ val_gic_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
       }
 
       status |= os_g005_entry(num_pe);
-      status |= os_g006_entry(num_pe);
+      if (!g_el1physkip)
+          status |= os_g006_entry(num_pe);
+
       status |= os_g007_entry(num_pe);
   }
 

--- a/val/src/acs_timer.c
+++ b/val/src/acs_timer.c
@@ -347,9 +347,10 @@ val_timer_create_info_table(uint64_t *timer_info_table)
   /* UEFI or other EL1 software may have enabled the EL1 physical/virtual timer.
      Disable the timers to prevent interrupts at un-expected times */
 
-  val_timer_set_phy_el1(0);
-  val_timer_set_vir_el1(0);
-
+  if (!g_el1physkip) {
+     val_timer_set_phy_el1(0);
+     val_timer_set_vir_el1(0);
+  }
   val_print(ACS_PRINT_TEST, " TIMER_INFO: Number of system timers  : %4d \n", g_timer_info_table->header.num_platform_timer);
 
 }


### PR DESCRIPTION
In some platforms when running bsa at EL1, an exception is observed when EL1 timers are accessed.  el1physkip added as debug option to skip the timer access 

 - implemented "-el1physkip" command line option to skip EL1 register checks
 - commented el1 timer register read and write api's which causing execption in val_timer_create_info_table function