### PR TITLE
Changes for sbsa linux build

### DIFF
--- a/val/sbsa/include/sbsa_acs_ete.h
+++ b/val/sbsa/include/sbsa_acs_ete.h
@@ -18,9 +18,9 @@
 #ifndef __SBSA_AVS_ETE_H
 #define __SBSA_AVS_ETE_H
 
-#define TRBLIMITR_EL1_E     (1 << 0)
-#define TRBLIMITR_EL1_nVM   (1 << 5)
-#define TRBLIMITR_EL1_XE    (1 << 6)
+#define ACS_TRBLIMITR_EL1_E     (1 << 0)
+#define ACS_TRBLIMITR_EL1_nVM   (1 << 5)
+#define ACS_TRBLIMITR_EL1_XE    (1 << 6)
 
 #define TR_I_ADDR_CTXT_L_32IS0  0x82
 #define TR_I_ADDR_CTXT_L_32IS1  0x83

--- a/val/sbsa/src/sbsa_acs_ete.c
+++ b/val/sbsa/src/sbsa_acs_ete.c
@@ -136,9 +136,9 @@ uint64_t val_ete_generate_trace(uint64_t buffer_addr, uint32_t self_hosted_trace
 
     /* Update TRBLIMITR_EL1_E/XE Based on SelfHostedTraceEnabled & Enable Trace Buffer Unit */
     if (self_hosted_trace_enabled == SH_TRACE_ENABLE_TRUE)
-        AA64EnableTRBUTrace(index, buffer_addr, TRBLIMITR_EL1_E);
+        AA64EnableTRBUTrace(index, buffer_addr, ACS_TRBLIMITR_EL1_E);
     else
-        AA64EnableTRBUTrace(index, buffer_addr, TRBLIMITR_EL1_XE | TRBLIMITR_EL1_nVM);
+        AA64EnableTRBUTrace(index, buffer_addr, ACS_TRBLIMITR_EL1_XE | ACS_TRBLIMITR_EL1_nVM);
 
     AA64EnableETETrace();
 

--- a/val/sbsa/src/sbsa_execute_test.c
+++ b/val/sbsa/src/sbsa_execute_test.c
@@ -22,18 +22,21 @@
 
 // SBSA Specific Headers
 #include "sbsa/include/sbsa_val_interface.h"
+#include "sbsa/include/sbsa_acs_smmu.h"
+#include "sbsa/include/sbsa_acs_pcie.h"
+
+#ifndef TARGET_LINUX
 #include "sbsa/include/sbsa_acs_pe.h"
 #include "sbsa/include/sbsa_acs_memory.h"
 #include "sbsa/include/sbsa_acs_gic.h"
-#include "sbsa/include/sbsa_acs_smmu.h"
 #include "sbsa/include/sbsa_acs_wd.h"
-#include "sbsa/include/sbsa_acs_pcie.h"
 #include "sbsa/include/sbsa_acs_exerciser.h"
 #include "sbsa/include/sbsa_acs_mpam.h"
 #include "sbsa/include/sbsa_acs_pmu.h"
 #include "sbsa/include/sbsa_acs_ras.h"
 #include "sbsa/include/sbsa_acs_nist.h"
 #include "sbsa/include/sbsa_acs_ete.h"
+#endif
 
 extern uint32_t pcie_bdf_table_list_flag;
 extern pcie_device_bdf_table *g_pcie_bdf_table;


### PR DESCRIPTION
Linux also exposes trace buffer related register with same macro name as used in ACS code which is resulting in redefine error build failure.
Appending ACS_ in trace buffer registers macro.