### PR TITLE
Restoring default values of ACS Ctrl register

### DIFF
--- a/test_pool/exerciser/operating_system/test_os_e001.c
+++ b/test_pool/exerciser/operating_system/test_os_e001.c
@@ -224,11 +224,15 @@ payload(void)
   uint32_t test_skip;
   uint64_t bar_base;
   uint32_t curr_bdf_failed = 0;
+  pcie_device_bdf_table *bdf_tbl_ptr;
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
 
   fail_cnt = 0;
   test_skip = 1;
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
   instance = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+
+  uint32_t acsctrl_default[bdf_tbl_ptr->num_entries][1];
 
   /* Check If PCIe Hierarchy supports P2P. */
   if (val_pcie_p2p_support() == NOT_IMPLEMENTED) {
@@ -245,6 +249,10 @@ payload(void)
     val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 2));
     return;
   }
+
+  /* Store ACS Control reg bits in an array for every Exerciser and reset them
+     to default at the end. */
+  val_pcie_read_acsctrl(acsctrl_default);
 
   while (instance-- != 0)
   {
@@ -312,6 +320,9 @@ payload(void)
       /* Clear error status bits of the Req RP*/
       clear_error_status(req_rp_bdf);
   }
+
+  /* Write back default values of ACS Control reg. */
+  val_pcie_write_acsctrl(acsctrl_default);
 
   if (test_skip == 1)
       val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 3));

--- a/test_pool/exerciser/operating_system/test_os_e002.c
+++ b/test_pool/exerciser/operating_system/test_os_e002.c
@@ -359,6 +359,7 @@ payload(void)
 
   tbl_index = 0;
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  uint32_t acsctrl_default[bdf_tbl_ptr->num_entries][1];
 
   /* Check If PCIe Hierarchy supports P2P. */
   if (val_pcie_p2p_support() == NOT_IMPLEMENTED) {
@@ -375,6 +376,9 @@ payload(void)
     val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 2));
     return;
   }
+
+  /* Store ACS Control reg bits in an array for every BDF and reset them to default at the end. */
+  val_pcie_read_acsctrl(acsctrl_default);
 
   while (tbl_index < bdf_tbl_ptr->num_entries)
   {
@@ -471,11 +475,14 @@ payload(void)
                   val_print(ACS_PRINT_ERR, "\n       ACS Redirected Req Check Failed for 0x%x",
                                                                                    req_rp_bdf);
               }
-           }
+         }
       }
 
 
   }
+
+  /* Write back default values of ACS Control reg. */
+  val_pcie_write_acsctrl(acsctrl_default);
 
   if (test_skip == 1)
       val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 3));

--- a/val/include/bsa_acs_pcie_spec.h
+++ b/val/include/bsa_acs_pcie_spec.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -217,6 +217,7 @@
 #define DSTS_SHIFT     16
 #define DS_UNCORR_MASK 0x6
 #define DS_CORR_MASK   0x1
+#define ACSCTRL_SHIFT  0x0F
 
 /* DPC Capability struct offsets and shifts */
 #define DPC_CTRL_OFFSET        0x4

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -234,6 +234,8 @@ uint32_t val_pcie_is_sig_target_abort(uint32_t bdf);
 void val_pcie_clear_sig_target_abort(uint32_t bdf);
 uint32_t val_pcie_link_cap_support(uint32_t bdf);
 uint32_t val_pcie_mem_get_offset(uint32_t bdf, PCIE_MEM_TYPE_INFO_e mem_type);
+void val_pcie_read_acsctrl(uint32_t arr[][1]);
+void val_pcie_write_acsctrl(uint32_t arr[][1]);
 
 /* IO-VIRT APIs */
 typedef enum {

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -2512,3 +2512,69 @@ uint32_t val_pcie_scan_bridge_devices_and_check_memtype(uint32_t bdf)
 
   return status;
 }
+
+/**
+  @brief  Read ACS Control register for all the BDFs and store it in an array.
+
+  @param  arr - 2-D array to store tbl_index and ACS Control reg values.
+  @return None
+
+**/
+void val_pcie_read_acsctrl(uint32_t arr[][1])
+{
+  uint32_t cap_base;
+  uint32_t reg_value;
+  uint32_t bdf;
+  uint32_t tbl_index = 0;
+
+  /* Get the PCI Express Capability structure offset and
+   * use that offset to read Access Control Service register
+   */
+
+  while (tbl_index < g_pcie_bdf_table->num_entries)
+  {
+      bdf = g_pcie_bdf_table->device[tbl_index].bdf;
+      val_pcie_find_capability(bdf, PCIE_ECAP, ECID_ACS, &cap_base);
+      val_pcie_read_cfg(bdf, cap_base + ACSCR_OFFSET, &reg_value);
+      arr[tbl_index][0] = reg_value;
+
+      val_print(ACS_PRINT_INFO, "\n       ACS Control Reg value read for BDF 0x%x is", bdf);
+      val_print(ACS_PRINT_INFO, " %llx", arr[tbl_index][0]);
+      tbl_index++;
+  }
+
+  return;
+}
+
+/**
+  @brief  Write back the default ACS Control register for all the BDFs which were stored in array
+          before.
+
+  @param  arr - 2-D array to store tbl_index and ACS Control reg values.
+  @return None
+
+**/
+void val_pcie_write_acsctrl(uint32_t arr[][1])
+{
+
+  uint32_t cap_base;
+  uint32_t bdf;
+  uint32_t tbl_index = 0;
+
+  /* Get the PCI Express Capability structure offset and
+   * use that offset to write Access Control Service register
+   */
+
+  while (tbl_index < g_pcie_bdf_table->num_entries)
+  {
+      bdf = g_pcie_bdf_table->device[tbl_index].bdf;
+      val_pcie_find_capability(bdf, PCIE_ECAP, ECID_ACS, &cap_base);
+      val_pcie_write_cfg(bdf, cap_base + ACSCR_OFFSET, arr[tbl_index][0]);
+
+      val_print(ACS_PRINT_INFO, "\n       ACS Control Reg value written for BDF 0x%x is", bdf);
+      val_print(ACS_PRINT_INFO, " %llx", arr[tbl_index][0]);
+      tbl_index++;
+  }
+
+  return;
+}


### PR DESCRIPTION
 - Introduced APIs to read, store default ACS control register bits and to write them back at the end of the test.
 - Changes made to exerciser tests e001 and e002 to restore default ACS control reg values.