### PR TITLE
fix for issue #194 : FLR test should poll for device readiness

### DIFF
--- a/test_pool/pcie/operating_system/test_os_p035.c
+++ b/test_pool/pcie/operating_system/test_os_p035.c
@@ -68,6 +68,7 @@ payload(void)
   uint32_t test_fails;
   uint32_t test_skip = 1;
   uint32_t idx;
+  uint32_t timeout;
   uint32_t status;
   addr_t config_space_addr;
   void *func_config_space;
@@ -142,7 +143,22 @@ payload(void)
           /* If test runs for atleast an endpoint */
           test_skip = 0;
 
-          /* Vendor Id must not be 0xFF after max FLR period */
+          /* If Vendor Id is 0xFF after max FLR period, wait
+           * for 1 ms and read again. Keep polling for 5 secs */
+          timeout = (5 * TIMEOUT_LARGE);
+          while (timeout-- > 0)
+          {
+              val_pcie_read_cfg(bdf, 0, &reg_value);
+              if ((reg_value & TYPE01_VIDR_MASK) == TYPE01_VIDR_MASK)
+              {
+                  status = val_time_delay_ms(ONE_MILLISECOND);
+                  continue;
+              }
+              else
+                  break;
+          }
+
+          /* Vendor Id must not be 0xFF after max timeout period */
           val_pcie_read_cfg(bdf, 0, &reg_value);
           if ((reg_value & TYPE01_VIDR_MASK) == TYPE01_VIDR_MASK)
           {


### PR DESCRIPTION
- Few devices might require more than 100ms to complete the FLR.
- Hence modified to below logic Check if FLR PCIe capability is set If so, initiate FLR and Wait 100 ms Read back the VID register from config space If value is 0xFF, delay for 1 ms, then read again Keep polling until a maximum timeout of 5 secs