### PR TITLE
Fixes irq_to_hwirq() API should have a return type of uint64

### DIFF
--- a/platform/pal_baremetal/common/include/pal_common_support.h
+++ b/platform/pal_baremetal/common/include/pal_common_support.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -509,7 +509,7 @@ typedef struct {
   uint32_t  vector_lower_addr; ///< Base Address of the controller
   uint32_t  vector_data;       ///< Base Address of the controller
   uint32_t  vector_control;    ///< IRQ to install an ISR
-  uint32_t  vector_irq_base;   ///< Base IRQ for the vectors in the block
+  uint64_t  vector_irq_base;   ///< Base IRQ for the vectors in the block
   uint32_t  vector_n_irqs;     ///< Number of irq vectors in the block
   uint32_t  vector_mapped_irq_base; ///< Mapped IRQ number base for this MSI
 }PERIPHERAL_VECTOR_BLOCK;

--- a/platform/pal_uefi_acpi/include/pal_uefi.h
+++ b/platform/pal_uefi_acpi/include/pal_uefi.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -389,7 +389,7 @@ typedef struct {
   UINT32         vector_lower_addr; ///< Base Address of the controller
   UINT32         vector_data;       ///< Base Address of the controller
   UINT32         vector_control;    ///< IRQ to install an ISR
-  UINT32         vector_irq_base;   ///< Base IRQ for the vectors in the block
+  UINT64         vector_irq_base;   ///< Base IRQ for the vectors in the block
   UINT32         vector_n_irqs;     ///< Number of irq vectors in the block
   UINT32         vector_mapped_irq_base; ///< Mapped IRQ number base for this MSI
 }PERIPHERAL_VECTOR_BLOCK;

--- a/platform/pal_uefi_dt/include/pal_uefi.h
+++ b/platform/pal_uefi_dt/include/pal_uefi.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -390,7 +390,7 @@ typedef struct {
   UINT32         vector_lower_addr; ///< Base Address of the controller
   UINT32         vector_data;       ///< Base Address of the controller
   UINT32         vector_control;    ///< IRQ to install an ISR
-  UINT32         vector_irq_base;   ///< Base IRQ for the vectors in the block
+  UINT64         vector_irq_base;   ///< Base IRQ for the vectors in the block
   UINT32         vector_n_irqs;     ///< Number of irq vectors in the block
   UINT32         vector_mapped_irq_base; ///< Mapped IRQ number base for this MSI
 }PERIPHERAL_VECTOR_BLOCK;

--- a/test_pool/pcie/operating_system/test_os_p064.c
+++ b/test_pool/pcie/operating_system/test_os_p064.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,8 +64,8 @@ check_list_duplicates (PERIPHERAL_VECTOR_LIST *list_one, PERIPHERAL_VECTOR_LIST 
 
   uint32_t fcount = 0;
   uint32_t scount = 0;
-  uint32_t irq_start1, irq_end1;
-  uint32_t irq_start2, irq_end2;
+  uint64_t irq_start1, irq_end1;
+  uint64_t irq_start2, irq_end2;
 
   flist_node = list_one;
   slist_node = list_two;

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -635,7 +635,7 @@ typedef struct {
   uint32_t         vector_lower_addr; ///< Base Address of the controller
   uint32_t         vector_data;       ///< Base Address of the controller
   uint32_t         vector_control;    ///< IRQ to install an ISR
-  uint32_t         vector_irq_base;   ///< Base IRQ for the vectors in the block
+  uint64_t         vector_irq_base;   ///< Base IRQ for the vectors in the block
   uint32_t         vector_n_irqs;     ///< Number of irq vectors in the block
   uint32_t         vector_mapped_irq_base; ///< Mapped IRQ number base for this MSI
 }PERIPHERAL_VECTOR_BLOCK;


### PR DESCRIPTION
Fixes irq_to_hwirq() API should have a return type of uint64