### PR TITLE
PE tests 9, 11, 12, and 54 are made more verbose on failure

### DIFF
--- a/test_pool/pe/operating_system/test_os_c009.c
+++ b/test_pool/pe/operating_system/test_os_c009.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018,2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018,2021,2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,18 +28,23 @@ payload()
 {
   uint64_t data = 0;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+  uint32_t primary_pe_idx = val_pe_get_primary_index();
 
   /* Check ID_AA64DFR0_EL1[11:8] for PMUver */
   data = VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64DFR0_EL1), 8, 11);
 
   if ((data != 0x0) && (data != 0xF)) {
-    /* PMCR_EL0 Bits 15:11 for Number of counters. */
-    data = VAL_EXTRACT_BITS(val_pe_reg_read(PMCR_EL0), 11, 15);
-    if (data > 3)
-        val_set_status(index, RESULT_PASS(TEST_NUM, 1));
-    else
-        val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
-
+      /* PMCR_EL0 Bits 15:11 for Number of counters. */
+      data = VAL_EXTRACT_BITS(val_pe_reg_read(PMCR_EL0), 11, 15);
+      if (data > 3)
+          val_set_status(index, RESULT_PASS(TEST_NUM, 1));
+      else {
+          if (index == primary_pe_idx) {
+              val_print(ACS_PRINT_ERR,
+              "\n       Number of PMU counters reported: %d, expected >= 4", data);
+          }
+          val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
+      }
   } else {
       val_set_status(index, RESULT_FAIL(TEST_NUM, 2));
   }

--- a/test_pool/pe/operating_system/test_os_c012.c
+++ b/test_pool/pe/operating_system/test_os_c012.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018,2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018,2021,2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,14 +28,21 @@ payload()
 {
   uint64_t data = 0;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+  uint32_t primary_pe_idx = val_pe_get_primary_index();
 
-  data = val_pe_reg_read(ID_AA64DFR0_EL1);
+  data = val_pe_reg_read(ID_AA64DFR0_EL1);  /* bits 23:20 for number of synchronous
+                                               watchpoints - 1 */
+  data = (((data >> 20) & 0xF) > 2) + 1;    /* number of synchronous watchpoints */
 
-  if (((data >> 20) & 0xF) > 2) //bits 23:20 for Number of watchpoints - 1
-        val_set_status(index, RESULT_PASS(TEST_NUM, 1));
-  else
-        val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
-
+  if (data > 3)
+      val_set_status(index, RESULT_PASS(TEST_NUM, 1));
+  else {
+      if (index == primary_pe_idx) {
+          val_print(ACS_PRINT_ERR,
+          "\n       Number of synchronous watchpoints reported: %d, expected > 3", data);
+      }
+      val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
+  }
   return;
 
 }

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -76,6 +76,7 @@ uint32_t val_pe_get_gmain_gsiv(uint32_t index);
 uint64_t val_pe_get_mpid(void);
 uint32_t val_pe_get_index_mpid(uint64_t mpid);
 uint32_t val_pe_install_esr(uint32_t exception_type, void (*esr)(uint64_t, void *));
+uint32_t val_pe_get_primary_index(void);
 
 void     val_execute_on_pe(uint32_t index, void (*payload)(void), uint64_t args);
 int      val_suspend_pe(uint64_t entry, uint32_t context_id);

--- a/val/src/acs_pe_infra.c
+++ b/val/src/acs_pe_infra.c
@@ -32,6 +32,8 @@ PE_INFO_TABLE *g_pe_info_table;
 **/
 ARM_SMC_ARGS g_smc_args;
 
+/* global variable to store primary PE index */
+uint32_t g_primary_pe_index = 0;
 
 /**
   @brief   This API will call PAL layer to fill in the PE information
@@ -76,6 +78,13 @@ val_pe_create_info_table(uint64_t *pe_info_table)
       val_print(ACS_PRINT_ERR, "\n *** CRITICAL ERROR: Num PE is 0x0 ***\n", 0);
       return ACS_STATUS_ERR;
   }
+
+  /* store primary PE index for debug message printing purposes on
+     multi PE tests */
+  g_primary_pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
+  val_print(ACS_PRINT_DEBUG, " PE_INFO: Primary PE index       : %4d \n",
+            g_primary_pe_index);
+
   return ACS_STATUS_PASS;
 }
 
@@ -382,4 +391,18 @@ val_pe_cache_clean_range(uint64_t start_addr, uint64_t length)
       aligned_addr += line_length;
   }
 #endif
+}
+
+
+/**
+  @brief   This API returns the index of primary PE on which system is booted.
+           1. Caller       -  Test Suite, VAL
+           2. Prerequisite -  val_create_peinfo_table
+  @param   None
+  @return  Primary PE index.
+**/
+uint32_t
+val_pe_get_primary_index(void)
+{
+  return g_primary_pe_index;
 }


### PR DESCRIPTION
Fixes:#199

- Added prints which outputs data reported by the system and what is expected for primary PE.