### PR TITLE
BSA Errata Mantis - 590 & 596

### DIFF
--- a/val/include/bsa_acs_pe.h
+++ b/val/include/bsa_acs_pe.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2020,2022-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2020,2022-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -165,7 +165,8 @@ typedef enum {
   DBGBCR12_EL1,
   DBGBCR13_EL1,
   DBGBCR14_EL1,
-  DBGBCR15_EL1
+  DBGBCR15_EL1,
+  ID_AA64ISAR2_EL1
 } BSA_ACS_PE_REGS;
 
 uint64_t ArmReadMpidr(void);
@@ -187,6 +188,8 @@ uint64_t AA64ReadCtr(void);
 uint64_t AA64ReadIsar0(void);
 
 uint64_t AA64ReadIsar1(void);
+
+uint64_t AA64ReadIsar2(void);
 
 uint64_t AA64ReadSctlr3(void);
 

--- a/val/src/AArch64/PeRegSysSupport.S
+++ b/val/src/AArch64/PeRegSysSupport.S
@@ -1,5 +1,5 @@
 #/** @file
-# Copyright (c) 2016-2020,2021 Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2016-2020, 2021, 2024, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,6 +48,7 @@ GCC_ASM_EXPORT (AA64ReadCtr)
 GCC_ASM_EXPORT (ArmReadMmfr0)
 GCC_ASM_EXPORT (AA64ReadIsar0)
 GCC_ASM_EXPORT (AA64ReadIsar1)
+GCC_ASM_EXPORT (AA64ReadIsar2)
 GCC_ASM_EXPORT (AA64ReadSctlr3)
 GCC_ASM_EXPORT (AA64ReadSctlr2)
 GCC_ASM_EXPORT (AA64ReadSctlr1)
@@ -170,6 +171,10 @@ ASM_PFX(AA64ReadIsar0):
 
 ASM_PFX(AA64ReadIsar1):
   mrs   x0, id_aa64isar1_el1
+  ret
+
+ASM_PFX(AA64ReadIsar2):
+  mrs   x0, id_aa64isar2_el1
   ret
 
 ASM_PFX(AA64ReadSctlr3):

--- a/val/src/acs_pe.c
+++ b/val/src/acs_pe.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -132,6 +132,8 @@ val_pe_reg_read(uint32_t reg_id)
           return AA64ReadIsar0();
       case ID_AA64ISAR1_EL1:
           return AA64ReadIsar1();
+      case ID_AA64ISAR2_EL1:
+          return AA64ReadIsar2();
       case SCTLR_EL3:
           return AA64ReadSctlr3();
       case SCTLR_EL2:


### PR DESCRIPTION
BSA Errata Mantis - 590 & 596

-The B_PE_15 is changed to check for both generic and address auth 
-The rule is changed to check both QARMA5 and QARMA3 algorithm 
-The implementation defined algorithm is not recommended