### PR TITLE
Check PMUv3 support before reading PMU registers

### DIFF
--- a/test_pool/memory_map/operating_system/test_os_m002.c
+++ b/test_pool/memory_map/operating_system/test_os_m002.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2021, 2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -71,6 +71,7 @@ payload()
           goto normal_mem_test;
       }
 
+      val_print(ACS_PRINT_DEBUG, "\n       Device Mem Address : 0x%llx", addr);
       /* Access must not cause a deadlock */
       original_value = *((volatile addr_t*)addr);
       *((volatile addr_t*)addr) = original_value;
@@ -96,7 +97,7 @@ normal_mem_test:
                                    " instance %d", instance);
           return;
       }
-
+      val_print(ACS_PRINT_DEBUG, "\n       Normal Mem Address : 0x%llx", addr);
       /* Access must not cause a deadlock */
       original_value = *((volatile addr_t*)addr);
       *((volatile addr_t*)addr) = original_value;

--- a/test_pool/pe/operating_system/test_os_c001.c
+++ b/test_pool/pe/operating_system/test_os_c001.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018,2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021, 2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +28,7 @@
 #define SPE               2
 #define LOR               3
 #define AA32              4
+#define PMUV3             5
 
 #define MASK_AA64MMFR0    0xF
 #define MASK_MIDR         0x00F0FFFF
@@ -79,9 +80,9 @@ reg_details reg_list[] = {
     {MVFR0_EL1,        0x0,            "MVFR0_EL1"       , AA32},
     {MVFR1_EL1,        0x0,            "MVFR1_EL1"       , AA32},
     {MVFR2_EL1,        0x0,            "MVFR2_EL1"       , AA32},
-    {PMCEID0_EL0,      0x0,            "PMCEID0_EL0"     , 0x0 },
-    {PMCEID1_EL0,      0x0,            "PMCEID1_EL0"     , 0x0 },
-    {PMCR_EL0,         MASK_PMCR,      "PMCR_EL0"        , 0x0 },
+    {PMCEID0_EL0,      0x0,            "PMCEID0_EL0"     , PMUV3},
+    {PMCEID1_EL0,      0x0,            "PMCEID1_EL0"     , PMUV3},
+    {PMCR_EL0,         MASK_PMCR,      "PMCR_EL0"        , PMUV3},
     {PMBIDR_EL1,       0x0,            "PMBIDR_EL1"      , SPE },
     {PMSIDR_EL1,       0x0,            "PMSIDR_EL1"      , SPE },
     {ERRIDR_EL1,       0x0,            "ERRIDR_EL1"      , RAS },
@@ -133,6 +134,15 @@ return_reg_value(uint32_t reg, uint8_t dependency)
         temp = val_pe_reg_read(ID_AA64PFR0_EL1);
         temp = (temp & 1);
         if(temp == 0)
+            return val_pe_reg_read(reg);
+        else
+            return 0;
+        break;
+
+    case PMUV3: // If PMUv3 is not supported, then skip register check
+        temp = val_pe_reg_read(ID_AA64DFR0_EL1);
+        temp = (temp >> 8) & 0xf;
+        if (temp != 0 && temp != 0xf)
             return val_pe_reg_read(reg);
         else
             return 0;


### PR DESCRIPTION
Fixes for #249 - 

PE test 1: Check for PMuv3 support before reading PMU registers.
Mem test 102: Added debug print for memory address 