### PR TITLE
Test 104: Fix to run test only if Peripheral is connected as PCIe device

### DIFF
--- a/platform/pal_baremetal/src/pal_peripherals.c
+++ b/platform/pal_baremetal/src/pal_peripherals.c
@@ -128,6 +128,14 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
     per_info->width = 1;
     per_info->irq   = platform_uart_cfg.GlobalSystemInterrupt;
     per_info->type  = PERIPHERAL_TYPE_UART;
+    per_info->bdf = 0;
+
+    if(platform_uart_cfg.PciVendorId != 0xFFFF)
+    {
+       DeviceBdf = PCIE_CREATE_BDF(platform_uart_cfg.PciSegment, platform_uart_cfg.PciBusNumber,
+                                         platform_uart_cfg.PciDeviceNumber, platform_uart_cfg.PciFunctionNumber);
+       per_info->bdf = DeviceBdf;
+    }
 
     if (platform_uart_cfg.BaudRate < 8)
         per_info->baud_rate = spcr_baudrate_id[platform_uart_cfg.BaudRate];

--- a/test_pool/memory_map/operating_system/test_os_m004.c
+++ b/test_pool/memory_map/operating_system/test_os_m004.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021, 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,6 +47,10 @@ payload (void)
   while (count) {
       count--;
       dev_bdf = (uint32_t)val_peripheral_get_info (ANY_BDF, count);
+
+      if (dev_bdf == 0)
+          continue;
+
       dev_type = val_pcie_get_device_type(dev_bdf);
       // 1: Normal PCIe device, 2: PCIe Host bridge, 3: PCIe bridge device, else: INVALID
 
@@ -66,13 +70,13 @@ payload (void)
       data = val_pcie_is_devicedma_64bit(dev_bdf);
       if (data == 0) {
           if (!val_pcie_is_device_behind_smmu(dev_bdf)) {
-              val_print(ACS_PRINT_ERR, "\n       WARNING:The device with bdf=0x%x", dev_bdf);
-              val_print(ACS_PRINT_ERR, "\n       doesn't support 64 bit addressing and is not", 0);
-              val_print(ACS_PRINT_ERR, "\n       behind smmu. device is of type = %d", dev_type);
+              val_print(ACS_PRINT_ERR, "\n   WARNING:The device with bdf=0x%x", dev_bdf);
+              val_print(ACS_PRINT_ERR, "\n   doesn't support 64 bit addressing and is not", 0);
+              val_print(ACS_PRINT_ERR, "\n   behind smmu. device is of type = %d", dev_type);
               val_set_status(index, RESULT_FAIL (TEST_NUM, 1));
               return;
           }
-      }
+       }
   }
 
   if (test_run)

--- a/val/src/acs_memory.c
+++ b/val/src/acs_memory.c
@@ -65,7 +65,8 @@ val_memory_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 #ifndef TARGET_LINUX
       status |= os_m002_entry(num_pe);
       status |= os_m003_entry(num_pe);
-#else
+#endif
+#if defined(TARGET_LINUX) || defined(ENABLE_OOB) || defined(TARGET_EMULATION)
       status |= os_m004_entry(num_pe);
 #endif
 


### PR DESCRIPTION
- Added a guard as test should proceed only if peripheral is connected as PCIe device, else the device id will be Invalid