### PR TITLE
Enable BSA UEFI build Github actions

### DIFF
--- a/.github/workflows/build-bsa-uefi.yml
+++ b/.github/workflows/build-bsa-uefi.yml
@@ -1,0 +1,103 @@
+name: BSA-ACS UEFI application build
+
+on:
+  push:
+    branches:                # trigger on push to master
+      - master
+  pull_request:              # trigger on pull requests to master
+    branches:
+      - master
+  schedule:
+      - cron: '0 4 * * *'    # runs at 10 AM IST (4 AM UTC) every day
+  workflow_dispatch:         # to dispatch from Github Actions
+
+jobs:
+  build_acpi:
+    name: BSA-ACS UEFI build for ACPI target
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y git build-essential nasm
+
+      - name: Download edk2 and its submodules
+        run: |
+          git clone --recursive --branch edk2-stable202208 https://github.com/tianocore/edk2
+          git clone https://github.com/tianocore/edk2-libc edk2/edk2-libc
+
+      - name: Checkout bsa-acs repository
+        uses: actions/checkout@v3
+        with:
+          path: 'edk2/ShellPkg/Application/bsa-acs'
+
+      - name: Apply edk2 BSA patch for ACPI target
+        run: |
+          cd edk2
+          git apply ShellPkg/Application/bsa-acs/patches/edk2-202208-bsa-acpi.diff
+
+      - name: Download Arm GCC cross-compiler
+        run: |
+          mkdir -p /opt/cross
+          cd /opt/cross
+          wget https://developer.arm.com/-/media/Files/downloads/gnu-a/10.3-2021.07/binrel/gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu.tar.xz
+          tar -xf gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu.tar.xz
+
+      - name: Set up EDK2 environment and build Bsa.efi
+        run: |
+          cd edk2
+          export GCC49_AARCH64_PREFIX=/opt/cross/gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-
+          export PACKAGES_PATH=$PWD/edk2-libc
+          source edksetup.sh
+          make -C BaseTools/Source/C
+          source ShellPkg/Application/bsa-acs/tools/scripts/acsbuild.sh
+      - name: Save Bsa.efi as an artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: Bsa_acpi_target.efi
+          path: edk2/Build/Shell/DEBUG_GCC49/AARCH64/Bsa.efi
+          if-no-files-found: error
+
+  build_dt:
+    name: BSA-ACS UEFI build for DT target
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y git build-essential nasm
+
+      - name: Download edk2 and its submodules
+        run: |
+          git clone --recursive --branch edk2-stable202208 https://github.com/tianocore/edk2
+          git clone https://github.com/tianocore/edk2-libc edk2/edk2-libc
+
+      - name: Checkout bsa-acs repository
+        uses: actions/checkout@v3
+        with:
+          path: 'edk2/ShellPkg/Application/bsa-acs'
+
+      - name: Apply edk2 BSA patch for DT target
+        run: |
+          cd edk2
+          git apply ShellPkg/Application/bsa-acs/patches/edk2-202208-bsa-dt.diff
+
+      - name: Download Arm GCC cross-compiler
+        run: |
+          mkdir -p /opt/cross
+          cd /opt/cross
+          wget https://developer.arm.com/-/media/Files/downloads/gnu-a/10.3-2021.07/binrel/gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu.tar.xz
+          tar -xf gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu.tar.xz
+
+      - name: Set up EDK2 environment and build Bsa.efi
+        run: |
+          cd edk2
+          export GCC49_AARCH64_PREFIX=/opt/cross/gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-
+          export PACKAGES_PATH=$PWD/edk2-libc
+          source edksetup.sh
+          make -C BaseTools/Source/C
+          source ShellPkg/Application/bsa-acs/tools/scripts/acsbuild.sh
+      - name: Save Bsa.efi as an artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: Bsa_dt_target.efi
+          path: edk2/Build/Shell/DEBUG_GCC49/AARCH64/Bsa.efi
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Base System Architecture - Architecture Compliance Suite
 
+[![BSA-ACS UEFI Build](https://github.com/ARM-software/bsa-acs/actions/workflows/build-bsa-uefi.yml/badge.svg?event=schedule)](https://github.com/ARM-software/bsa-acs/actions/workflows/build-bsa-uefi.yml)
 
 ## Base System Architecture
 **Base System Architecture** (BSA) specification describes a hardware system architecture based on the Arm 64-bit architecture. System software such as operating systems, hypervisors, and firmware rely on this. It addresses PE features and key aspects of system architecture.

--- a/patches/edk2-202208-bsa-acpi.diff
+++ b/patches/edk2-202208-bsa-acpi.diff
@@ -1,0 +1,21 @@
+diff --git a/ShellPkg/ShellPkg.dsc b/ShellPkg/ShellPkg.dsc
+index 38fde3dc71..c329cb0030 100644
+--- a/ShellPkg/ShellPkg.dsc
++++ b/ShellPkg/ShellPkg.dsc
+@@ -22,6 +22,8 @@
+ !include MdePkg/MdeLibs.dsc.inc
+ 
+ [LibraryClasses.common]
++  BsaValLib|ShellPkg/Application/bsa-acs/val/BsaValLib.inf
++  BsaPalLib|ShellPkg/Application/bsa-acs/platform/pal_uefi_acpi/BsaPalLib.inf
+   UefiApplicationEntryPoint|MdePkg/Library/UefiApplicationEntryPoint/UefiApplicationEntryPoint.inf
+   UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf
+   UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
+@@ -87,6 +89,7 @@
+   # Build all the libraries when building this package.
+   # This helps developers test changes and how they affect the package.
+   #
++  ShellPkg/Application/bsa-acs/uefi_app/BsaAcs.inf
+   ShellPkg/Library/UefiShellLib/UefiShellLib.inf
+   ShellPkg/Library/UefiShellAcpiViewCommandLib/UefiShellAcpiViewCommandLib.inf
+   ShellPkg/Library/UefiShellCommandLib/UefiShellCommandLib.inf

--- a/patches/edk2-202208-bsa-dt.diff
+++ b/patches/edk2-202208-bsa-dt.diff
@@ -1,0 +1,37 @@
+diff --git a/MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.c b/MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.c
+index f0a8b9fe62..e41e0de3e0 100644
+--- a/MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.c
++++ b/MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.c
+@@ -90,8 +90,8 @@ UefiHiiServicesLibConstructor (
+   //
+   // Retrieve the pointer to the UEFI HII Config Routing Protocol
+   //
+-  Status = gBS->LocateProtocol (&gEfiHiiConfigRoutingProtocolGuid, NULL, (VOID **)&gHiiConfigRouting);
+-  ASSERT_EFI_ERROR (Status);
++  //Status = gBS->LocateProtocol (&gEfiHiiConfigRoutingProtocolGuid, NULL, (VOID **)&gHiiConfigRouting);
++  //ASSERT_EFI_ERROR (Status);
+ 
+   //
+   // Retrieve the pointer to the optional UEFI HII Font Protocol
+diff --git a/ShellPkg/ShellPkg.dsc b/ShellPkg/ShellPkg.dsc
+index 38fde3dc71..559c2217d3 100644
+--- a/ShellPkg/ShellPkg.dsc
++++ b/ShellPkg/ShellPkg.dsc
+@@ -22,6 +22,9 @@
+ !include MdePkg/MdeLibs.dsc.inc
+ 
+ [LibraryClasses.common]
++  FdtLib|EmbeddedPkg/Library/FdtLib/FdtLib.inf
++  BsaValLib|ShellPkg/Application/bsa-acs/val/BsaValLib.inf
++  BsaPalLib|ShellPkg/Application/bsa-acs/platform/pal_uefi_dt/BsaPalLib.inf
+   UefiApplicationEntryPoint|MdePkg/Library/UefiApplicationEntryPoint/UefiApplicationEntryPoint.inf
+   UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf
+   UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
+@@ -87,6 +90,7 @@
+   # Build all the libraries when building this package.
+   # This helps developers test changes and how they affect the package.
+   #
++  ShellPkg/Application/bsa-acs/uefi_app/BsaAcs.inf
+   ShellPkg/Library/UefiShellLib/UefiShellLib.inf
+   ShellPkg/Library/UefiShellAcpiViewCommandLib/UefiShellAcpiViewCommandLib.inf
+   ShellPkg/Library/UefiShellCommandLib/UefiShellCommandLib.inf


### PR DESCRIPTION
- added actions YAML and required edk2 patches
- added build-status badge for scheduled cron.
- the workflow as two jobs for acpi and dt targets.