### PR TITLE
Dump only the value of BITS which are under test

### DIFF
--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -1833,8 +1833,10 @@ uint32_t val_pcie_bitfield_check(uint32_t bdf, uint64_t *bitfield_entry)
   {
       val_print(ACS_PRINT_ERR, "\n       BDF 0x%x : ", bdf);
       val_print(ACS_PRINT_ERR, bf_entry->err_str2, 0);
-      val_print(ACS_PRINT_ERR, ": 0x%x", reg_overwrite_value);
-      val_print(ACS_PRINT_ERR, " instead of 0x%x", reg_value);
+      val_print(ACS_PRINT_ERR, ": 0x%x",
+                          reg_overwrite_value >> REG_SHIFT(alignment_byte_cnt, bf_entry->start));
+      val_print(ACS_PRINT_ERR, " instead of 0x%x",
+                          reg_value >> REG_SHIFT(alignment_byte_cnt, bf_entry->start));
       if (!val_strncmp(bf_entry->err_str2, "WARNING", WARN_STR_LEN))
           return 0;
       return 1;


### PR DESCRIPTION
Fixes #255

For PCIe bitfield values and attributes tests, logs captures value of offset where the BITS under test are present.
Debug print is now modified to only prints value of BITS under test 