### PR TITLE
Enabling BME and MSE bits only for UEFI

### DIFF
--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -693,11 +693,14 @@ val_pcie_create_device_bdf_table()
                       if (val_pcie_is_host_bridge(bdf))
                           continue;
 
+#ifndef TARGET_LINUX
                       /* Enable memory access and bus master enable for all BDF's
                        * For BM systems, these bits are enabled during enumeration in PAL
+                       * For linux, the driver takes care.
                       */
                       val_pcie_enable_bme(bdf);
                       val_pcie_enable_msa(bdf);
+#endif
 
 		      /* Skip if the device is a PCI legacy device */
                       p_cap = val_pcie_find_capability(


### PR DESCRIPTION
- BME and MSE bits enablement changes were added to include RP which has a legacy device connected to them for compliance check. On Linux, USB disconnect issue was seen on a system that has USB connected via a PCIe controller. It could be due to difference between the number of valid BDF's found by ACS vs devices listed by linux (lspci) Enabling of BME and MSE bits of a PCIe device (which is found by ACS but not listed by lspci) could have triggered the USB disconnect issue.

- BME and MSE bits enablement is required by tests that performs BAR related checks. In Linux ACS there are no such tests present, so enabling these bits can be skipped for linux enviroment. Enabling BME and MSE bits only for UEFI