### PR TITLE
Added prints to inform SPCR table not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ The Arm SystemReady ACS test suite may run at a higher privilege level. An attac
 
 ## Limitations
 
+ - For systems that present firmware compliant to SBBR, BSA depends on SPCR acpi table to get UART information.
+   UEFI console setting must be set to "serial" on these systems.
  - ITS test are available only for systems that present firmware compliant to SBBR.
  - Some PCIe and Exerciser test are dependent on PCIe features supported by the test system.
    Please fill the required API's with test system information.

--- a/platform/pal_uefi_acpi/src/pal_peripherals.c
+++ b/platform/pal_uefi_acpi/src/pal_peripherals.c
@@ -141,6 +141,10 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
     per_info->interface_type = spcr->InterfaceType;
     per_info++;
   }
+  else {
+    bsa_print(ACS_PRINT_DEBUG, L"  WARNING:SPCR acpi table not found\n", 0);
+    bsa_print(ACS_PRINT_DEBUG, L"  UEFI console setting must be set to serial\n", 0);
+ }
 
   if (PLATFORM_GENERIC_UART_BASE) {
     peripheralInfoTable->header.num_uart++;


### PR DESCRIPTION
For systems that present firmware compliant to SBBR, BSA depends on SPCR acpi table to get UART information.
UEFI console setting must be set to "serial" on these systems