### PR TITLE
Removed unused command line options from UEFI help.

### DIFF
--- a/uefi_app/BsaAcsMain.c
+++ b/uefi_app/BsaAcsMain.c
@@ -279,8 +279,6 @@ HelpMsg (
          "-hyp    Enable the execution of hypervisor tests\n"
          "-ps     Enable the execution of platform security tests\n"
          "-dtb    Enable the execution of dtb dump\n"
-         "-rciep  Enable running pcie tests for RCiEP\n"
-         "-iep    Enable running pcie tests for iEP\n"
          "-sbsa   Enable sbsa requirements for bsa binary\n"
          "-el1physkip Skips EL1 register checks\n"
   );


### PR DESCRIPTION
  - Resolves: #210
  - Removed -rciep and -iep options in UEFI help message which are not being used anymore.