### PR TITLE
Fix for mismatch in function prototypes

### DIFF
--- a/val/include/bsa_acs_exerciser.h
+++ b/val/include/bsa_acs_exerciser.h
@@ -118,7 +118,7 @@ uint32_t val_exerciser_ops(EXERCISER_OPS ops, uint64_t param, uint32_t instance)
 uint32_t val_exerciser_get_data(EXERCISER_DATA_TYPE type, exerciser_data_t *data, uint32_t instance);
 uint32_t val_exerciser_execute_tests(uint32_t *g_sw_view);
 uint32_t val_exerciser_get_bdf(uint32_t instance);
-uint32_t val_get_exerciser_err_info(uint32_t type);
+uint32_t val_get_exerciser_err_info(EXERCISER_ERROR_CODE type);
 uint32_t val_exerciser_get_rootport(uint32_t bdf, uint32_t *rp_bdf);
 uint32_t val_exerciser_create_device_bdf_table(void);
 uint32_t val_exerciser_get_legacy_irq_map (uint32_t bdf, PERIPHERAL_IRQ_MAP *irq_map);

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -184,7 +184,7 @@ typedef enum {
 void     val_wd_create_info_table(uint64_t *wd_info_table);
 void     val_wd_free_info_table(void);
 uint32_t val_wd_execute_tests(uint32_t num_pe, uint32_t *g_sw_view);
-uint64_t val_wd_get_info(uint32_t index, uint32_t info_type);
+uint64_t val_wd_get_info(uint32_t index, WD_INFO_TYPE_e info_type);
 uint32_t val_wd_set_ws0(uint32_t index, uint32_t timeout);
 uint64_t val_get_counter_frequency(void);
 

--- a/val/src/acs_gic.c
+++ b/val/src/acs_gic.c
@@ -403,7 +403,7 @@ val_get_cpuif_base(void)
   @return  32-bit data
 **/
 uint32_t
-val_gic_get_info(uint32_t type)
+val_gic_get_info(GIC_INFO_e type)
 {
 
   if (g_gic_info_table == NULL) {


### PR DESCRIPTION
 - Mismatch between function prototype and definition causing build failure with GCC 13.1.1
 - Fixed the function prototype for val_get_exerciser_err_info, val_wd_get_info and val_gic_get_info
 - Resolves: #174