### PR TITLE
Better messaging of capability check tests

### DIFF
--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -1733,6 +1733,7 @@ uint32_t val_pcie_bitfield_check(uint32_t bdf, uint64_t *bitfield_entry)
 
   uint32_t bf_value;
   uint32_t cap_base;
+  uint32_t id;
   uint32_t shft_cnt;
   uint32_t reg_value;
   uint32_t reg_offset;
@@ -1760,9 +1761,11 @@ uint32_t val_pcie_bitfield_check(uint32_t bdf, uint64_t *bitfield_entry)
           break;
       case PCIE_CAP:
           status = val_pcie_find_capability(bdf, PCIE_CAP, bf_entry->cap_id, &cap_base);
+          id = bf_entry->cap_id;
           break;
       case PCIE_ECAP:
           status = val_pcie_find_capability(bdf, PCIE_ECAP, bf_entry->ecap_id, &cap_base);
+          id = bf_entry->ecap_id;
           break;
       default:
           val_print(ACS_PRINT_ERR, "\n       Invalid reg_type : 0x%x  ", bf_entry->reg_type);
@@ -1771,7 +1774,8 @@ uint32_t val_pcie_bitfield_check(uint32_t bdf, uint64_t *bitfield_entry)
 
   if (status != PCIE_SUCCESS)
   {
-      val_print(ACS_PRINT_ERR, "\n       PCIe Capability not found for BDF 0x%x", bdf);
+      val_print(ACS_PRINT_ERR, "\n       PCIe Capability 0x%x", id);
+      val_print(ACS_PRINT_ERR, " not found for BDF 0x%x", bdf);
       return status;
   }
 


### PR DESCRIPTION
- Better messaging by adding prints of the capability id that is not found for register check tests