### PR TITLE
UART_BASE Type is changed to uint64_t.

### DIFF
--- a/test_pool/peripherals/operating_system/test_os_d005.c
+++ b/test_pool/peripherals/operating_system/test_os_d005.c
@@ -74,7 +74,7 @@ payload()
   uint32_t ier_scratch3;
   uint32_t mcr_reg;
   uint32_t msr_status;
-  uint32_t uart_base;
+  uint64_t uart_base;
   uint32_t lcr_reg;
   uint32_t lcr_scratch2;
   uint32_t lcr_scratch3;
@@ -143,7 +143,7 @@ payload()
               }
           }
 
-          val_print(ACS_PRINT_ERR, "\nDEBUG: uart_base %X", uart_base);
+          val_print(ACS_PRINT_ERR, "\nDEBUG: uart_base %llx", uart_base);
           val_print(ACS_PRINT_ERR, "\nDEBUG: access_width %d", access_width);
 
 


### PR DESCRIPTION
-The defined type of uart_base is changed to uint64_t -The UART_BASE print modifier is changed from 'X' to "llX'

Fixes: https://github.com/ARM-software/arm-systemready/issues/105