### PR TITLE
Enhancements to -t option

### DIFF
--- a/val/src/acs_exerciser.c
+++ b/val/src/acs_exerciser.c
@@ -439,7 +439,7 @@ val_exerciser_execute_tests(uint32_t *g_sw_view)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_EXERCISER_TEST_NUM_BASE) {
-          val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Exerciser tests \n", 0);
+          val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all Exerciser tests \n", 0);
           return ACS_STATUS_SKIP;
       }
   }
@@ -447,7 +447,7 @@ val_exerciser_execute_tests(uint32_t *g_sw_view)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(ACS_EXERCISER_TEST_NUM_BASE);
   if (status) {
-    val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Exerciser tests \n", 0);
+    val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all Exerciser tests \n", 0);
     return ACS_STATUS_SKIP;
   }
 

--- a/val/src/acs_gic.c
+++ b/val/src/acs_gic.c
@@ -40,7 +40,7 @@ val_gic_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_GIC_TEST_NUM_BASE) {
-          val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all GIC tests \n", 0);
+          val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all GIC tests \n", 0);
           return ACS_STATUS_SKIP;
       }
   }
@@ -48,7 +48,7 @@ val_gic_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(ACS_GIC_TEST_NUM_BASE);
   if (status) {
-      val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all GIC tests \n", 0);
+      val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all GIC tests \n", 0);
       return ACS_STATUS_SKIP;
   }
 

--- a/val/src/acs_memory.c
+++ b/val/src/acs_memory.c
@@ -39,7 +39,7 @@ val_memory_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_MEMORY_MAP_TEST_BASE) {
-        val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Memory tests \n", 0);
+        val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all Memory tests \n", 0);
         return ACS_STATUS_SKIP;
       }
   }
@@ -47,7 +47,7 @@ val_memory_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(ACS_MEMORY_MAP_TEST_BASE);
   if (status) {
-      val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Memory tests \n", 0);
+      val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all Memory tests \n", 0);
       return ACS_STATUS_SKIP;
   }
 

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -298,7 +298,7 @@ val_pcie_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_PCIE_TEST_NUM_BASE) {
-          val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all PCIe tests \n", 0);
+          val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all PCIe tests \n", 0);
           return ACS_STATUS_SKIP;
       }
   }
@@ -306,7 +306,7 @@ val_pcie_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(ACS_PCIE_TEST_NUM_BASE);
   if (status) {
-      val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all PCIe tests \n", 0);
+      val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all PCIe tests \n", 0);
       return ACS_STATUS_SKIP;
   }
 

--- a/val/src/acs_pe.c
+++ b/val/src/acs_pe.c
@@ -46,7 +46,7 @@ val_pe_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_PE_TEST_NUM_BASE) {
-        val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all PE tests \n", 0);
+        val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all PE tests \n", 0);
         return ACS_STATUS_SKIP;
       }
   }
@@ -54,7 +54,7 @@ val_pe_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(ACS_PE_TEST_NUM_BASE);
   if (status) {
-      val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all PE tests \n", 0);
+      val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all PE tests \n", 0);
       return ACS_STATUS_SKIP;
   }
 

--- a/val/src/acs_peripherals.c
+++ b/val/src/acs_peripherals.c
@@ -39,7 +39,7 @@ val_peripheral_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_PER_TEST_NUM_BASE) {
-          val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Peripheral tests \n", 0);
+          val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all Peripheral tests \n", 0);
           return ACS_STATUS_SKIP;
       }
   }
@@ -47,7 +47,7 @@ val_peripheral_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(ACS_PER_TEST_NUM_BASE);
   if (status) {
-      val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Peripheral tests \n", 0);
+      val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all Peripheral tests \n", 0);
       return ACS_STATUS_SKIP;
   }
 

--- a/val/src/acs_smmu.c
+++ b/val/src/acs_smmu.c
@@ -61,7 +61,7 @@ val_smmu_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_SMMU_TEST_NUM_BASE) {
-          val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all SMMU tests \n", 0);
+          val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all SMMU tests \n", 0);
           return ACS_STATUS_SKIP;
       }
   }
@@ -69,7 +69,7 @@ val_smmu_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(ACS_SMMU_TEST_NUM_BASE);
   if (status) {
-      val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all SMMU tests \n", 0);
+      val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all SMMU tests \n", 0);
       return ACS_STATUS_SKIP;
   }
 

--- a/val/src/acs_status.c
+++ b/val/src/acs_status.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2022, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@
 #include "include/bsa_acs_val.h"
 #include "include/bsa_acs_common.h"
 
+extern uint32_t g_override_skip;
 
 /**
   @brief  Parse the input status and print the appropriate information to console
@@ -32,6 +33,10 @@
 void
 val_report_status(uint32_t index, uint32_t status, char8_t *ruleid)
 {
+
+  /* Test stays quiet if it is overridden by any of the user options */
+  if (!g_override_skip)
+    return;
 
   if (IS_TEST_FAIL(status)) {
       val_print(ACS_PRINT_ERR, "\n       Failed on PE - %4d", index);

--- a/val/src/acs_timer.c
+++ b/val/src/acs_timer.c
@@ -39,7 +39,7 @@ val_timer_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_TIMER_TEST_NUM_BASE) {
-          val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Timer tests \n", 0);
+          val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all Timer tests \n", 0);
           return ACS_STATUS_SKIP;
       }
   }
@@ -47,7 +47,7 @@ val_timer_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(ACS_TIMER_TEST_NUM_BASE);
   if (status) {
-      val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Timer tests \n", 0);
+      val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all Timer tests \n", 0);
       return ACS_STATUS_SKIP;
   }
 

--- a/val/src/acs_wakeup.c
+++ b/val/src/acs_wakeup.c
@@ -39,7 +39,7 @@ val_wakeup_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_WAKEUP_TEST_NUM_BASE) {
-          val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Wakeup tests \n", 0);
+          val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all Wakeup tests \n", 0);
           return ACS_STATUS_SKIP;
       }
   }
@@ -47,7 +47,7 @@ val_wakeup_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(ACS_WAKEUP_TEST_NUM_BASE);
   if (status) {
-      val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Wakeup tests \n", 0);
+      val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all Wakeup tests \n", 0);
       return ACS_STATUS_SKIP;
   }
 

--- a/val/src/acs_wd.c
+++ b/val/src/acs_wd.c
@@ -38,7 +38,7 @@ val_wd_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_WD_TEST_NUM_BASE) {
-          val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Watchdog tests \n", 0);
+          val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all Watchdog tests \n", 0);
           return ACS_STATUS_SKIP;
       }
   }
@@ -46,7 +46,7 @@ val_wd_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(ACS_WD_TEST_NUM_BASE);
   if (status) {
-      val_print(ACS_PRINT_TEST, "\n       USER Override - Skipping all Watchdog tests \n", 0);
+      val_print(ACS_PRINT_INFO, "\n       USER Override - Skipping all Watchdog tests \n", 0);
       return ACS_STATUS_SKIP;
   }
 


### PR DESCRIPTION
 - No console prints for tests not mentioned in -t option.
 - Total test count aligns with the tests that are actually being run with user override options.