### PR TITLE
Add memory-model consistency tests (litmus tests) to bsa-acs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+mem_test/kvm-unit-tests

--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ To provide a baseline, the build steps to integrate and run the Bare-metal tests
 
 For details on generating the binaries to run on Bare-metal environment, refer [README.md](pal/baremetal/README.md)
 
+## ACS build steps - Memory model consistency tests
+To evaluate the correctness and consistency of a system's memory model, memory model consistency tests (litmus tests) can be optionally built into BSA UEFI application,
+the build and run steps are provided in [mem_test/README.md](mem_test/README.md).
+
 ## Security implication
 The Arm SystemReady ACS test suite may run at a higher privilege level. An attacker may utilize these tests to elevate the privilege which can potentially reveal the platform security assets. To prevent the leakage of Secure information, Arm strongly recommends that you run the ACS test suite only on development platforms. If it is run on production systems, the system should be scrubbed after running the test suite.
 

--- a/mem_test/LibCFlat.inf
+++ b/mem_test/LibCFlat.inf
@@ -1,0 +1,92 @@
+## @file
+#  Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+#  SPDX-License-Identifier : Apache-2.0
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = LibCFlat
+  FILE_GUID                      = 49c4f0f6-0151-4280-a58c-8344ea411d31
+  MODULE_TYPE                    = UEFI_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = LibCFlat|UEFI_APPLICATION UEFI_DRIVER
+
+[Sources.common]
+
+  kvm-unit-tests/lib/argv.c
+  kvm-unit-tests/lib/printf.c
+  kvm-unit-tests/lib/string.c
+  kvm-unit-tests/lib/abort.c
+  kvm-unit-tests/lib/report.c
+  kvm-unit-tests/lib/stack.c
+  kvm-unit-tests/lib/arm64/processor.c
+  kvm-unit-tests/lib/arm64/spinlock.c
+  kvm-unit-tests/lib/arm64/gic-v3-its.c
+  kvm-unit-tests/lib/arm64/gic-v3-its-cmd.c
+  litmus-tests/utils.c
+  litmus-tests/kvm_timeofday.c
+  litmus-tests/litmus_rand.c
+  kvm-unit-tests/lib/util.c
+  kvm-unit-tests/lib/getchar.c
+  kvm-unit-tests/lib/alloc_phys.c
+  kvm-unit-tests/lib/alloc_page.c
+  kvm-unit-tests/lib/vmalloc.c
+  kvm-unit-tests/lib/alloc.c
+  kvm-unit-tests/lib/devicetree.c
+  kvm-unit-tests/lib/acpi.c
+  kvm-unit-tests/lib/pci.c
+  kvm-unit-tests/lib/pci-host-generic.c
+  kvm-unit-tests/lib/pci-testdev.c
+  kvm-unit-tests/lib/virtio.c
+  kvm-unit-tests/lib/virtio-mmio.c
+  kvm-unit-tests/lib/chr-testdev.c
+  kvm-unit-tests/lib/arm/io.c
+  kvm-unit-tests/lib/arm/setup.c
+  kvm-unit-tests/lib/arm/mmu.c
+  kvm-unit-tests/lib/arm/bitops.c
+  kvm-unit-tests/lib/arm/psci.c
+  kvm-unit-tests/lib/arm/smp.c
+  kvm-unit-tests/lib/arm/delay.c
+  kvm-unit-tests/lib/arm/gic.c
+  kvm-unit-tests/lib/arm/gic-v2.c
+  kvm-unit-tests/lib/arm/gic-v3.c
+  kvm-unit-tests/lib/arm/timer.c
+  efi_bsa_entry.c
+  kvm-unit-tests/lib/auxinfo.c
+
+# adding libfdt file sources
+  kvm-unit-tests/lib/libfdt/fdt.c
+  kvm-unit-tests/lib/libfdt/fdt_ro.c
+  kvm-unit-tests/lib/libfdt/fdt_wip.c
+  kvm-unit-tests/lib/libfdt/fdt_sw.c
+  kvm-unit-tests/lib/libfdt/fdt_rw.c
+  kvm-unit-tests/lib/libfdt/fdt_strerror.c
+  kvm-unit-tests/lib/libfdt/fdt_empty_tree.c
+  kvm-unit-tests/lib/libfdt/fdt_addresses.c
+  kvm-unit-tests/lib/libfdt/fdt_overlay.c
+  kvm-unit-tests/lib/libfdt/fdt_check.c
+
+# eabi_compat.o
+  kvm-unit-tests/lib/arm/eabi_compat.c
+# for smc etc
+  memTestBsaSupport.S
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[BuildOptions]
+  GCC:*_*_*_ASM_FLAGS  = -march=armv8.2-a -I${WORKSPACE}/ShellPkg/Application/bsa-acs/mem_test/kvm-unit-tests/lib/arm64
+  GCC:*_*_*_CC_FLAGS == -g -gdwarf-4 -mstrict-align -fno-common -mno-outline-atomics -DNOSWP -std=gnu99 -ffreestanding -g -fno-strict-aliasing -Wwrite-strings -Wempty-body -Wuninitialized -Wignored-qualifiers -Wno-missing-braces -fomit-frame-pointer -fno-stack-protector -Wno-frame-address -DCONFIG_EFI -fshort-wchar -fPIC -Wclobbered -Wunused-but-set-parameter -Wmissing-parameter-type -Wold-style-declaration -Woverride-init -Wmissing-prototypes -Wstrict-prototypes -DSTRING_ARRAY_NAME=LibCFlatStrings -fno-builtin -Wall -Werror -Wno-array-bounds -include AutoGen.h -mlittle-endian -fno-short-enums -fverbose-asm -funsigned-char -ffunction-sections -fdata-sections -Wno-address -fno-asynchronous-unwind-tables -fno-unwind-tables -fno-pic -fno-pie -ffixed-x18 -mcmodel=small -O0 -DBSA_ACS -Wstrict-prototypes -I${WORKSPACE}/ShellPkg/Application/bsa-acs/mem_test/kvm-unit-tests/lib -I${WORKSPACE}/ShellPkg/Application/bsa-acs/mem_test/kvm-unit-tests/lib/libfdt -I${WORKSPACE}/ShellPkg/Application/bsa-acs/mem_test/kvm-unit-tests/lib/arm64 -fno-jump-tables
+  GCC:*_*_*_PP_FLAGS = -I ${WORKSPACE}/ShellPkg/Application/bsa-acs/mem_test/kvm-unit-tests/lib/arm64

--- a/mem_test/README.md
+++ b/mem_test/README.md
@@ -1,0 +1,69 @@
+# Memory model consistency tests
+Memory model consistency tests (litmus tests) are small parallel programs designed to evaluate the correctness and
+consistency of a computer system's memory model, particularly in the context of concurrent or parallel programming.
+These parallel payloads with specific memory access patterns are run for several iterations to observe how the system
+handles memory synchronization, caching, and reordering. By analyzing the outcomes of these tests, developers can gain
+insights into the reliability of the memory model implementation and identify any subtle bugs or inconsistencies that
+might lead to unpredictable behavior in concurrent programs.
+
+## Release details
+ - Code quality: v1.0.0 EAC
+ - The tests can be run at Silicon level.
+ - The tests checks for forbidden behaviors that memory model should not exhibit.
+ - For litmus tests scenario and instructions to analyze litmus tests log output, refer the [Memory model tests Scenario & User Guide](../mem_test/memory_model_tests_scenario_user_guide.rst).
+
+## Steps to build litmus tests into bsa-acs
+1. Setup edk2 build directory
+>          git clone --branch  edk2-stable202402 https://github.com/tianocore/edk2.git
+>          cd edk2
+>          git clone https://github.com/tianocore/edk2-libc.git
+>          git submodule update --init --recursive
+
+2. Download source files and apply edk2 patch
+>          git clone https://github.com/ARM-software/bsa-acs.git ShellPkg/Application/bsa-acs
+>          git clone https://github.com/relokin/kvm-unit-tests.git ShellPkg/Application/bsa-acs/mem_test/kvm-unit-tests
+>          git -C ShellPkg/Application/bsa-acs/mem_test/kvm-unit-tests checkout target-efi-bsa
+>          git apply ShellPkg/Application/bsa-acs/mem_test/patches/mem_test_edk2.patch
+
+3. Build bsa-acs UEFI app <br>
+Note :  Install GCC-ARM 13.2 [toolchain](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+>          export GCC49_AARCH64_PREFIX=<path to CC>arm-gnu-toolchain-13.2.Rel1-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-
+>          export PACKAGES_PATH=`pwd`/edk2-libc
+>          source edksetup.sh
+>          make -C BaseTools/Source/C
+>          source ShellPkg/Application/bsa-acs/tools/scripts/acsbuild.sh ENABLE_MEMTEST
+
+4. BSA EFI application path
+- The EFI executable file is generated at <edk2-path>/Build/Shell/DEBUG_GCC49/AARCH64/Bsa.efi
+
+## Test suite execution on QEMU platform
+1. Fetch uefi-firmware
+>          wget https://releases.linaro.org/components/kernel/uefi-linaro/16.02/release/qemu64/QEMU_EFI.fd
+
+2. Run QEMU model <br>
+**Note** : <br> 1. Follow steps provided in [Emulation environment with secondary-storage](../README.md#22-emulation-environment-with-secondary-storage) to create .img file containing Bsa.efi executable. <br> 2. Follow instructions from https://www.qemu.org/download/#source to obtain QEMU model.
+
+>          IMG_PATH=<path to .img containing Bsa.efi>
+>          QEMU_PATH=<path to QEMU model>
+>                 e.g. /data_sda/user01/qemu/qemu-7.2.0/build/qemu-system-aarch64
+>          BIOS_PATH=<pat to QEMU_EFI.fd>
+
+>          $QEMU_PATH -nodefaults -machine virt -accel tcg -cpu cortex-a57 -device pci-testdev -display none -serial stdio -bios $BIOS_PATH -drive file=$IMG_PATH,if=virtio,format=raw -smp 8 -m 512 -machine virtualization=on
+
+3. Press Esc to enter the shell prompt, and navigate to disk containing Bsa.efi, and run BSA app.
+>          Bsa.efi
+
+## Limitations
+ - The kvm-unit-tests print function depends on SPCR ACPI table for UART base address and UEFI console setting must be set to "serial". In case of non-availability of SPCR,
+   set `CONFIG_UART_EARLY_BASE` in `bsa-acs/mem_test/kvm-unit-tests/lib/arm/io.c` to UART base address of system under test, after step 2 in [build steps](#steps-to-build-litmus-tests-into-bsa-acs).
+ - Initializing memory model tests infra and transitioning from EL1 to EL2 is observed to be time-consuming (approximately 30 minutes) in systems with large PE caches. The duration of each test run varies, ranging from 1 minute in silicon to 40 minutes in certain emulated platforms like Arm FVP models.
+ - The printf implementation in kvm-unit-tests works only with a serial interface. For HDMI or other outputs, a console splitter or similar device is required.
+
+## Feedback, contributions, and support
+
+ - For feedback, use the GitHub Issue Tracker that is associated with this repository.
+ - For support, send an email to "support-systemready-acs@arm.com" with details.
+ - Arm licensees may contact Arm directly through their partner managers.
+ - Arm welcomes code contributions through GitHub pull requests. See the GitHub documentation on how to raise pull requests.
+
+*Copyright (c) 2023-2024, Arm Limited and Contributors. All rights reserved.*

--- a/mem_test/bsa_acs_litmus.h
+++ b/mem_test/bsa_acs_litmus.h
@@ -1,0 +1,55 @@
+/** @file
+ * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef __BSA_ACS_LITMUS_H__
+#define __BSA_ACS_LITMUS_H__
+
+int _X2_2B_2W_2B_dmb_2E_sys(int argc, char **argv);
+int CO_2D_MIXED_2D_20cc_2B_H(int argc, char **argv);
+int CoRR(int argc, char **argv);
+int CoRW1(int argc, char **argv);
+int CoRW2_2B_posb1b0_2B_h0(int argc, char **argv);
+int CoRW2(int argc, char **argv);
+int CoWR(int argc, char **argv);
+int CoWW(int argc, char **argv);
+int LB_2B_BEQ4(int argc, char **argv);
+int LB_2B_CSEL_2D_addr_2D_po_2B_DMB(int argc, char **argv);
+int LB_2B_CSEL_2D_rfi_2D_data_2B_DMB(int argc, char **argv);
+int LB_2B_dmb_2E_sy_2B_data_2D_wsi_2D_wsi_2B_MIXED_2B_H(int argc, char **argv);
+int LB_2B_dmb_2E_sys(int argc, char **argv);
+int LB_2B_rel_2B_BEQ2(int argc, char **argv);
+int LB_2B_rel_2B_CSEL_2D_CSEL(int argc, char **argv);
+int LB_2B_rel_2B_data(int argc, char **argv);
+int MP_2B_dmb_2E_sys(int argc, char **argv);
+int MP_2D_Koeln(int argc, char **argv);
+int R_2B_dmb_2E_sys(int argc, char **argv);
+int S_2B_dmb_2E_sys(int argc, char **argv);
+int S_2B_rel_2B_CSEL_2D_data(int argc, char **argv);
+int S_2B_rel_2B_CSEL_2D_rf_2D_reg(int argc, char **argv);
+int SB_2B_dmb_2E_sys(int argc, char **argv);
+int T10B(int argc, char **argv);
+int T10C(int argc, char **argv);
+int T15_2D_corrected(int argc, char **argv);
+int T15_2D_datadep_2D_corrected(int argc, char **argv);
+int T3_2D_bis(int argc, char **argv);
+int T3(int argc, char **argv);
+int T7(int argc, char **argv);
+int T7dep(int argc, char **argv);
+int T8_2B_BIS(int argc, char **argv);
+int T9B(int argc, char **argv);
+
+#endif

--- a/mem_test/efi_bsa_entry.c
+++ b/mem_test/efi_bsa_entry.c
@@ -1,0 +1,295 @@
+/*
+ * EFI-related functions to set up and run test cases in EFI
+ *
+ * Copyright (c) 2021, SUSE, Varad Gautam <varad.gautam@suse.com>
+ * Copyright (c) 2021, Google Inc, Zixuan Wang <zixuanwang@google.com>
+ * Copyright (c) 2023-2024, Arm Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ */
+
+#include "efi.h"
+#include <argv.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <libcflat.h>
+#include <asm/setup.h>
+#include "bsa_acs_litmus.h"
+
+/* From lib/argv.c */
+extern int __argc, __envc;
+extern char *__argv[100];
+extern char *__environ[200];
+
+efi_status_t mem_model_execute_tests(efi_handle_t handle, efi_system_table_t *sys_tab);
+efi_system_table_t *efi_system_table = NULL;
+
+static void efi_free_pool(void *ptr)
+{
+    efi_bs_call(free_pool, ptr);
+}
+
+efi_status_t efi_get_memory_map(struct efi_boot_memmap *map)
+{
+    efi_memory_desc_t *m = NULL;
+    efi_status_t status;
+    unsigned long key = 0, map_size = 0, desc_size = 0;
+    u32 desc_ver;
+
+    status = efi_bs_call(get_memory_map, &map_size,
+                 NULL, &key, &desc_size, &desc_ver);
+    if (status != EFI_BUFFER_TOO_SMALL || map_size == 0)
+        goto out;
+
+    /*
+     * Pad map_size with additional descriptors so we don't need to
+     * retry.
+     */
+    map_size += 4 * desc_size;
+    *map->buff_size = map_size;
+    status = efi_bs_call(allocate_pool, EFI_LOADER_DATA,
+                 map_size, (void **)&m);
+    if (status != EFI_SUCCESS)
+        goto out;
+
+    /* Get the map. */
+    status = efi_bs_call(get_memory_map, &map_size,
+                 m, &key, &desc_size, &desc_ver);
+    if (status != EFI_SUCCESS) {
+        efi_free_pool(m);
+        goto out;
+    }
+
+    *map->desc_ver = desc_ver;
+    *map->desc_size = desc_size;
+    *map->map_size = map_size;
+    *map->key_ptr = key;
+out:
+    *map->map = m;
+    return status;
+}
+
+efi_status_t efi_exit_boot_services(void *handle, struct efi_boot_memmap *map)
+{
+    return efi_bs_call(exit_boot_services, handle, *map->key_ptr);
+}
+
+efi_status_t efi_get_system_config_table(efi_guid_t table_guid, void **table)
+{
+    size_t i;
+    efi_config_table_t *tables;
+
+    tables = (efi_config_table_t *)efi_system_table->tables;
+    for (i = 0; i < efi_system_table->nr_tables; i++) {
+        if (!memcmp(&table_guid, &tables[i].guid, sizeof(efi_guid_t))) {
+            *table = tables[i].table;
+            return EFI_SUCCESS;
+        }
+    }
+    return EFI_NOT_FOUND;
+}
+
+// /* Adapted from drivers/firmware/efi/libstub/efi-stub.c */
+// static char *efi_convert_cmdline(struct efi_loaded_image_64 *image, int *cmd_line_len)
+// {
+//     const u16 *s2;
+//     unsigned long cmdline_addr = 0;
+//     int options_chars = image->load_options_size;
+//     const u16 *options = image->load_options;
+//     int options_bytes = 0, safe_options_bytes = 0;  /* UTF-8 bytes */
+//     bool in_quote = false;
+//     efi_status_t status;
+//     const int COMMAND_LINE_SIZE = 2048;
+
+//     if (options) {
+//         s2 = options;
+//         while (options_bytes < COMMAND_LINE_SIZE && options_chars--) {
+//             u16 c = *s2++;
+
+//             if (c < 0x80) {
+//                 if (c == L'\0' || c == L'\n')
+//                     break;
+//                 if (c == L'"')
+//                     in_quote = !in_quote;
+//                 else if (!in_quote && isspace((char)c))
+//                     safe_options_bytes = options_bytes;
+
+//                 options_bytes++;
+//                 continue;
+//             }
+
+//             /*
+//              * Get the number of UTF-8 bytes corresponding to a
+//              * UTF-16 character.
+//              * The first part handles everything in the BMP.
+//              */
+//             options_bytes += 2 + (c >= 0x800);
+//             /*
+//              * Add one more byte for valid surrogate pairs. Invalid
+//              * surrogates will be replaced with 0xfffd and take up
+//              * only 3 bytes.
+//              */
+//             if ((c & 0xfc00) == 0xd800) {
+//                 /*
+//                  * If the very last word is a high surrogate,
+//                  * we must ignore it since we can't access the
+//                  * low surrogate.
+//                  */
+//                 if (!options_chars) {
+//                     options_bytes -= 3;
+//                 } else if ((*s2 & 0xfc00) == 0xdc00) {
+//                     options_bytes++;
+//                     options_chars--;
+//                     s2++;
+//                 }
+//             }
+//         }
+//         if (options_bytes >= COMMAND_LINE_SIZE) {
+//             options_bytes = safe_options_bytes;
+//             printf("Command line is too long: truncated to %d bytes\n",
+//                    options_bytes);
+//         }
+//     }
+
+//     options_bytes++;        /* NUL termination */
+
+//     status = efi_bs_call(allocate_pool, EFI_LOADER_DATA, options_bytes, (void **)&cmdline_addr);
+//     if (status != EFI_SUCCESS)
+//         return NULL;
+
+//     snprintf((char *)cmdline_addr, options_bytes, "%.*ls", options_bytes - 1, options);
+
+//     *cmd_line_len = options_bytes;
+//     return (char *)cmdline_addr;
+// }
+
+efi_status_t mem_model_execute_tests(efi_handle_t handle, efi_system_table_t *sys_tab)
+{
+    efi_status_t status;
+    efi_bootinfo_t efi_bootinfo;
+
+    efi_system_table = sys_tab;
+
+    /* Memory map struct values */
+    efi_memory_desc_t *map = NULL;
+    unsigned long map_size = 0, desc_size = 0, key = 0, buff_size = 0;
+    u32 desc_ver;
+
+    /* Helper variables needed to get the cmdline */
+    struct efi_loaded_image_64 *image;
+    efi_guid_t loaded_image_proto = LOADED_IMAGE_PROTOCOL_GUID;
+    char *cmdline_ptr = NULL;
+    //int cmdline_size = 0;
+
+    /*
+     * Get a handle to the loaded image protocol.  This is used to get
+     * information about the running image, such as size and the command
+     * line.
+     */
+    status = efi_bs_call(handle_protocol, handle, &loaded_image_proto, (void *)&image);
+    if (status != EFI_SUCCESS) {
+        printf("Failed to get loaded image protocol\n");
+        goto efi_main_error;
+    }
+
+    // cmdline_ptr = efi_convert_cmdline(image, &cmdline_size);
+    // if (!cmdline_ptr) {
+    //     printf("getting command line via LOADED_IMAGE_PROTOCOL\n");
+    //     status = EFI_OUT_OF_RESOURCES;
+    //     goto efi_main_error;
+    // }
+    setup_args(cmdline_ptr);
+
+    /* Set up efi_bootinfo */
+    efi_bootinfo.mem_map.map = &map;
+    efi_bootinfo.mem_map.map_size = &map_size;
+    efi_bootinfo.mem_map.desc_size = &desc_size;
+    efi_bootinfo.mem_map.desc_ver = &desc_ver;
+    efi_bootinfo.mem_map.key_ptr = &key;
+    efi_bootinfo.mem_map.buff_size = &buff_size;
+
+    /* Get EFI memory map */
+    status = efi_get_memory_map(&efi_bootinfo.mem_map);
+    if (status != EFI_SUCCESS) {
+        printf("Failed to get memory map\n");
+        goto efi_main_error;
+    }
+
+    /* Set up arch-specific resources */
+    status = setup_efi(&efi_bootinfo);
+    if (status != EFI_SUCCESS) {
+        printf("Failed to set up arch-specific resources\n");
+        goto efi_main_error;
+    }
+
+      printf("\nRunning tests ...\n\n");
+      printf("\n*********************************************\n");
+      _X2_2B_2W_2B_dmb_2E_sys(__argc, __argv);
+      printf("\n*********************************************\n");
+      CO_2D_MIXED_2D_20cc_2B_H(__argc, __argv);
+      printf("\n*********************************************\n");
+      CoRR(__argc, __argv);
+      printf("\n*********************************************\n");
+      CoRW1(__argc, __argv);
+      printf("\n*********************************************\n");
+      CoRW2_2B_posb1b0_2B_h0(__argc, __argv);
+      printf("\n*********************************************\n");
+      CoRW2(__argc, __argv);
+      printf("\n*********************************************\n");
+      CoWR(__argc, __argv);
+      printf("\n*********************************************\n");
+      CoWW(__argc, __argv);
+      printf("\n*********************************************\n");
+      LB_2B_BEQ4(__argc, __argv);
+      printf("\n*********************************************\n");
+      LB_2B_CSEL_2D_addr_2D_po_2B_DMB(__argc, __argv);
+      printf("\n*********************************************\n");
+      LB_2B_CSEL_2D_rfi_2D_data_2B_DMB(__argc, __argv);
+      printf("\n*********************************************\n");
+      LB_2B_dmb_2E_sy_2B_data_2D_wsi_2D_wsi_2B_MIXED_2B_H(__argc, __argv);
+      printf("\n*********************************************\n");
+      LB_2B_dmb_2E_sys(__argc, __argv);
+      printf("\n*********************************************\n");
+      LB_2B_rel_2B_BEQ2(__argc, __argv);
+      printf("\n*********************************************\n");
+      LB_2B_rel_2B_CSEL_2D_CSEL(__argc, __argv);
+      printf("\n*********************************************\n");
+      LB_2B_rel_2B_data(__argc, __argv);
+      printf("\n*********************************************\n");
+      MP_2B_dmb_2E_sys(__argc, __argv);
+      printf("\n*********************************************\n");
+      MP_2D_Koeln(__argc, __argv);
+      printf("\n*********************************************\n");
+      R_2B_dmb_2E_sys(__argc, __argv);
+      printf("\n*********************************************\n");
+      S_2B_dmb_2E_sys(__argc, __argv);
+      printf("\n*********************************************\n");
+      S_2B_rel_2B_CSEL_2D_data(__argc, __argv);
+      printf("\n*********************************************\n");
+      S_2B_rel_2B_CSEL_2D_rf_2D_reg(__argc, __argv);
+      printf("\n*********************************************\n");
+      SB_2B_dmb_2E_sys(__argc, __argv);
+      printf("\n*********************************************\n");
+      T10B(__argc, __argv);
+      printf("\n*********************************************\n");
+      T10C(__argc, __argv);
+      printf("\n*********************************************\n");
+      T15_2D_corrected(__argc, __argv);
+      printf("\n*********************************************\n");
+      T15_2D_datadep_2D_corrected(__argc, __argv);
+      printf("\n*********************************************\n");
+      T3_2D_bis(__argc, __argv);
+      printf("\n*********************************************\n");
+      T3(__argc, __argv);
+      printf("\n*********************************************\n");
+      T7(__argc, __argv);
+      printf("\n*********************************************\n");
+      T7dep(__argc, __argv);
+      printf("\n*********************************************\n");
+      T8_2B_BIS(__argc, __argv);
+      printf("\n*********************************************\n");
+      T9B(__argc, __argv);
+      printf("\n\n      *** Memory model consistency tests run complete. Reset the system. ***  ");
+efi_main_error:
+    return 0;
+}

--- a/mem_test/litmus-tests/2+2W+dmb.sys.c
+++ b/mem_test/litmus-tests/2+2W+dmb.sys.c
@@ -1,0 +1,1159 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 2
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *y,*x;
+  pteval_t *pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int x;
+  int y;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("[x]=%d;",p->x);
+  printf(" [y]=%d;",p->y);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->x == q->x &&
+    p->y == q->y &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults 2+2W+dmb.sys %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->x) {
+  case 2:
+    switch (p->y) {
+    case 2:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y);
+
+noinline static void code0(int *x,int *y) {
+  int trashed_x0;
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"mov %w[x0],#2\n"
+"#_litmus_P0_2\n\t"
+"str %w[x0],[%[x1]]\n"
+"#_litmus_P0_3\n\t"
+"dmb sy\n"
+"#_litmus_P0_4\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P0_5\n\t"
+"str %w[x2],[%[x3]]\n"
+"#_litmus_P0_6\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x2] "=&r" (trashed_x2),[x0] "=&r" (trashed_x0)
+:[x1] "r" (x),[x3] "r" (y)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y);
+
+noinline static void code1(int *x,int *y) {
+  int trashed_x0;
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"mov %w[x0],#2\n"
+"#_litmus_P1_2\n\t"
+"str %w[x0],[%[x1]]\n"
+"#_litmus_P1_3\n\t"
+"dmb sy\n"
+"#_litmus_P1_4\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P1_5\n\t"
+"str %w[x2],[%[x3]]\n"
+"#_litmus_P1_6\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x2] "=&r" (trashed_x2),[x0] "=&r" (trashed_x0)
+:[x1] "r" (y),[x3] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(x,y);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    litmus_flush_tlb((void *)y);
+    _log->y = *y;
+    barrier_wait(_b);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    _log->x = *x;
+    barrier_wait(_b);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test 2+2W+dmb.sys Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists ([x]=2 /\\ [y]=2)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=9495f1f810a4f034c732242a8a2c3eed\n");
+  puts("Cycle=Wse DMB.SYdWW Wse DMB.SYdWW\n");
+  puts("Generator=diycross7 (version 7.54+01(dev))\n");
+  puts("Com=Ws Ws\n");
+  puts("Orig=DMB.SYdWW Wse DMB.SYdWW Wse\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation 2+2W+dmb.sys %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time 2+2W+dmb.sys ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int _X2_2B_2W_2B_dmb_2E_sys (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/CO-MIXED-20cc+H.c
+++ b/mem_test/litmus-tests/CO-MIXED-20cc+H.c
@@ -1,0 +1,1120 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 1
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *x;
+  pteval_t *pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  uint16_t x;
+  uint16_t out_0_x2;
+  uint32_t _pad;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("0:X2=%d;",p->out_0_x2);
+  printf(" [x]=%d;",p->x);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_0_x2 == q->out_0_x2 &&
+    p->x == q->x &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults CO-MIXED-20cc+H %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_0_x2) {
+  case 513:
+    switch (p->x) {
+    case 514:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_1_x;
+} param_t;
+
+static param_t param = {-1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_1_x=%d}",p->part,p->c_0_x,p->c_1_x);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(uint16_t *x,uint16_t *out_0_x2);
+
+noinline static void code0(uint16_t *x,uint16_t *out_0_x2) {
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"strb %w[x1],[%[x5]]\n"
+"#_litmus_P0_2\n\t"
+"ldrh %w[x2],[%[x5]]\n"
+"#_litmus_P0_3\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x2] "=&r" (*out_0_x2)
+:[x1] "r" ((int)(1)),"[x2]" ((uint16_t)(0)),[x5] "r" (x)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(uint16_t *x);
+
+noinline static void code1(uint16_t *x) {
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"strh %w[x1],[%[x5]]\n"
+"#_litmus_P1_2\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:
+:[x1] "r" ((uint16_t)(514)),[x5] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  uint16_t *x = (uint16_t *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    barrier_wait(_b);
+    code0(x,&_log->out_0_x2);
+    barrier_wait(_b);
+    barrier_wait(_b);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    barrier_wait(_b);
+    code1(x);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    _log->x = *x;
+    barrier_wait(_b);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test CO-MIXED-20cc+H Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists ([x]=514 /\\ 0:X2=513)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=f1d5e854502ed9c4f5bdf11a1a49a103\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation CO-MIXED-20cc+H %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time CO-MIXED-20cc+H ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int CO_2D_MIXED_2D_20cc_2B_H (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/CoRR.c
+++ b/mem_test/litmus-tests/CoRR.c
@@ -1,0 +1,1123 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 1
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *x;
+  pteval_t *pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_1_x1;
+  int out_1_x2;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("1:X1=%d;",p->out_1_x1);
+  printf(" 1:X2=%d;",p->out_1_x2);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_1_x1 == q->out_1_x1 &&
+    p->out_1_x2 == q->out_1_x2 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults CoRR %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_1_x1) {
+  case 1:
+    switch (p->out_1_x2) {
+    case 0:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_1_x;
+} param_t;
+
+static param_t param = {-1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_1_x=%d}",p->part,p->c_0_x,p->c_1_x);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x);
+
+noinline static void code0(int *x) {
+  int trashed_x0;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"mov %w[x0],#1\n"
+"#_litmus_P0_2\n\t"
+"str %w[x0],[%[x1]]\n"
+"#_litmus_P0_3\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x0] "=&r" (trashed_x0)
+:[x1] "r" (x)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *out_1_x1,int *out_1_x2);
+
+noinline static void code1(int *x,int *out_1_x1,int *out_1_x2) {
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldr %w[x1],[%[x0]]\n"
+"#_litmus_P1_2\n\t"
+"ldr %w[x2],[%[x0]]\n"
+"#_litmus_P1_3\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x2] "=&r" (*out_1_x2),[x1] "=&r" (*out_1_x1)
+:[x0] "r" (x),"[x1]" ((int)(0)),"[x2]" ((int)(0))
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    barrier_wait(_b);
+    code0(x);
+    barrier_wait(_b);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    barrier_wait(_b);
+    code1(x,&_log->out_1_x1,&_log->out_1_x2);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test CoRR Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (1:X1=1 /\\ 1:X2=0)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=58714bf58ff46be75de27369e727776e\n");
+  puts("Cycle=Rfe PosRR Fre\n");
+  puts("Generator=diycross7 (version 7.56+03)\n");
+  puts("Com=Rf Fr\n");
+  puts("Orig=Rfe PosRR Fre\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation CoRR %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time CoRR ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int CoRR (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/CoRW1.c
+++ b/mem_test/litmus-tests/CoRW1.c
@@ -1,0 +1,1083 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 1
+#define NVARS 1
+#define NEXE 4
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0]]
+3, 2, 1, 0,
+};
+
+static const int role[] = {
+// [[0]]
+0, 0, 0, 0,
+};
+
+static const char *group[] = {
+"[[0]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *x;
+  pteval_t *pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_0_x1;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("0:X1=%d;",p->out_0_x1);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_0_x1 == q->out_0_x1 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults CoRW1 %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_0_x1) {
+  case 1:
+    return 1;
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x;
+} param_t;
+
+static param_t param = {-1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d}",p->part,p->c_0_x);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax];
+} stats_t;
+
+#define HASHSZ 7
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *out_0_x1);
+
+noinline static void code0(int *x,int *out_0_x1) {
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"ldr %w[x1],[%[x0]]\n"
+"#_litmus_P0_2\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P0_3\n\t"
+"str %w[x2],[%[x0]]\n"
+"#_litmus_P0_4\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x1] "=&r" (*out_0_x1),[x2] "=&r" (trashed_x2)
+:[x0] "r" (x),"[x1]" ((int)(0))
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    barrier_wait(_b);
+    code0(x,&_log->out_0_x1);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.part = part;
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test CoRW1 Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (0:X1=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=6a19e09fb3f24bada1985dc15445199f\n");
+  puts("Cycle=Rfe PosRW\n");
+  puts("Generator=diycross7 (version 7.56+03)\n");
+  puts("Com=Rf\n");
+  puts("Orig=PosRW Rfe\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation CoRW1 %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time CoRW1 ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int CoRW1 (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/CoRW2+posb1b0+h0.c
+++ b/mem_test/litmus-tests/CoRW2+posb1b0+h0.c
@@ -1,0 +1,1134 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 1
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *x;
+  pteval_t *pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  uint16_t x;
+  uint16_t out_1_x3;
+  uint16_t out_1_x0;
+  uint32_t _pad;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("1:X0=%d;",p->out_1_x0);
+  printf(" 1:X3=%d;",p->out_1_x3);
+  printf(" [x]=%d;",p->x);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_1_x0 == q->out_1_x0 &&
+    p->out_1_x3 == q->out_1_x3 &&
+    p->x == q->x &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults CoRW2+posb1b0+h0 %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_1_x0) {
+  case 1: case 0:
+    switch (p->out_1_x3) {
+    case 258:
+      switch (p->x) {
+      case 257:
+        return 1;
+      default:
+        return 0;
+      }
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_1_x;
+} param_t;
+
+static param_t param = {-1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_1_x=%d}",p->part,p->c_0_x,p->c_1_x);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax];
+} stats_t;
+
+#define HASHSZ 55
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(uint16_t *x);
+
+noinline static void code0(uint16_t *x) {
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"strh %w[x0],[%[x1]]\n"
+"#_litmus_P0_2\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:
+:[x0] "r" ((int)(257)),[x1] "r" (x)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(uint16_t *x,uint16_t *out_1_x0,uint16_t *out_1_x3);
+
+noinline static void code1(uint16_t *x,uint16_t *out_1_x0,uint16_t *out_1_x3) {
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldrb %w[x0],[%[x1],#1]\n"
+"#_litmus_P1_2\n\t"
+"strb %w[x2],[%[x1]]\n"
+"#_litmus_P1_3\n\t"
+"ldrh %w[x3],[%[x1]]\n"
+"#_litmus_P1_4\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x3] "=&r" (*out_1_x3),[x0] "=&r" (*out_1_x0)
+:"[x0]" ((uint16_t)(0)),[x1] "r" (x),[x2] "r" ((int)(2)),"[x3]" ((uint16_t)(0))
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  uint16_t *x = (uint16_t *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    barrier_wait(_b);
+    code0(x);
+    barrier_wait(_b);
+    barrier_wait(_b);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    barrier_wait(_b);
+    code1(x,&_log->out_1_x0,&_log->out_1_x3);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    _log->x = *x;
+    barrier_wait(_b);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test CoRW2+posb1b0+h0 Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists ((1:X0=0 \\/ 1:X0=1) /\\ 1:X3=258 /\\ [x]=257)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=e66e66945cd186d00d05e8f49297de61\n");
+  puts("Cycle=Wseb0h0 Rfeh0b1 PosRWb1b0\n");
+  puts("Generator=diycross7 (version 7.54+02(dev))\n");
+  puts("Com=Rf Ws\n");
+  puts("Orig=Rfeh0b1 PosRWb1b0 Wseb0h0\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation CoRW2+posb1b0+h0 %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time CoRW2+posb1b0+h0 ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int CoRW2_2B_posb1b0_2B_h0 (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/CoRW2.c
+++ b/mem_test/litmus-tests/CoRW2.c
@@ -1,0 +1,1129 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 1
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *x;
+  pteval_t *pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_1_x1;
+  int x;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("1:X1=%d;",p->out_1_x1);
+  printf(" [x]=%d;",p->x);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_1_x1 == q->out_1_x1 &&
+    p->x == q->x &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults CoRW2 %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_1_x1) {
+  case 1:
+    switch (p->x) {
+    case 1:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_1_x;
+} param_t;
+
+static param_t param = {-1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_1_x=%d}",p->part,p->c_0_x,p->c_1_x);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x);
+
+noinline static void code0(int *x) {
+  int trashed_x0;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"mov %w[x0],#1\n"
+"#_litmus_P0_2\n\t"
+"str %w[x0],[%[x1]]\n"
+"#_litmus_P0_3\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x0] "=&r" (trashed_x0)
+:[x1] "r" (x)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *out_1_x1);
+
+noinline static void code1(int *x,int *out_1_x1) {
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldr %w[x1],[%[x0]]\n"
+"#_litmus_P1_2\n\t"
+"mov %w[x2],#2\n"
+"#_litmus_P1_3\n\t"
+"str %w[x2],[%[x0]]\n"
+"#_litmus_P1_4\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x1] "=&r" (*out_1_x1),[x2] "=&r" (trashed_x2)
+:[x0] "r" (x),"[x1]" ((int)(0))
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    barrier_wait(_b);
+    code0(x);
+    barrier_wait(_b);
+    barrier_wait(_b);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    barrier_wait(_b);
+    code1(x,&_log->out_1_x1);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    _log->x = *x;
+    barrier_wait(_b);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test CoRW2 Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists ([x]=1 /\\ 1:X1=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=53edb9ad1ca1ec4ea68b54b174d2602e\n");
+  puts("Cycle=Rfe PosRW Coe\n");
+  puts("Generator=diycross7 (version 7.56+03)\n");
+  puts("Com=Rf Co\n");
+  puts("Orig=Rfe PosRW Coe\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation CoRW2 %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time CoRW2 ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int CoRW2 (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/CoWR.c
+++ b/mem_test/litmus-tests/CoWR.c
@@ -1,0 +1,1083 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 1
+#define NVARS 1
+#define NEXE 4
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0]]
+3, 2, 1, 0,
+};
+
+static const int role[] = {
+// [[0]]
+0, 0, 0, 0,
+};
+
+static const char *group[] = {
+"[[0]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *x;
+  pteval_t *pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_0_x2;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("0:X2=%d;",p->out_0_x2);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_0_x2 == q->out_0_x2 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults CoWR %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_0_x2) {
+  case 0:
+    return 1;
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x;
+} param_t;
+
+static param_t param = {-1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d}",p->part,p->c_0_x);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax];
+} stats_t;
+
+#define HASHSZ 7
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *out_0_x2);
+
+noinline static void code0(int *x,int *out_0_x2) {
+  int trashed_x0;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"mov %w[x0],#1\n"
+"#_litmus_P0_2\n\t"
+"str %w[x0],[%[x1]]\n"
+"#_litmus_P0_3\n\t"
+"ldr %w[x2],[%[x1]]\n"
+"#_litmus_P0_4\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x2] "=&r" (*out_0_x2),[x0] "=&r" (trashed_x0)
+:[x1] "r" (x),"[x2]" ((int)(0))
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    barrier_wait(_b);
+    code0(x,&_log->out_0_x2);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.part = part;
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test CoWR Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (0:X2=0)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=4fda10c1cc7377ce0736114e9a11568b\n");
+  puts("Cycle=Fre PosWR\n");
+  puts("Generator=diycross7 (version 7.56+03)\n");
+  puts("Com=Fr\n");
+  puts("Orig=PosWR Fre\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation CoWR %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time CoWR ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int CoWR (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/CoWW.c
+++ b/mem_test/litmus-tests/CoWW.c
@@ -1,0 +1,1088 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 1
+#define NVARS 1
+#define NEXE 4
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0]]
+3, 2, 1, 0,
+};
+
+static const int role[] = {
+// [[0]]
+0, 0, 0, 0,
+};
+
+static const char *group[] = {
+"[[0]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *x;
+  pteval_t *pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int x;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("[x]=%d;",p->x);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->x == q->x &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults CoWW %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->x) {
+  case 1:
+    return 1;
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x;
+} param_t;
+
+static param_t param = {-1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d}",p->part,p->c_0_x);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax];
+} stats_t;
+
+#define HASHSZ 7
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x);
+
+noinline static void code0(int *x) {
+  int trashed_x0;
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"mov %w[x0],#1\n"
+"#_litmus_P0_2\n\t"
+"str %w[x0],[%[x1]]\n"
+"#_litmus_P0_3\n\t"
+"mov %w[x2],#2\n"
+"#_litmus_P0_4\n\t"
+"str %w[x2],[%[x1]]\n"
+"#_litmus_P0_5\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x2] "=&r" (trashed_x2),[x0] "=&r" (trashed_x0)
+:[x1] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    barrier_wait(_b);
+    code0(x);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    _log->x = *x;
+    barrier_wait(_b);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.part = part;
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test CoWW Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists ([x]=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=88f44e31b2257e72cc73f3f3c72a2d38\n");
+  puts("Cycle=Coe PosWW\n");
+  puts("Generator=diycross7 (version 7.56+03)\n");
+  puts("Com=Co\n");
+  puts("Orig=PosWW Coe\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation CoWW %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time CoWW ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int CoWW (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/LB+BEQ4.c
+++ b/mem_test/litmus-tests/LB+BEQ4.c
@@ -1,0 +1,1149 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 2
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *P1_over;
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *y,*x;
+  pteval_t *pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_0_x0;
+  int out_1_x0;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("0:X0=%d;",p->out_0_x0);
+  printf(" 1:X0=%d;",p->out_1_x0);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_0_x0 == q->out_0_x0 &&
+    p->out_1_x0 == q->out_1_x0 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults LB+BEQ4 %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_0_x0) {
+  case 1:
+    switch (p->out_1_x0) {
+    case 1:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y,int *out_0_x0);
+
+noinline static void code0(int *x,int *y,int *out_0_x0) {
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"ldr %w[x0],[%[x3]]\n"
+"#_litmus_P0_2\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P0_3\n\t"
+"stlr %w[x2],[%[x1]]\n"
+"#_litmus_P0_4\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x0] "=&r" (*out_0_x0),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (x),[x3] "r" (y)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *out_1_x0);
+
+noinline static void code1(int *x,int *y,int *out_1_x0) {
+  int trashed_x4;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldr %w[x0],[%[x1]]\n"
+"#_litmus_P1_2\n\t"
+"cmp %w[x0],#0\n"
+"#_litmus_P1_3\n\t"
+"b.eq 1f\n"
+"#_litmus_P1_4\n"
+"1:\n"
+"#_litmus_P1_5\n\t"
+"mov %w[x4],#1\n"
+"#_litmus_P1_6\n\t"
+"str %w[x4],[%[x3]]\n"
+"#_litmus_P1_7\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x0] "=&r" (*out_1_x0),[x4] "=&r" (trashed_x4)
+:"[x0]" ((int)(0)),[x1] "r" (x),[x3] "r" (y)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->P1_over = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,0)+4;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(x,y,&_log->out_0_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    litmus_flush_tlb((void *)y);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test LB+BEQ4 Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (0:X0=1 /\\ 1:X0=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=35d7bf71ce0bc0fd5c8dbe98d370d0e7\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation LB+BEQ4 %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time LB+BEQ4 ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int LB_2B_BEQ4 (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/LB+CSEL-addr-po+DMB.c
+++ b/mem_test/litmus-tests/LB+CSEL-addr-po+DMB.c
@@ -1,0 +1,1176 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 4
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *y,*x,*b,*a;
+  pteval_t *pte_y,saved_pte_y,*pte_x,saved_pte_x,*pte_b,saved_pte_b,*pte_a,saved_pte_a;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_0_x0;
+  int out_1_x0;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("0:X0=%d;",p->out_0_x0);
+  printf(" 1:X0=%d;",p->out_1_x0);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_0_x0 == q->out_0_x0 &&
+    p->out_1_x0 == q->out_1_x0 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults LB+CSEL-addr-po+DMB %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_0_x0) {
+  case 1:
+    switch (p->out_1_x0) {
+    case 1:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_a,c_0_b,c_0_x,c_0_y,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_a",&param.c_0_a,id,cmax},
+  {"c_0_b",&param.c_0_b,id,cmax},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_a=%d, c_0_b=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_a,p->c_0_b,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *a,int *b,int *x,int *y,int *out_0_x0);
+
+noinline static void code0(int *a,int *b,int *x,int *y,int *out_0_x0) {
+  void* trashed_x3;
+  int trashed_x7;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"ldr %w[x0],[%[x1]]\n"
+"#_litmus_P0_2\n\t"
+"cmp %w[x0],#1\n"
+"#_litmus_P0_3\n\t"
+"csel %[x3],%[x4],%[x5],eq\n"
+"#_litmus_P0_4\n\t"
+"str %w[x6],[%[x3]]\n"
+"#_litmus_P0_5\n\t"
+"mov %w[x7],#1\n"
+"#_litmus_P0_6\n\t"
+"str %w[x7],[%[x8]]\n"
+"#_litmus_P0_7\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x0] "=&r" (*out_0_x0),[x7] "=&r" (trashed_x7),[x3] "=&r" (trashed_x3)
+:"[x0]" ((int)(0)),[x1] "r" (x),[x4] "r" (a),[x5] "r" (b),[x6] "r" (0),[x8] "r" (y)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *out_1_x0);
+
+noinline static void code1(int *x,int *y,int *out_1_x0) {
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldr %w[x0],[%[x8]]\n"
+"#_litmus_P1_2\n\t"
+"dmb sy\n"
+"#_litmus_P1_3\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P1_4\n\t"
+"str %w[x2],[%[x1]]\n"
+"#_litmus_P1_5\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x0] "=&r" (*out_1_x0),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (x),[x8] "r" (y)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+  _vars->b = _mem;
+  _vars->pte_b = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_b = *_p;
+  _mem += _sz ;
+  _vars->a = _mem;
+  _vars->pte_a = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_a = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  int *b = (int *)_vars->b;
+  int *a = (int *)_vars->a;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *b = 0;
+    litmus_flush_tlb((void *)b);
+    *a = 0;
+    litmus_flush_tlb((void *)a);
+    barrier_wait(_b);
+    if (_p->c_0_a == ctouch) cache_touch((void *)a);
+    else if (_p->c_0_a == cflush) cache_flush((void *)a);
+    if (_p->c_0_b == ctouch) cache_touch((void *)b);
+    else if (_p->c_0_b == cflush) cache_flush((void *)b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(a,b,x,y,&_log->out_0_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(b,_vars->pte_b,_vars->saved_pte_b);
+    (void)litmus_set_pte_safe(a,_vars->pte_a,_vars->saved_pte_a);
+    litmus_flush_tlb((void *)b);
+    litmus_flush_tlb((void *)a);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)y);
+    litmus_flush_tlb((void *)x);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_a = comp_param(&c->seed,&q->c_0_a,cmax,1);
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_b = comp_param(&c->seed,&q->c_0_b,cmax,1);
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test LB+CSEL-addr-po+DMB Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (0:X0=1 /\\ 1:X0=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=84502037722d735f35c04f15d36db2d5\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation LB+CSEL-addr-po+DMB %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time LB+CSEL-addr-po+DMB ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int LB_2B_CSEL_2D_addr_2D_po_2B_DMB (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/LB+CSEL-rfi-data+DMB.c
+++ b/mem_test/litmus-tests/LB+CSEL-rfi-data+DMB.c
@@ -1,0 +1,1166 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 3
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *z,*y,*x;
+  pteval_t *pte_z,saved_pte_z,*pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_0_x0;
+  int out_1_x0;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("0:X0=%d;",p->out_0_x0);
+  printf(" 1:X0=%d;",p->out_1_x0);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_0_x0 == q->out_0_x0 &&
+    p->out_1_x0 == q->out_1_x0 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults LB+CSEL-rfi-data+DMB %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_0_x0) {
+  case 1:
+    switch (p->out_1_x0) {
+    case 1:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_0_z,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_0_z",&param.c_0_z,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_0_z=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_x,p->c_0_y,p->c_0_z,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y,int *z,int *out_0_x0);
+
+noinline static void code0(int *x,int *y,int *z,int *out_0_x0) {
+  int trashed_x2;
+  int trashed_x6;
+  int trashed_x8;
+  int trashed_x9;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"ldr %w[x0],[%[x1]]\n"
+"#_litmus_P0_2\n\t"
+"cmp %w[x0],#1\n"
+"#_litmus_P0_3\n\t"
+"csel %w[x2],%w[x3],%w[x4],eq\n"
+"#_litmus_P0_4\n\t"
+"str %w[x2],[%[x5]]\n"
+"#_litmus_P0_5\n\t"
+"ldr %w[x6],[%[x5]]\n"
+"#_litmus_P0_6\n\t"
+"eor %w[x8],%w[x6],%w[x6]\n"
+"#_litmus_P0_7\n\t"
+"add %w[x9],%w[x8],%w[x3]\n"
+"#_litmus_P0_8\n\t"
+"str %w[x9],[%[x10]]\n"
+"#_litmus_P0_9\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x0] "=&r" (*out_0_x0),[x9] "=&r" (trashed_x9),[x8] "=&r" (trashed_x8),[x6] "=&r" (trashed_x6),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (x),[x3] "r" ((int)(1)),[x4] "r" ((int)(2)),[x5] "r" (z),[x10] "r" (y)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *out_1_x0);
+
+noinline static void code1(int *x,int *y,int *out_1_x0) {
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldr %w[x0],[%[x10]]\n"
+"#_litmus_P1_2\n\t"
+"dmb sy\n"
+"#_litmus_P1_3\n\t"
+"str %w[x2],[%[x1]]\n"
+"#_litmus_P1_4\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x0] "=&r" (*out_1_x0)
+:"[x0]" ((int)(0)),[x1] "r" (x),[x2] "r" ((int)(1)),[x10] "r" (y)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->z = _mem;
+  _vars->pte_z = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_z = *_p;
+  _mem += _sz ;
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *z = (int *)_vars->z;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *z = 0;
+    litmus_flush_tlb((void *)z);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    if (_p->c_0_z == ctouch) cache_touch((void *)z);
+    else if (_p->c_0_z == cflush) cache_flush((void *)z);
+    barrier_wait(_b);
+    code0(x,y,z,&_log->out_0_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(z,_vars->pte_z,_vars->saved_pte_z);
+    litmus_flush_tlb((void *)z);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)y);
+    litmus_flush_tlb((void *)x);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_0_z = comp_param(&c->seed,&q->c_0_z,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test LB+CSEL-rfi-data+DMB Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (0:X0=1 /\\ 1:X0=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=e377774c3cb44f0ee5d6c165f9ee03c5\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation LB+CSEL-rfi-data+DMB %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time LB+CSEL-rfi-data+DMB ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int LB_2B_CSEL_2D_rfi_2D_data_2B_DMB (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/LB+dmb.sy+data-wsi-wsi+MIXED+H.c
+++ b/mem_test/litmus-tests/LB+dmb.sy+data-wsi-wsi+MIXED+H.c
@@ -1,0 +1,1167 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 2
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *y,*x;
+  pteval_t *pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  uint16_t x;
+  uint16_t out_1_x0;
+  uint16_t out_0_x0;
+  uint32_t _pad;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("0:X0=%d;",p->out_0_x0);
+  printf(" 1:X0=%d;",p->out_1_x0);
+  printf(" [x]=%d;",p->x);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_0_x0 == q->out_0_x0 &&
+    p->out_1_x0 == q->out_1_x0 &&
+    p->x == q->x &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults LB+dmb.sy+data-wsi-wsi+MIXED+H %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_0_x0) {
+  case 2:
+    switch (p->out_1_x0) {
+    case 1:
+      switch (p->x) {
+      case 3:
+        return 1;
+      default:
+        return 0;
+      }
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 55
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(uint16_t *x,uint16_t *y,uint16_t *out_0_x0);
+
+noinline static void code0(uint16_t *x,uint16_t *y,uint16_t *out_0_x0) {
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"ldrb %w[x0],[%[x1]]\n"
+"#_litmus_P0_2\n\t"
+"dmb sy\n"
+"#_litmus_P0_3\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P0_4\n\t"
+"strh %w[x2],[%[x3]]\n"
+"#_litmus_P0_5\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x0] "=&r" (*out_0_x0),[x2] "=&r" (trashed_x2)
+:"[x0]" ((uint16_t)(0)),[x1] "r" (x),[x3] "r" (y)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(uint16_t *x,uint16_t *y,uint16_t *out_1_x0);
+
+noinline static void code1(uint16_t *x,uint16_t *y,uint16_t *out_1_x0) {
+  int trashed_x2;
+  int trashed_x4;
+  int trashed_x5;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldrb %w[x0],[%[x1]]\n"
+"#_litmus_P1_2\n\t"
+"eor %w[x2],%w[x0],%w[x0]\n"
+"#_litmus_P1_3\n\t"
+"add %w[x2],%w[x2],#1\n"
+"#_litmus_P1_4\n\t"
+"strb %w[x2],[%[x3],#1]\n"
+"#_litmus_P1_5\n\t"
+"mov %w[x4],#2\n"
+"#_litmus_P1_6\n\t"
+"strh %w[x4],[%[x3]]\n"
+"#_litmus_P1_7\n\t"
+"mov %w[x5],#3\n"
+"#_litmus_P1_8\n\t"
+"strh %w[x5],[%[x3]]\n"
+"#_litmus_P1_9\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x0] "=&r" (*out_1_x0),[x5] "=&r" (trashed_x5),[x4] "=&r" (trashed_x4),[x2] "=&r" (trashed_x2)
+:"[x0]" ((uint16_t)(0)),[x1] "r" (y),[x3] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  uint16_t *y = (uint16_t *)_vars->y;
+  uint16_t *x = (uint16_t *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(x,y,&_log->out_0_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    _log->x = *x;
+    barrier_wait(_b);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test LB+dmb.sy+data-wsi-wsi+MIXED+H Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (0:X0=2 /\\ 1:X0=1 /\\ [x]=3)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=6abf1eb78cc78278cc5d374b19bf4778\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation LB+dmb.sy+data-wsi-wsi+MIXED+H %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time LB+dmb.sy+data-wsi-wsi+MIXED+H ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int LB_2B_dmb_2E_sy_2B_data_2D_wsi_2D_wsi_2B_MIXED_2B_H (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/LB+dmb.sys.c
+++ b/mem_test/litmus-tests/LB+dmb.sys.c
@@ -1,0 +1,1149 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 2
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *y,*x;
+  pteval_t *pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_0_x0;
+  int out_1_x0;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("0:X0=%d;",p->out_0_x0);
+  printf(" 1:X0=%d;",p->out_1_x0);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_0_x0 == q->out_0_x0 &&
+    p->out_1_x0 == q->out_1_x0 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults LB+dmb.sys %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_0_x0) {
+  case 1:
+    switch (p->out_1_x0) {
+    case 1:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y,int *out_0_x0);
+
+noinline static void code0(int *x,int *y,int *out_0_x0) {
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"ldr %w[x0],[%[x1]]\n"
+"#_litmus_P0_2\n\t"
+"dmb sy\n"
+"#_litmus_P0_3\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P0_4\n\t"
+"str %w[x2],[%[x3]]\n"
+"#_litmus_P0_5\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x0] "=&r" (*out_0_x0),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (x),[x3] "r" (y)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *out_1_x0);
+
+noinline static void code1(int *x,int *y,int *out_1_x0) {
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldr %w[x0],[%[x1]]\n"
+"#_litmus_P1_2\n\t"
+"dmb sy\n"
+"#_litmus_P1_3\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P1_4\n\t"
+"str %w[x2],[%[x3]]\n"
+"#_litmus_P1_5\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x0] "=&r" (*out_1_x0),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (y),[x3] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(x,y,&_log->out_0_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    litmus_flush_tlb((void *)y);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test LB+dmb.sys Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (0:X0=1 /\\ 1:X0=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=016af9c5476352f228452a1de398c157\n");
+  puts("Cycle=Rfe DMB.SYdRW Rfe DMB.SYdRW\n");
+  puts("Generator=diycross7 (version 7.54+01(dev))\n");
+  puts("Com=Rf Rf\n");
+  puts("Orig=DMB.SYdRW Rfe DMB.SYdRW Rfe\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation LB+dmb.sys %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time LB+dmb.sys ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int LB_2B_dmb_2E_sys (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/LB+rel+BEQ2.c
+++ b/mem_test/litmus-tests/LB+rel+BEQ2.c
@@ -1,0 +1,1154 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 2
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *P1_over;
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *y,*x;
+  pteval_t *pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_0_x0;
+  int out_1_x3;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("0:X0=%d;",p->out_0_x0);
+  printf(" 1:X3=%d;",p->out_1_x3);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_0_x0 == q->out_0_x0 &&
+    p->out_1_x3 == q->out_1_x3 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults LB+rel+BEQ2 %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_0_x0) {
+  case 1:
+    switch (p->out_1_x3) {
+    case 1:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y,int *out_0_x0);
+
+noinline static void code0(int *x,int *y,int *out_0_x0) {
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"ldr %w[x0],[%[x5]]\n"
+"#_litmus_P0_2\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P0_3\n\t"
+"stlr %w[x2],[%[x4]]\n"
+"#_litmus_P0_4\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x0] "=&r" (*out_0_x0),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x4] "r" (y),[x5] "r" (x)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *out_1_x3);
+
+noinline static void code1(int *x,int *y,int *out_1_x3) {
+  int trashed_x1;
+  int trashed_x8;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldr %w[x3],[%[x4]]\n"
+"#_litmus_P1_2\n\t"
+"cmp %w[x0],#1\n"
+"#_litmus_P1_3\n\t"
+"mov %w[x1],#7\n"
+"#_litmus_P1_4\n\t"
+"b.eq 1f\n"
+"#_litmus_P1_5\n\t"
+"mov %w[x1],%w[x3]\n"
+"#_litmus_P1_6\n"
+"1:\n"
+"#_litmus_P1_7\n\t"
+"mov %w[x8],#7\n"
+"#_litmus_P1_8\n\t"
+"str %w[x1],[%[x5]]\n"
+"#_litmus_P1_9\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x3] "=&r" (*out_1_x3),[x8] "=&r" (trashed_x8),[x1] "=&r" (trashed_x1)
+:[x0] "r" (0),"[x3]" ((int)(0)),[x4] "r" (y),[x5] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->P1_over = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,0)+6;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(x,y,&_log->out_0_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    litmus_flush_tlb((void *)y);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x3);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test LB+rel+BEQ2 Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (0:X0=1 /\\ 1:X3=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=0b905e9fdd2eed81d0a3ea708936a864\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation LB+rel+BEQ2 %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time LB+rel+BEQ2 ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int LB_2B_rel_2B_BEQ2 (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/LB+rel+CSEL-CSEL.c
+++ b/mem_test/litmus-tests/LB+rel+CSEL-CSEL.c
@@ -1,0 +1,1147 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 2
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *y,*x;
+  pteval_t *pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_0_x9;
+  int out_1_x1;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("0:X9=%d;",p->out_0_x9);
+  printf(" 1:X1=%d;",p->out_1_x1);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_0_x9 == q->out_0_x9 &&
+    p->out_1_x1 == q->out_1_x1 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults LB+rel+CSEL-CSEL %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_0_x9) {
+  case 1:
+    switch (p->out_1_x1) {
+    case 1:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y,int *out_0_x9);
+
+noinline static void code0(int *x,int *y,int *out_0_x9) {
+  int trashed_x11;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"ldr %w[x9],[%[x10]]\n"
+"#_litmus_P0_2\n\t"
+"mov %w[x11],#1\n"
+"#_litmus_P0_3\n\t"
+"stlr %w[x11],[%[x2]]\n"
+"#_litmus_P0_4\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x9] "=&r" (*out_0_x9),[x11] "=&r" (trashed_x11)
+:[x2] "r" (y),"[x9]" ((int)(0)),[x10] "r" (x)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *out_1_x1);
+
+noinline static void code1(int *x,int *y,int *out_1_x1) {
+  int trashed_x3;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldr %w[x1],[%[x2]]\n"
+"#_litmus_P1_2\n\t"
+"cmp %w[x1],#1\n"
+"#_litmus_P1_3\n\t"
+"csel %w[x3],%w[x4],%w[x5],eq\n"
+"#_litmus_P1_4\n\t"
+"cmp %w[x3],#1\n"
+"#_litmus_P1_5\n\t"
+"csel %w[x3],%w[x4],%w[x5],eq\n"
+"#_litmus_P1_6\n\t"
+"str %w[x3],[%[x10]]\n"
+"#_litmus_P1_7\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x1] "=&r" (*out_1_x1),[x3] "=&r" (trashed_x3)
+:"[x1]" ((int)(0)),[x2] "r" (y),[x4] "r" ((int)(1)),[x5] "r" ((int)(2)),[x10] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(x,y,&_log->out_0_x9);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    litmus_flush_tlb((void *)y);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x1);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test LB+rel+CSEL-CSEL Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (1:X1=1 /\\ 0:X9=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=cde974680e211f086092760e1625c779\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation LB+rel+CSEL-CSEL %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time LB+rel+CSEL-CSEL ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int LB_2B_rel_2B_CSEL_2D_CSEL (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/LB+rel+data.c
+++ b/mem_test/litmus-tests/LB+rel+data.c
@@ -1,0 +1,1146 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 2
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *y,*x;
+  pteval_t *pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_0_x0;
+  int out_1_x0;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("0:X0=%d;",p->out_0_x0);
+  printf(" 1:X0=%d;",p->out_1_x0);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_0_x0 == q->out_0_x0 &&
+    p->out_1_x0 == q->out_1_x0 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults LB+rel+data %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_0_x0) {
+  case 1:
+    switch (p->out_1_x0) {
+    case 1:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y,int *out_0_x0);
+
+noinline static void code0(int *x,int *y,int *out_0_x0) {
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"ldr %w[x0],[%[x1]]\n"
+"#_litmus_P0_2\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P0_3\n\t"
+"stlr %w[x2],[%[x3]]\n"
+"#_litmus_P0_4\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x0] "=&r" (*out_0_x0),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (x),[x3] "r" (y)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *out_1_x0);
+
+noinline static void code1(int *x,int *y,int *out_1_x0) {
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldr %w[x0],[%[x1]]\n"
+"#_litmus_P1_2\n\t"
+"eor %w[x2],%w[x0],%w[x0]\n"
+"#_litmus_P1_3\n\t"
+"add %w[x2],%w[x2],#1\n"
+"#_litmus_P1_4\n\t"
+"str %w[x2],[%[x3]]\n"
+"#_litmus_P1_5\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x0] "=&r" (*out_1_x0),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (y),[x3] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(x,y,&_log->out_0_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    litmus_flush_tlb((void *)y);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test LB+rel+data Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (0:X0=1 /\\ 1:X0=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=e568e2e810b9c6333e9722f4063f1cc7\n");
+  puts("Generator=diyone7 (version 7.56+02~dev)\n");
+  puts("Com=Rf Rf\n");
+  puts("Orig=PodRWPL RfeLP DpDatadW Rfe\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation LB+rel+data %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time LB+rel+data ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int LB_2B_rel_2B_data (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/MP+dmb.sys.c
+++ b/mem_test/litmus-tests/MP+dmb.sys.c
@@ -1,0 +1,1149 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 2
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *y,*x;
+  pteval_t *pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_1_x0;
+  int out_1_x2;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("1:X0=%d;",p->out_1_x0);
+  printf(" 1:X2=%d;",p->out_1_x2);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_1_x0 == q->out_1_x0 &&
+    p->out_1_x2 == q->out_1_x2 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults MP+dmb.sys %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_1_x0) {
+  case 1:
+    switch (p->out_1_x2) {
+    case 0:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y);
+
+noinline static void code0(int *x,int *y) {
+  int trashed_x0;
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"mov %w[x0],#1\n"
+"#_litmus_P0_2\n\t"
+"str %w[x0],[%[x1]]\n"
+"#_litmus_P0_3\n\t"
+"dmb sy\n"
+"#_litmus_P0_4\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P0_5\n\t"
+"str %w[x2],[%[x3]]\n"
+"#_litmus_P0_6\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x2] "=&r" (trashed_x2),[x0] "=&r" (trashed_x0)
+:[x1] "r" (x),[x3] "r" (y)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *out_1_x0,int *out_1_x2);
+
+noinline static void code1(int *x,int *y,int *out_1_x0,int *out_1_x2) {
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldr %w[x0],[%[x1]]\n"
+"#_litmus_P1_2\n\t"
+"dmb sy\n"
+"#_litmus_P1_3\n\t"
+"ldr %w[x2],[%[x3]]\n"
+"#_litmus_P1_4\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x2] "=&r" (*out_1_x2),[x0] "=&r" (*out_1_x0)
+:"[x0]" ((int)(0)),[x1] "r" (y),"[x2]" ((int)(0)),[x3] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(x,y);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    litmus_flush_tlb((void *)y);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x0,&_log->out_1_x2);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test MP+dmb.sys Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (1:X0=1 /\\ 1:X2=0)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=592564b7f5bb278c1fc33861dd44472b\n");
+  puts("Cycle=Rfe DMB.SYdRR Fre DMB.SYdWW\n");
+  puts("Generator=diycross7 (version 7.54+01(dev))\n");
+  puts("Com=Rf Fr\n");
+  puts("Orig=DMB.SYdWW Rfe DMB.SYdRR Fre\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation MP+dmb.sys %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time MP+dmb.sys ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int MP_2B_dmb_2E_sys (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/MP-Koeln.c
+++ b/mem_test/litmus-tests/MP-Koeln.c
@@ -1,0 +1,1155 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 2
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *y,*x;
+  pteval_t *pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  uint16_t y;
+  uint16_t out_1_x3;
+  uint16_t out_1_x0;
+  uint32_t _pad;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("1:X0=%d;",p->out_1_x0);
+  printf(" 1:X3=%d;",p->out_1_x3);
+  printf(" [y]=%d;",p->y);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_1_x0 == q->out_1_x0 &&
+    p->out_1_x3 == q->out_1_x3 &&
+    p->y == q->y &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults MP-Koeln %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_1_x0) {
+  case 2:
+    switch (p->out_1_x3) {
+    case 0:
+      switch (p->y) {
+      case 514:
+        return 1;
+      default:
+        return 0;
+      }
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 55
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(uint16_t *x,uint16_t *y);
+
+noinline static void code0(uint16_t *x,uint16_t *y) {
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"strh %w[x0],[%[x1]]\n"
+"#_litmus_P0_2\n\t"
+"stlrb %w[x2],[%[x3]]\n"
+"#_litmus_P0_3\n\t"
+"strh %w[x4],[%[x3]]\n"
+"#_litmus_P0_4\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:
+:[x0] "r" ((int)(257)),[x1] "r" (x),[x2] "r" ((int)(1)),[x3] "r" (y),[x4] "r" ((int)(514))
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(uint16_t *x,uint16_t *y,uint16_t *out_1_x0,uint16_t *out_1_x3);
+
+noinline static void code1(uint16_t *x,uint16_t *y,uint16_t *out_1_x0,uint16_t *out_1_x3) {
+  void* trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"add %[x2],%[x1],#1\n"
+"#_litmus_P1_2\n\t"
+"ldarb %w[x0],[%[x2]]\n"
+"#_litmus_P1_3\n\t"
+"ldrh %w[x3],[%[x4]]\n"
+"#_litmus_P1_4\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x3] "=&r" (*out_1_x3),[x0] "=&r" (*out_1_x0),[x2] "=&r" (trashed_x2)
+:"[x0]" ((uint16_t)(0)),[x1] "r" (y),"[x3]" ((uint16_t)(0)),[x4] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  uint16_t *y = (uint16_t *)_vars->y;
+  uint16_t *x = (uint16_t *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(x,y);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    litmus_flush_tlb((void *)y);
+    _log->y = *y;
+    barrier_wait(_b);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x0,&_log->out_1_x3);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test MP-Koeln Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists ([y]=514 /\\ 1:X0=2 /\\ 1:X3=0)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=675b44091c5d4fa9768321ed98ac629b\n");
+  puts("Generator=diyone7 (version 7.54+02(dev))\n");
+  puts("Com=Rf Fr\n");
+  puts("Orig=PodWWh0L.b0 PosWWL.b0h0 Rfeh0A.b1 PodRRA.b1h0 Freh0h0\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation MP-Koeln %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time MP-Koeln ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int MP_2D_Koeln (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/R+dmb.sys.c
+++ b/mem_test/litmus-tests/R+dmb.sys.c
@@ -1,0 +1,1155 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 2
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *y,*x;
+  pteval_t *pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_1_x2;
+  int y;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("1:X2=%d;",p->out_1_x2);
+  printf(" [y]=%d;",p->y);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_1_x2 == q->out_1_x2 &&
+    p->y == q->y &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults R+dmb.sys %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_1_x2) {
+  case 0:
+    switch (p->y) {
+    case 2:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y);
+
+noinline static void code0(int *x,int *y) {
+  int trashed_x0;
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"mov %w[x0],#1\n"
+"#_litmus_P0_2\n\t"
+"str %w[x0],[%[x1]]\n"
+"#_litmus_P0_3\n\t"
+"dmb sy\n"
+"#_litmus_P0_4\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P0_5\n\t"
+"str %w[x2],[%[x3]]\n"
+"#_litmus_P0_6\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x2] "=&r" (trashed_x2),[x0] "=&r" (trashed_x0)
+:[x1] "r" (x),[x3] "r" (y)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *out_1_x2);
+
+noinline static void code1(int *x,int *y,int *out_1_x2) {
+  int trashed_x0;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"mov %w[x0],#2\n"
+"#_litmus_P1_2\n\t"
+"str %w[x0],[%[x1]]\n"
+"#_litmus_P1_3\n\t"
+"dmb sy\n"
+"#_litmus_P1_4\n\t"
+"ldr %w[x2],[%[x3]]\n"
+"#_litmus_P1_5\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x2] "=&r" (*out_1_x2),[x0] "=&r" (trashed_x0)
+:[x1] "r" (y),"[x2]" ((int)(0)),[x3] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(x,y);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    litmus_flush_tlb((void *)y);
+    _log->y = *y;
+    barrier_wait(_b);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x2);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test R+dmb.sys Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists ([y]=2 /\\ 1:X2=0)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=27b30cccf8f93d544bb1f886cf4cdf48\n");
+  puts("Cycle=Fre DMB.SYdWW Wse DMB.SYdWR\n");
+  puts("Generator=diycross7 (version 7.54+01(dev))\n");
+  puts("Com=Ws Fr\n");
+  puts("Orig=DMB.SYdWW Wse DMB.SYdWR Fre\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation R+dmb.sys %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time R+dmb.sys ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int R_2B_dmb_2E_sys (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/S+dmb.sys.c
+++ b/mem_test/litmus-tests/S+dmb.sys.c
@@ -1,0 +1,1155 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 2
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *y,*x;
+  pteval_t *pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_1_x0;
+  int x;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("1:X0=%d;",p->out_1_x0);
+  printf(" [x]=%d;",p->x);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_1_x0 == q->out_1_x0 &&
+    p->x == q->x &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults S+dmb.sys %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_1_x0) {
+  case 1:
+    switch (p->x) {
+    case 2:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y);
+
+noinline static void code0(int *x,int *y) {
+  int trashed_x0;
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"mov %w[x0],#2\n"
+"#_litmus_P0_2\n\t"
+"str %w[x0],[%[x1]]\n"
+"#_litmus_P0_3\n\t"
+"dmb sy\n"
+"#_litmus_P0_4\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P0_5\n\t"
+"str %w[x2],[%[x3]]\n"
+"#_litmus_P0_6\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x2] "=&r" (trashed_x2),[x0] "=&r" (trashed_x0)
+:[x1] "r" (x),[x3] "r" (y)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *out_1_x0);
+
+noinline static void code1(int *x,int *y,int *out_1_x0) {
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldr %w[x0],[%[x1]]\n"
+"#_litmus_P1_2\n\t"
+"dmb sy\n"
+"#_litmus_P1_3\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P1_4\n\t"
+"str %w[x2],[%[x3]]\n"
+"#_litmus_P1_5\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x0] "=&r" (*out_1_x0),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (y),[x3] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(x,y);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    _log->x = *x;
+    barrier_wait(_b);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test S+dmb.sys Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists ([x]=2 /\\ 1:X0=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=687f291fee293c61358dfb0225d8ceee\n");
+  puts("Cycle=Rfe DMB.SYdRW Wse DMB.SYdWW\n");
+  puts("Generator=diycross7 (version 7.54+01(dev))\n");
+  puts("Com=Rf Ws\n");
+  puts("Orig=DMB.SYdWW Rfe DMB.SYdRW Wse\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation S+dmb.sys %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time S+dmb.sys ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int S_2B_dmb_2E_sys (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/S+rel+CSEL-data.c
+++ b/mem_test/litmus-tests/S+rel+CSEL-data.c
@@ -1,0 +1,1172 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 3
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *z,*y,*x;
+  pteval_t *pte_z,saved_pte_z,*pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_1_x1;
+  int x;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("1:X1=%d;",p->out_1_x1);
+  printf(" [x]=%d;",p->x);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_1_x1 == q->out_1_x1 &&
+    p->x == q->x &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults S+rel+CSEL-data %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_1_x1) {
+  case 1:
+    switch (p->x) {
+    case 1:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_1_x,c_1_y,c_1_z;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+  {"c_1_z",&param.c_1_z,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d, c_1_z=%d}",p->part,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y,p->c_1_z);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y);
+
+noinline static void code0(int *x,int *y) {
+  int trashed_x9;
+  int trashed_x11;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"mov %w[x9],#1\n"
+"#_litmus_P0_2\n\t"
+"str %w[x9],[%[x10]]\n"
+"#_litmus_P0_3\n\t"
+"mov %w[x11],#1\n"
+"#_litmus_P0_4\n\t"
+"stlr %w[x11],[%[x2]]\n"
+"#_litmus_P0_5\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x11] "=&r" (trashed_x11),[x9] "=&r" (trashed_x9)
+:[x2] "r" (y),[x10] "r" (x)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *z,int *out_1_x1);
+
+noinline static void code1(int *x,int *y,int *z,int *out_1_x1) {
+  int trashed_x3;
+  int trashed_x8;
+  int trashed_x9;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldr %w[x1],[%[x2]]\n"
+"#_litmus_P1_2\n\t"
+"cmp %w[x1],#1\n"
+"#_litmus_P1_3\n\t"
+"csel %w[x3],%w[x4],%w[x5],eq\n"
+"#_litmus_P1_4\n\t"
+"str %w[x3],[%[x6]]\n"
+"#_litmus_P1_5\n\t"
+"ldr %w[x9],[%[x6]]\n"
+"#_litmus_P1_6\n\t"
+"eor %w[x8],%w[x9],%w[x9]\n"
+"#_litmus_P1_7\n\t"
+"add %w[x8],%w[x8],#2\n"
+"#_litmus_P1_8\n\t"
+"str %w[x8],[%[x10]]\n"
+"#_litmus_P1_9\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x1] "=&r" (*out_1_x1),[x9] "=&r" (trashed_x9),[x8] "=&r" (trashed_x8),[x3] "=&r" (trashed_x3)
+:"[x1]" ((int)(0)),[x2] "r" (y),[x4] "r" (0),[x5] "r" (0),[x6] "r" (z),[x10] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->z = _mem;
+  _vars->pte_z = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_z = *_p;
+  _mem += _sz ;
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *z = (int *)_vars->z;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(x,y);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    _log->x = *x;
+    barrier_wait(_b);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *z = 0;
+    litmus_flush_tlb((void *)z);
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    if (_p->c_1_z == ctouch) cache_touch((void *)z);
+    else if (_p->c_1_z == cflush) cache_flush((void *)z);
+    barrier_wait(_b);
+    code1(x,y,z,&_log->out_1_x1);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(z,_vars->pte_z,_vars->saved_pte_z);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    litmus_flush_tlb((void *)z);
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      ctx->p.c_1_z = comp_param(&c->seed,&q->c_1_z,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test S+rel+CSEL-data Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (1:X1=1 /\\ [x]=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=d59a341d01ccd1d001249bb7d4e0561c\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation S+rel+CSEL-data %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time S+rel+CSEL-data ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int S_2B_rel_2B_CSEL_2D_data (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/S+rel+CSEL-rf-reg.c
+++ b/mem_test/litmus-tests/S+rel+CSEL-rf-reg.c
@@ -1,0 +1,1149 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 2
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *y,*x;
+  pteval_t *pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_1_x1;
+  int x;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("1:X1=%d;",p->out_1_x1);
+  printf(" [x]=%d;",p->x);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_1_x1 == q->out_1_x1 &&
+    p->x == q->x &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults S+rel+CSEL-rf-reg %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_1_x1) {
+  case 1:
+    switch (p->x) {
+    case 1:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y);
+
+noinline static void code0(int *x,int *y) {
+  int trashed_x9;
+  int trashed_x11;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"mov %w[x9],#1\n"
+"#_litmus_P0_2\n\t"
+"str %w[x9],[%[x10]]\n"
+"#_litmus_P0_3\n\t"
+"mov %w[x11],#1\n"
+"#_litmus_P0_4\n\t"
+"stlr %w[x11],[%[x2]]\n"
+"#_litmus_P0_5\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x11] "=&r" (trashed_x11),[x9] "=&r" (trashed_x9)
+:[x2] "r" (y),[x10] "r" (x)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *out_1_x1);
+
+noinline static void code1(int *x,int *y,int *out_1_x1) {
+  int trashed_x3;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldr %w[x1],[%[x2]]\n"
+"#_litmus_P1_2\n\t"
+"cmp %w[x1],#1\n"
+"#_litmus_P1_3\n\t"
+"csel %w[x3],%w[x4],%w[x5],eq\n"
+"#_litmus_P1_4\n\t"
+"str %w[x3],[%[x10]]\n"
+"#_litmus_P1_5\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x1] "=&r" (*out_1_x1),[x3] "=&r" (trashed_x3)
+:"[x1]" ((int)(0)),[x2] "r" (y),[x4] "r" (0),[x5] "r" (0),[x10] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(x,y);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x1);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    _log->x = *x;
+    barrier_wait(_b);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test S+rel+CSEL-rf-reg Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (1:X1=1 /\\ [x]=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=ea465446c406b0a20d2ee3ff61d60a99\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation S+rel+CSEL-rf-reg %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time S+rel+CSEL-rf-reg ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int S_2B_rel_2B_CSEL_2D_rf_2D_reg (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/SB+dmb.sys.c
+++ b/mem_test/litmus-tests/SB+dmb.sys.c
@@ -1,0 +1,1149 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 2
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *y,*x;
+  pteval_t *pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_0_x2;
+  int out_1_x2;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("0:X2=%d;",p->out_0_x2);
+  printf(" 1:X2=%d;",p->out_1_x2);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_0_x2 == q->out_0_x2 &&
+    p->out_1_x2 == q->out_1_x2 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults SB+dmb.sys %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_0_x2) {
+  case 0:
+    switch (p->out_1_x2) {
+    case 0:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y,int *out_0_x2);
+
+noinline static void code0(int *x,int *y,int *out_0_x2) {
+  int trashed_x0;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"mov %w[x0],#1\n"
+"#_litmus_P0_2\n\t"
+"str %w[x0],[%[x1]]\n"
+"#_litmus_P0_3\n\t"
+"dmb sy\n"
+"#_litmus_P0_4\n\t"
+"ldr %w[x2],[%[x3]]\n"
+"#_litmus_P0_5\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x2] "=&r" (*out_0_x2),[x0] "=&r" (trashed_x0)
+:[x1] "r" (x),"[x2]" ((int)(0)),[x3] "r" (y)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *out_1_x2);
+
+noinline static void code1(int *x,int *y,int *out_1_x2) {
+  int trashed_x0;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"mov %w[x0],#1\n"
+"#_litmus_P1_2\n\t"
+"str %w[x0],[%[x1]]\n"
+"#_litmus_P1_3\n\t"
+"dmb sy\n"
+"#_litmus_P1_4\n\t"
+"ldr %w[x2],[%[x3]]\n"
+"#_litmus_P1_5\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x2] "=&r" (*out_1_x2),[x0] "=&r" (trashed_x0)
+:[x1] "r" (y),"[x2]" ((int)(0)),[x3] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(x,y,&_log->out_0_x2);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    litmus_flush_tlb((void *)y);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x2);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test SB+dmb.sys Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (0:X2=0 /\\ 1:X2=0)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=38b65863d32068bb3325505c2570bcef\n");
+  puts("Cycle=Fre DMB.SYdWR Fre DMB.SYdWR\n");
+  puts("Generator=diycross7 (version 7.54+01(dev))\n");
+  puts("Com=Fr Fr\n");
+  puts("Orig=DMB.SYdWR Fre DMB.SYdWR Fre\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation SB+dmb.sys %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time SB+dmb.sys ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int SB_2B_dmb_2E_sys (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/T10B.c
+++ b/mem_test/litmus-tests/T10B.c
@@ -1,0 +1,1185 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 4
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *zb,*za,*y,*x;
+  pteval_t *pte_zb,saved_pte_zb,*pte_za,saved_pte_za,*pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_0_x3;
+  int out_1_x0;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("0:X3=%d;",p->out_0_x3);
+  printf(" 1:X0=%d;",p->out_1_x0);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_0_x3 == q->out_0_x3 &&
+    p->out_1_x0 == q->out_1_x0 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults T10B %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_0_x3) {
+  case 1:
+    switch (p->out_1_x0) {
+    case 1:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_1_x,c_1_y,c_1_za,c_1_zb;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+  {"c_1_za",&param.c_1_za,id,cmax},
+  {"c_1_zb",&param.c_1_zb,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d, c_1_za=%d, c_1_zb=%d}",p->part,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y,p->c_1_za,p->c_1_zb);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y,int *out_0_x3);
+
+noinline static void code0(int *x,int *y,int *out_0_x3) {
+  int trashed_x0;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"mov %w[x0],#1\n"
+"#_litmus_P0_2\n\t"
+"ldr %w[x3],[%[x1]]\n"
+"#_litmus_P0_3\n\t"
+"stlr %w[x0],[%[x2]]\n"
+"#_litmus_P0_4\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x3] "=&r" (*out_0_x3),[x0] "=&r" (trashed_x0)
+:[x1] "r" (x),[x2] "r" (y),"[x3]" ((int)(0))
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *za,int *zb,int *out_1_x0);
+
+noinline static void code1(int *x,int *y,int *za,int *zb,int *out_1_x0) {
+  int trashed_x2;
+  int trashed_x7;
+  int trashed_x8;
+  int trashed_x10;
+  int trashed_x11;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldr %w[x0],[%[x1]]\n"
+"#_litmus_P1_2\n\t"
+"cmp %w[x0],#0\n"
+"#_litmus_P1_3\n\t"
+"csel %w[x2],%w[x4],%w[x5],eq\n"
+"#_litmus_P1_4\n\t"
+"str %w[x2],[%[x6]]\n"
+"#_litmus_P1_5\n\t"
+"ldr %w[x7],[%[x6]]\n"
+"#_litmus_P1_6\n\t"
+"str %w[x7],[%[x9]]\n"
+"#_litmus_P1_7\n\t"
+"ldr %w[x8],[%[x9]]\n"
+"#_litmus_P1_8\n\t"
+"eor %w[x10],%w[x8],%w[x8]\n"
+"#_litmus_P1_9\n\t"
+"mov %w[x11],#1\n"
+"#_litmus_P1_10\n\t"
+"str %w[x11],[%[x3],%w[x10],sxtw]\n"
+"#_litmus_P1_11\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x0] "=&r" (*out_1_x0),[x11] "=&r" (trashed_x11),[x10] "=&r" (trashed_x10),[x8] "=&r" (trashed_x8),[x7] "=&r" (trashed_x7),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (y),[x3] "r" (x),[x4] "r" (0),[x5] "r" (0),[x6] "r" (za),[x9] "r" (zb)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->zb = _mem;
+  _vars->pte_zb = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_zb = *_p;
+  _mem += _sz ;
+  _vars->za = _mem;
+  _vars->pte_za = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_za = *_p;
+  _mem += _sz ;
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *zb = (int *)_vars->zb;
+  int *za = (int *)_vars->za;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(x,y,&_log->out_0_x3);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)y);
+    litmus_flush_tlb((void *)x);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *zb = 0;
+    litmus_flush_tlb((void *)zb);
+    *za = 0;
+    litmus_flush_tlb((void *)za);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    if (_p->c_1_za == ctouch) cache_touch((void *)za);
+    else if (_p->c_1_za == cflush) cache_flush((void *)za);
+    if (_p->c_1_zb == ctouch) cache_touch((void *)zb);
+    else if (_p->c_1_zb == cflush) cache_flush((void *)zb);
+    barrier_wait(_b);
+    code1(x,y,za,zb,&_log->out_1_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(zb,_vars->pte_zb,_vars->saved_pte_zb);
+    (void)litmus_set_pte_safe(za,_vars->pte_za,_vars->saved_pte_za);
+    litmus_flush_tlb((void *)zb);
+    litmus_flush_tlb((void *)za);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      ctx->p.c_1_za = comp_param(&c->seed,&q->c_1_za,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      ctx->p.c_1_zb = comp_param(&c->seed,&q->c_1_zb,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test T10B Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (1:X0=1 /\\ 0:X3=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=1fc014528683e4c8d0a344ef09b243f0\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation T10B %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time T10B ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int T10B (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/T10C.c
+++ b/mem_test/litmus-tests/T10C.c
@@ -1,0 +1,1180 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 4
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *zb,*za,*y,*x;
+  pteval_t *pte_zb,saved_pte_zb,*pte_za,saved_pte_za,*pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_0_x3;
+  int out_1_x0;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("0:X3=%d;",p->out_0_x3);
+  printf(" 1:X0=%d;",p->out_1_x0);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_0_x3 == q->out_0_x3 &&
+    p->out_1_x0 == q->out_1_x0 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults T10C %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_0_x3) {
+  case 1:
+    switch (p->out_1_x0) {
+    case 1:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_1_x,c_1_y,c_1_za,c_1_zb;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+  {"c_1_za",&param.c_1_za,id,cmax},
+  {"c_1_zb",&param.c_1_zb,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d, c_1_za=%d, c_1_zb=%d}",p->part,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y,p->c_1_za,p->c_1_zb);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y,int *out_0_x3);
+
+noinline static void code0(int *x,int *y,int *out_0_x3) {
+  int trashed_x0;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"mov %w[x0],#1\n"
+"#_litmus_P0_2\n\t"
+"ldr %w[x3],[%[x1]]\n"
+"#_litmus_P0_3\n\t"
+"stlr %w[x0],[%[x2]]\n"
+"#_litmus_P0_4\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x3] "=&r" (*out_0_x3),[x0] "=&r" (trashed_x0)
+:[x1] "r" (x),[x2] "r" (y),"[x3]" ((int)(0))
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *za,int *zb,int *out_1_x0);
+
+noinline static void code1(int *x,int *y,int *za,int *zb,int *out_1_x0) {
+  int trashed_x2;
+  int trashed_x8;
+  int trashed_x10;
+  int trashed_x11;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldr %w[x0],[%[x1]]\n"
+"#_litmus_P1_2\n\t"
+"cmp %w[x0],#0\n"
+"#_litmus_P1_3\n\t"
+"csel %w[x2],%w[x4],%w[x5],eq\n"
+"#_litmus_P1_4\n\t"
+"str %w[x2],[%[x6]]\n"
+"#_litmus_P1_5\n\t"
+"ldr %w[x8],[%[x6]]\n"
+"#_litmus_P1_6\n\t"
+"eor %w[x10],%w[x8],%w[x8]\n"
+"#_litmus_P1_7\n\t"
+"mov %w[x11],#1\n"
+"#_litmus_P1_8\n\t"
+"str %w[x11],[%[x3],%w[x10],sxtw]\n"
+"#_litmus_P1_9\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x0] "=&r" (*out_1_x0),[x11] "=&r" (trashed_x11),[x10] "=&r" (trashed_x10),[x8] "=&r" (trashed_x8),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (y),[x3] "r" (x),[x4] "r" (0),[x5] "r" (0),[x6] "r" (za),[x9] "r" (zb)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->zb = _mem;
+  _vars->pte_zb = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_zb = *_p;
+  _mem += _sz ;
+  _vars->za = _mem;
+  _vars->pte_za = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_za = *_p;
+  _mem += _sz ;
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *zb = (int *)_vars->zb;
+  int *za = (int *)_vars->za;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(x,y,&_log->out_0_x3);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)y);
+    litmus_flush_tlb((void *)x);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *zb = 0;
+    litmus_flush_tlb((void *)zb);
+    *za = 0;
+    litmus_flush_tlb((void *)za);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    if (_p->c_1_za == ctouch) cache_touch((void *)za);
+    else if (_p->c_1_za == cflush) cache_flush((void *)za);
+    if (_p->c_1_zb == ctouch) cache_touch((void *)zb);
+    else if (_p->c_1_zb == cflush) cache_flush((void *)zb);
+    barrier_wait(_b);
+    code1(x,y,za,zb,&_log->out_1_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(zb,_vars->pte_zb,_vars->saved_pte_zb);
+    (void)litmus_set_pte_safe(za,_vars->pte_za,_vars->saved_pte_za);
+    litmus_flush_tlb((void *)zb);
+    litmus_flush_tlb((void *)za);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      ctx->p.c_1_za = comp_param(&c->seed,&q->c_1_za,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      ctx->p.c_1_zb = comp_param(&c->seed,&q->c_1_zb,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test T10C Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (1:X0=1 /\\ 0:X3=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=097669762222826bb4fe9c0075a23dab\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation T10C %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time T10C ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int T10C (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/T15-corrected.c
+++ b/mem_test/litmus-tests/T15-corrected.c
@@ -1,0 +1,1172 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 3
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *P1_L0;
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *z,*y,*x;
+  pteval_t *pte_z,saved_pte_z,*pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_1_x0;
+  int out_1_x10;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("1:X0=%d;",p->out_1_x0);
+  printf(" 1:X10=%d;",p->out_1_x10);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_1_x0 == q->out_1_x0 &&
+    p->out_1_x10 == q->out_1_x10 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults T15-corrected %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_1_x0) {
+  case 1:
+    switch (p->out_1_x10) {
+    case 0:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_1_x,c_1_y,c_1_z;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+  {"c_1_z",&param.c_1_z,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d, c_1_z=%d}",p->part,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y,p->c_1_z);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y);
+
+noinline static void code0(int *x,int *y) {
+  int trashed_x0;
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"mov %w[x0],#1\n"
+"#_litmus_P0_2\n\t"
+"str %w[x0],[%[x1]]\n"
+"#_litmus_P0_3\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P0_4\n\t"
+"stlr %w[x2],[%[x3]]\n"
+"#_litmus_P0_5\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x2] "=&r" (trashed_x2),[x0] "=&r" (trashed_x0)
+:[x1] "r" (x),[x3] "r" (y)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *z,int *out_1_x0,int *out_1_x10);
+
+noinline static void code1(int *x,int *y,int *z,int *out_1_x0,int *out_1_x10) {
+  int trashed_x2;
+  int trashed_x6;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldr %w[x0],[%[x1]]\n"
+"#_litmus_P1_2\n\t"
+"cmp %w[x0],#1\n"
+"#_litmus_P1_3\n\t"
+"csel %w[x2],%w[x3],%w[x4],eq\n"
+"#_litmus_P1_4\n\t"
+"str %w[x2],[%[x5]]\n"
+"#_litmus_P1_5\n\t"
+"ldr %w[x6],[%[x5]]\n"
+"#_litmus_P1_6\n\t"
+"cbnz %w[x6],1f\n"
+"#_litmus_P1_7\n"
+"1:\n"
+"#_litmus_P1_8\n\t"
+"isb\n"
+"#_litmus_P1_9\n\t"
+"ldr %w[x10],[%[x11]]\n"
+"#_litmus_P1_10\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x10] "=&r" (*out_1_x10),[x0] "=&r" (*out_1_x0),[x6] "=&r" (trashed_x6),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (y),[x3] "r" (0),[x4] "r" (0),[x5] "r" (z),"[x10]" ((int)(0)),[x11] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->z = _mem;
+  _vars->pte_z = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_z = *_p;
+  _mem += _sz ;
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->P1_L0 = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,0)+7;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *z = (int *)_vars->z;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(x,y);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *z = 0;
+    litmus_flush_tlb((void *)z);
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    if (_p->c_1_z == ctouch) cache_touch((void *)z);
+    else if (_p->c_1_z == cflush) cache_flush((void *)z);
+    barrier_wait(_b);
+    code1(x,y,z,&_log->out_1_x0,&_log->out_1_x10);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(z,_vars->pte_z,_vars->saved_pte_z);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    litmus_flush_tlb((void *)z);
+    litmus_flush_tlb((void *)y);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      ctx->p.c_1_z = comp_param(&c->seed,&q->c_1_z,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test T15-corrected Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (1:X0=1 /\\ 1:X10=0)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=5db46ee0793829976212675797204e06\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation T15-corrected %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time T15-corrected ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int T15_2D_corrected (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/T15-datadep-corrected.c
+++ b/mem_test/litmus-tests/T15-datadep-corrected.c
@@ -1,0 +1,1170 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 3
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *P1_L0;
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *z,*y,*x;
+  pteval_t *pte_z,saved_pte_z,*pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_1_x0;
+  int out_1_x10;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("1:X0=%d;",p->out_1_x0);
+  printf(" 1:X10=%d;",p->out_1_x10);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_1_x0 == q->out_1_x0 &&
+    p->out_1_x10 == q->out_1_x10 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults T15-datadep-corrected %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_1_x0) {
+  case 1:
+    switch (p->out_1_x10) {
+    case 0:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_1_x,c_1_y,c_1_z;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+  {"c_1_z",&param.c_1_z,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d, c_1_z=%d}",p->part,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y,p->c_1_z);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y);
+
+noinline static void code0(int *x,int *y) {
+  int trashed_x0;
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"mov %w[x0],#1\n"
+"#_litmus_P0_2\n\t"
+"str %w[x0],[%[x1]]\n"
+"#_litmus_P0_3\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P0_4\n\t"
+"stlr %w[x2],[%[x3]]\n"
+"#_litmus_P0_5\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x2] "=&r" (trashed_x2),[x0] "=&r" (trashed_x0)
+:[x1] "r" (x),[x3] "r" (y)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *z,int *out_1_x0,int *out_1_x10);
+
+noinline static void code1(int *x,int *y,int *z,int *out_1_x0,int *out_1_x10) {
+  int trashed_x2;
+  int trashed_x6;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldr %w[x0],[%[x1]]\n"
+"#_litmus_P1_2\n\t"
+"mov %w[x2],%w[x0]\n"
+"#_litmus_P1_3\n\t"
+"str %w[x2],[%[x5]]\n"
+"#_litmus_P1_4\n\t"
+"ldr %w[x6],[%[x5]]\n"
+"#_litmus_P1_5\n\t"
+"cbnz %w[x6],1f\n"
+"#_litmus_P1_6\n"
+"1:\n"
+"#_litmus_P1_7\n\t"
+"isb\n"
+"#_litmus_P1_8\n\t"
+"ldr %w[x10],[%[x11]]\n"
+"#_litmus_P1_9\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x10] "=&r" (*out_1_x10),[x0] "=&r" (*out_1_x0),[x6] "=&r" (trashed_x6),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (y),[x5] "r" (z),"[x10]" ((int)(0)),[x11] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->z = _mem;
+  _vars->pte_z = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_z = *_p;
+  _mem += _sz ;
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->P1_L0 = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,0)+6;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *z = (int *)_vars->z;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(x,y);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *z = 0;
+    litmus_flush_tlb((void *)z);
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    if (_p->c_1_z == ctouch) cache_touch((void *)z);
+    else if (_p->c_1_z == cflush) cache_flush((void *)z);
+    barrier_wait(_b);
+    code1(x,y,z,&_log->out_1_x0,&_log->out_1_x10);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(z,_vars->pte_z,_vars->saved_pte_z);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    litmus_flush_tlb((void *)z);
+    litmus_flush_tlb((void *)y);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      ctx->p.c_1_z = comp_param(&c->seed,&q->c_1_z,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test T15-datadep-corrected Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (1:X0=1 /\\ 1:X10=0)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=b7a554e4e4e1d2497c12d24244079b32\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation T15-datadep-corrected %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time T15-datadep-corrected ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int T15_2D_datadep_2D_corrected (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/T3-bis.c
+++ b/mem_test/litmus-tests/T3-bis.c
@@ -1,0 +1,1175 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 4
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *zb,*za,*y,*x;
+  pteval_t *pte_zb,saved_pte_zb,*pte_za,saved_pte_za,*pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_0_x0;
+  int out_1_x0;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("0:X0=%d;",p->out_0_x0);
+  printf(" 1:X0=%d;",p->out_1_x0);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_0_x0 == q->out_0_x0 &&
+    p->out_1_x0 == q->out_1_x0 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults T3-bis %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_0_x0) {
+  case 1:
+    switch (p->out_1_x0) {
+    case 1:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_0_za,c_0_zb,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_0_za",&param.c_0_za,id,cmax},
+  {"c_0_zb",&param.c_0_zb,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_0_za=%d, c_0_zb=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_x,p->c_0_y,p->c_0_za,p->c_0_zb,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y,int *za,int *zb,int *out_0_x0);
+
+noinline static void code0(int *x,int *y,int *za,int *zb,int *out_0_x0) {
+  int trashed_x2;
+  int trashed_x4;
+  void* trashed_x5;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"ldr %w[x0],[%[x1]]\n"
+"#_litmus_P0_2\n\t"
+"cmp %w[x0],#0\n"
+"#_litmus_P0_3\n\t"
+"csel %[x5],%[x10],%[x11],eq\n"
+"#_litmus_P0_4\n\t"
+"ldr %w[x4],[%[x5]]\n"
+"#_litmus_P0_5\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P0_6\n\t"
+"str %w[x2],[%[x3]]\n"
+"#_litmus_P0_7\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x0] "=&r" (*out_0_x0),[x5] "=&r" (trashed_x5),[x4] "=&r" (trashed_x4),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (x),[x3] "r" (y),[x10] "r" (za),[x11] "r" (zb)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *out_1_x0);
+
+noinline static void code1(int *x,int *y,int *out_1_x0) {
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldar %w[x0],[%[x1]]\n"
+"#_litmus_P1_2\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P1_3\n\t"
+"str %w[x2],[%[x3]]\n"
+"#_litmus_P1_4\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x0] "=&r" (*out_1_x0),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (y),[x3] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->zb = _mem;
+  _vars->pte_zb = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_zb = *_p;
+  _mem += _sz ;
+  _vars->za = _mem;
+  _vars->pte_za = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_za = *_p;
+  _mem += _sz ;
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *zb = (int *)_vars->zb;
+  int *za = (int *)_vars->za;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *zb = 0;
+    litmus_flush_tlb((void *)zb);
+    *za = 0;
+    litmus_flush_tlb((void *)za);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    if (_p->c_0_za == ctouch) cache_touch((void *)za);
+    else if (_p->c_0_za == cflush) cache_flush((void *)za);
+    if (_p->c_0_zb == ctouch) cache_touch((void *)zb);
+    else if (_p->c_0_zb == cflush) cache_flush((void *)zb);
+    barrier_wait(_b);
+    code0(x,y,za,zb,&_log->out_0_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(zb,_vars->pte_zb,_vars->saved_pte_zb);
+    (void)litmus_set_pte_safe(za,_vars->pte_za,_vars->saved_pte_za);
+    litmus_flush_tlb((void *)zb);
+    litmus_flush_tlb((void *)za);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)y);
+    litmus_flush_tlb((void *)x);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_0_za = comp_param(&c->seed,&q->c_0_za,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_0_zb = comp_param(&c->seed,&q->c_0_zb,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test T3-bis Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (0:X0=1 /\\ 1:X0=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=9f0ef8ba0748576166c0a6ff02f6400a\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation T3-bis %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time T3-bis ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int T3_2D_bis (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/T3.c
+++ b/mem_test/litmus-tests/T3.c
@@ -1,0 +1,1177 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 4
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *zb,*za,*y,*x;
+  pteval_t *pte_zb,saved_pte_zb,*pte_za,saved_pte_za,*pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_0_x0;
+  int out_1_x0;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("0:X0=%d;",p->out_0_x0);
+  printf(" 1:X0=%d;",p->out_1_x0);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_0_x0 == q->out_0_x0 &&
+    p->out_1_x0 == q->out_1_x0 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults T3 %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_0_x0) {
+  case 1:
+    switch (p->out_1_x0) {
+    case 1:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_0_za,c_0_zb,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_0_za",&param.c_0_za,id,cmax},
+  {"c_0_zb",&param.c_0_zb,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_0_za=%d, c_0_zb=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_x,p->c_0_y,p->c_0_za,p->c_0_zb,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y,int *za,int *zb,int *out_0_x0);
+
+noinline static void code0(int *x,int *y,int *za,int *zb,int *out_0_x0) {
+  int trashed_x2;
+  int trashed_x4;
+  void* trashed_x5;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"ldr %w[x0],[%[x1]]\n"
+"#_litmus_P0_2\n\t"
+"cmp %w[x0],#0\n"
+"#_litmus_P0_3\n\t"
+"csel %[x5],%[x10],%[x11],eq\n"
+"#_litmus_P0_4\n\t"
+"str %w[x4],[%[x5]]\n"
+"#_litmus_P0_5\n\t"
+"ldr %w[x4],[%[x5]]\n"
+"#_litmus_P0_6\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P0_7\n\t"
+"str %w[x2],[%[x3]]\n"
+"#_litmus_P0_8\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x0] "=&r" (*out_0_x0),[x5] "=&r" (trashed_x5),[x4] "=&r" (trashed_x4),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (x),[x3] "r" (y),"[x4]" (0),[x10] "r" (za),[x11] "r" (zb)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *out_1_x0);
+
+noinline static void code1(int *x,int *y,int *out_1_x0) {
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldar %w[x0],[%[x1]]\n"
+"#_litmus_P1_2\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P1_3\n\t"
+"str %w[x2],[%[x3]]\n"
+"#_litmus_P1_4\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x0] "=&r" (*out_1_x0),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (y),[x3] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->zb = _mem;
+  _vars->pte_zb = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_zb = *_p;
+  _mem += _sz ;
+  _vars->za = _mem;
+  _vars->pte_za = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_za = *_p;
+  _mem += _sz ;
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *zb = (int *)_vars->zb;
+  int *za = (int *)_vars->za;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *zb = 0;
+    litmus_flush_tlb((void *)zb);
+    *za = 0;
+    litmus_flush_tlb((void *)za);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    if (_p->c_0_za == ctouch) cache_touch((void *)za);
+    else if (_p->c_0_za == cflush) cache_flush((void *)za);
+    if (_p->c_0_zb == ctouch) cache_touch((void *)zb);
+    else if (_p->c_0_zb == cflush) cache_flush((void *)zb);
+    barrier_wait(_b);
+    code0(x,y,za,zb,&_log->out_0_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(zb,_vars->pte_zb,_vars->saved_pte_zb);
+    (void)litmus_set_pte_safe(za,_vars->pte_za,_vars->saved_pte_za);
+    litmus_flush_tlb((void *)zb);
+    litmus_flush_tlb((void *)za);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)y);
+    litmus_flush_tlb((void *)x);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_0_za = comp_param(&c->seed,&q->c_0_za,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_0_zb = comp_param(&c->seed,&q->c_0_zb,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test T3 Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (0:X0=1 /\\ 1:X0=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=ced0ccca35632d5cb39384962903a48f\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation T3 %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time T3 ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int T3 (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/T7.c
+++ b/mem_test/litmus-tests/T7.c
@@ -1,0 +1,1184 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 4
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *z,*y,*x,*a;
+  pteval_t *pte_z,saved_pte_z,*pte_y,saved_pte_y,*pte_x,saved_pte_x,*pte_a,saved_pte_a;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_0_x0;
+  int out_1_x0;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("0:X0=%d;",p->out_0_x0);
+  printf(" 1:X0=%d;",p->out_1_x0);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_0_x0 == q->out_0_x0 &&
+    p->out_1_x0 == q->out_1_x0 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults T7 %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_0_x0) {
+  case 1:
+    switch (p->out_1_x0) {
+    case 1:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_a,c_0_x,c_0_y,c_0_z,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_a",&param.c_0_a,id,cmax},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_0_z",&param.c_0_z,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_a=%d, c_0_x=%d, c_0_y=%d, c_0_z=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_a,p->c_0_x,p->c_0_y,p->c_0_z,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *a,int *x,int *y,int *z,int *out_0_x0);
+
+noinline static void code0(int *a,int *x,int *y,int *z,int *out_0_x0) {
+  int trashed_x2;
+  int trashed_x3;
+  int trashed_x4;
+  int trashed_x8;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"ldr %w[x0],[%[x1]]\n"
+"#_litmus_P0_2\n\t"
+"cmp %w[x0],#1\n"
+"#_litmus_P0_3\n\t"
+"mov %w[x3],#0\n"
+"#_litmus_P0_4\n\t"
+"mov %w[x4],#1\n"
+"#_litmus_P0_5\n\t"
+"csel %w[x2],%w[x3],%w[x4],eq\n"
+"#_litmus_P0_6\n\t"
+"str %w[x2],[%[x5]]\n"
+"#_litmus_P0_7\n\t"
+"ldar %w[x2],[%[x5]]\n"
+"#_litmus_P0_8\n\t"
+"ldr %w[x8],[%[x7]]\n"
+"#_litmus_P0_9\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P0_10\n\t"
+"str %w[x2],[%[x9]]\n"
+"#_litmus_P0_11\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x0] "=&r" (*out_0_x0),[x8] "=&r" (trashed_x8),[x4] "=&r" (trashed_x4),[x3] "=&r" (trashed_x3),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (x),[x5] "r" (z),[x7] "r" (a),[x9] "r" (y)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *out_1_x0);
+
+noinline static void code1(int *x,int *y,int *out_1_x0) {
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldar %w[x0],[%[x1]]\n"
+"#_litmus_P1_2\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P1_3\n\t"
+"str %w[x2],[%[x3]]\n"
+"#_litmus_P1_4\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x0] "=&r" (*out_1_x0),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (y),[x3] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->z = _mem;
+  _vars->pte_z = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_z = *_p;
+  _mem += _sz ;
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+  _vars->a = _mem;
+  _vars->pte_a = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_a = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *z = (int *)_vars->z;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  int *a = (int *)_vars->a;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *z = 0;
+    litmus_flush_tlb((void *)z);
+    *a = 0;
+    litmus_flush_tlb((void *)a);
+    barrier_wait(_b);
+    if (_p->c_0_a == ctouch) cache_touch((void *)a);
+    else if (_p->c_0_a == cflush) cache_flush((void *)a);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    if (_p->c_0_z == ctouch) cache_touch((void *)z);
+    else if (_p->c_0_z == cflush) cache_flush((void *)z);
+    barrier_wait(_b);
+    code0(a,x,y,z,&_log->out_0_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(z,_vars->pte_z,_vars->saved_pte_z);
+    (void)litmus_set_pte_safe(a,_vars->pte_a,_vars->saved_pte_a);
+    litmus_flush_tlb((void *)z);
+    litmus_flush_tlb((void *)a);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)y);
+    litmus_flush_tlb((void *)x);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_a = comp_param(&c->seed,&q->c_0_a,cmax,1);
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_0_z = comp_param(&c->seed,&q->c_0_z,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test T7 Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (0:X0=1 /\\ 1:X0=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=552d6657c8ca5f47b7f32e463e853fde\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation T7 %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time T7 ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int T7 (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/T7dep.c
+++ b/mem_test/litmus-tests/T7dep.c
@@ -1,0 +1,1187 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 4
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *z,*y,*x,*a;
+  pteval_t *pte_z,saved_pte_z,*pte_y,saved_pte_y,*pte_x,saved_pte_x,*pte_a,saved_pte_a;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_0_x0;
+  int out_1_x0;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("0:X0=%d;",p->out_0_x0);
+  printf(" 1:X0=%d;",p->out_1_x0);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_0_x0 == q->out_0_x0 &&
+    p->out_1_x0 == q->out_1_x0 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults T7dep %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_0_x0) {
+  case 1:
+    switch (p->out_1_x0) {
+    case 1:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_a,c_0_x,c_0_y,c_0_z,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_a",&param.c_0_a,id,cmax},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_0_z",&param.c_0_z,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_a=%d, c_0_x=%d, c_0_y=%d, c_0_z=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_a,p->c_0_x,p->c_0_y,p->c_0_z,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *a,int *x,int *y,int *z,int *out_0_x0);
+
+noinline static void code0(int *a,int *x,int *y,int *z,int *out_0_x0) {
+  int trashed_x2;
+  int trashed_x3;
+  int trashed_x4;
+  int trashed_x8;
+  int trashed_x10;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"ldr %w[x0],[%[x1]]\n"
+"#_litmus_P0_2\n\t"
+"cmp %w[x0],#1\n"
+"#_litmus_P0_3\n\t"
+"mov %w[x3],#0\n"
+"#_litmus_P0_4\n\t"
+"mov %w[x4],#1\n"
+"#_litmus_P0_5\n\t"
+"csel %w[x2],%w[x3],%w[x4],eq\n"
+"#_litmus_P0_6\n\t"
+"str %w[x2],[%[x5]]\n"
+"#_litmus_P0_7\n\t"
+"ldr %w[x2],[%[x5]]\n"
+"#_litmus_P0_8\n\t"
+"eor %w[x10],%w[x2],%w[x2]\n"
+"#_litmus_P0_9\n\t"
+"ldr %w[x8],[%[x7],%w[x10],sxtw]\n"
+"#_litmus_P0_10\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P0_11\n\t"
+"str %w[x2],[%[x9]]\n"
+"#_litmus_P0_12\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x0] "=&r" (*out_0_x0),[x10] "=&r" (trashed_x10),[x8] "=&r" (trashed_x8),[x4] "=&r" (trashed_x4),[x3] "=&r" (trashed_x3),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (x),[x5] "r" (z),[x7] "r" (a),[x9] "r" (y)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *out_1_x0);
+
+noinline static void code1(int *x,int *y,int *out_1_x0) {
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldar %w[x0],[%[x1]]\n"
+"#_litmus_P1_2\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P1_3\n\t"
+"str %w[x2],[%[x3]]\n"
+"#_litmus_P1_4\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x0] "=&r" (*out_1_x0),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (y),[x3] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->z = _mem;
+  _vars->pte_z = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_z = *_p;
+  _mem += _sz ;
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+  _vars->a = _mem;
+  _vars->pte_a = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_a = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *z = (int *)_vars->z;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  int *a = (int *)_vars->a;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *z = 0;
+    litmus_flush_tlb((void *)z);
+    *a = 0;
+    litmus_flush_tlb((void *)a);
+    barrier_wait(_b);
+    if (_p->c_0_a == ctouch) cache_touch((void *)a);
+    else if (_p->c_0_a == cflush) cache_flush((void *)a);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    if (_p->c_0_z == ctouch) cache_touch((void *)z);
+    else if (_p->c_0_z == cflush) cache_flush((void *)z);
+    barrier_wait(_b);
+    code0(a,x,y,z,&_log->out_0_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(z,_vars->pte_z,_vars->saved_pte_z);
+    (void)litmus_set_pte_safe(a,_vars->pte_a,_vars->saved_pte_a);
+    litmus_flush_tlb((void *)z);
+    litmus_flush_tlb((void *)a);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)y);
+    litmus_flush_tlb((void *)x);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_a = comp_param(&c->seed,&q->c_0_a,cmax,1);
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_0_z = comp_param(&c->seed,&q->c_0_z,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test T7dep Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (0:X0=1 /\\ 1:X0=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=0470a2ed9f48d4de9acce9fe08b1250a\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation T7dep %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time T7dep ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int T7dep (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/T8+BIS.c
+++ b/mem_test/litmus-tests/T8+BIS.c
@@ -1,0 +1,1178 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 3
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *z,*y,*x;
+  pteval_t *pte_z,saved_pte_z,*pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_0_x7;
+  int out_0_x0;
+  int out_1_x0;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("0:X0=%d;",p->out_0_x0);
+  printf(" 0:X7=%d;",p->out_0_x7);
+  printf(" 1:X0=%d;",p->out_1_x0);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_0_x0 == q->out_0_x0 &&
+    p->out_0_x7 == q->out_0_x7 &&
+    p->out_1_x0 == q->out_1_x0 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults T8+BIS %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_0_x0) {
+  case 1:
+    switch (p->out_0_x7) {
+    case 0:
+      switch (p->out_1_x0) {
+      case 1:
+        return 1;
+      default:
+        return 0;
+      }
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_0_z,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_0_z",&param.c_0_z,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_0_z=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_x,p->c_0_y,p->c_0_z,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 55
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y,int *z,int *out_0_x0,int *out_0_x7);
+
+noinline static void code0(int *x,int *y,int *z,int *out_0_x0,int *out_0_x7) {
+  int trashed_x2;
+  int trashed_x3;
+  int trashed_x8;
+  int trashed_x9;
+  int trashed_x11;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"ldr %w[x0],[%[x1]]\n"
+"#_litmus_P0_2\n\t"
+"cmp %w[x0],#1\n"
+"#_litmus_P0_3\n\t"
+"csel %w[x2],%w[x3],%w[x4],eq\n"
+"#_litmus_P0_4\n\t"
+"str %w[x2],[%[x5]]\n"
+"#_litmus_P0_5\n\t"
+"ldxr %w[x3],[%[x5]]\n"
+"#_litmus_P0_6\n\t"
+"ldr %w[x8],[%[x5]]\n"
+"#_litmus_P0_7\n\t"
+"eor %w[x9],%w[x8],%w[x8]\n"
+"#_litmus_P0_8\n\t"
+"mov %w[x11],#1\n"
+"#_litmus_P0_9\n\t"
+"str %w[x11],[%[x10],%w[x9],sxtw]\n"
+"#_litmus_P0_10\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x7] "=&r" (*out_0_x7),[x0] "=&r" (*out_0_x0),[x11] "=&r" (trashed_x11),[x9] "=&r" (trashed_x9),[x8] "=&r" (trashed_x8),[x3] "=&r" (trashed_x3),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (x),"[x3]" (0),[x4] "r" (0),[x5] "r" (z),"[x7]" ((int)(0)),[x10] "r" (y)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *out_1_x0);
+
+noinline static void code1(int *x,int *y,int *out_1_x0) {
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldar %w[x0],[%[x1]]\n"
+"#_litmus_P1_2\n\t"
+"mov %w[x2],#1\n"
+"#_litmus_P1_3\n\t"
+"str %w[x2],[%[x3]]\n"
+"#_litmus_P1_4\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x0] "=&r" (*out_1_x0),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (y),[x3] "r" (x)
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->z = _mem;
+  _vars->pte_z = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_z = *_p;
+  _mem += _sz ;
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *z = (int *)_vars->z;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *z = 0;
+    litmus_flush_tlb((void *)z);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    if (_p->c_0_z == ctouch) cache_touch((void *)z);
+    else if (_p->c_0_z == cflush) cache_flush((void *)z);
+    barrier_wait(_b);
+    code0(x,y,z,&_log->out_0_x0,&_log->out_0_x7);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(z,_vars->pte_z,_vars->saved_pte_z);
+    litmus_flush_tlb((void *)z);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x0);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)y);
+    litmus_flush_tlb((void *)x);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_0_z = comp_param(&c->seed,&q->c_0_z,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test T8+BIS Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (0:X0=1 /\\ 0:X7=0 /\\ 1:X0=1)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=0507e9cbaa49eba775868726822e67dd\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation T8+BIS %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time T8+BIS ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int T8_2B_BIS (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/T9B.c
+++ b/mem_test/litmus-tests/T9B.c
@@ -1,0 +1,1151 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* This C source is a product of litmus7 and includes source that is        */
+/* governed by the CeCILL-B license.                                        */
+/****************************************************************************/
+/* Parameters */
+#define OUT_n 1
+#define SIZE_OF_TEST 5000
+#define NUMBER_OF_RUN 200
+#define AVAIL 4
+#define N_n 2
+#define NVARS 2
+#define NEXE 2
+#define NTHREADS 4
+#define NOCCS 1
+/* Includes */
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif /* __ARM_NEON */
+#define STATS 1
+#define KVM 1
+#include <libcflat.h>
+#include "kvm-headers.h"
+#include "utils.h"
+
+typedef uint32_t count_t;
+#define PCTR PRIu32
+
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+/***************************/
+/* Get instruction opcodes */
+/***************************/
+
+static ins_t getnop(void) {
+  ins_t *x1;
+  ins_t r;
+  asm __volatile__ (
+    "adr %[x1],0f\n\t"
+    "ldr %w[x2],[%[x1]]\n\t"
+    "b 1f\n"
+    "0:\n\t"
+    "nop\n"
+    "1:\n"
+    :[x1] "=&r" (x1),[x2] "=&r" (r)
+    :
+    : "cc", "memory"
+);
+  return r;
+}
+
+
+static ins_t nop;
+
+
+// Find index of some instruction in code, skipping 'skip' occurrences
+static size_t find_ins(ins_t opcode,ins_t *p,int skip) {
+  ins_t *q = p;
+
+  for  ( ; *q != opcode || (skip-- > 0); q++);
+  return q-p ;
+}
+
+/* Cache flush/fetch instructions */
+#define CACHE_FLUSH 1
+inline static void cache_flush(void *p) {
+#ifdef CACHE_FLUSH
+  asm __volatile__ ("dc civac,%[p]" :: [p] "r" (p) : "memory");
+#endif
+}
+
+inline static void cache_touch(void *p) {
+  asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+
+#ifdef CACHE_TOUCH_STORE
+inline static void cache_touch_store(void *p) {
+  asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
+}
+#endif
+
+
+
+typedef struct {
+  volatile int c,sense;
+  int n ;
+} sense_t;
+
+static void barrier_init (sense_t *p,int n) {
+  p->n = p->c = n;
+  p->sense = 0;
+}
+
+/*
+barrier_wait:
+	ldr	w2, [x0,4]
+.L28:
+	ldaxr	w1, [x0]
+	sub	w1, w1, #1
+	stlxr	w3, w1, [x0]
+	cbnz	w3, .L28
+	cmp	w1, wzr
+	ble	.L24
+.L26:
+	ldr	w1, [x0,4]
+	cmp	w1, w2
+	beq	.L26
+	dmb	ish
+.L24:
+	ldr	w1, [x0,8]
+	str	w1, [x0]
+	mov	w1, 1
+	dmb	ish
+	sub	w2, w1, w2
+	str	w2, [x0,4]
+	dmb	ish
+	ret
+*/
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  int r1,r3 ;
+asm __volatile (
+"dmb sy\n"
+"0:\n\t"
+"ldxr %w[r1],%[c]\n\t"
+"sub %w[r1],%w[r1],#1\n\t"
+"stxr %w[r3],%w[r1],%[c]\n\t"
+"cbnz %w[r3],0b\n\t"
+"cmp %w[r1],wzr\n\t"
+"ble 2f\n\t"
+"dmb sy\n"
+"1:\n\t"
+"ldr %w[r1],%[s]\n\t"
+"cmp %w[r1],%w[ms]\n\t"
+"beq 1b\n\t"
+"b 3f\n"
+"2:\n\t"
+"dmb sy\n\t"
+"ldr %w[r1],%[n]\n\t"
+"str %w[r1],%[c]\n\t"
+"mov %w[r3],#1\n\t"
+"dmb sy\n\t"
+"sub %w[ms],%w[r3],%w[ms]\n\t"
+"str %w[ms],%[s]\n"
+"3:\n\t"
+"dsb sy\n\t"
+: [r1] "=&r" (r1), [r3] "=&r" (r3)
+: [c] "m" (p->c), [s] "m" (p->sense), [ms] "r" (sense), [n] "m" (p->n)
+: "memory") ;
+}
+#if 0
+/* C version */
+static void barrier_wait(sense_t *p) {
+  int sense = p->sense ;
+  __sync_synchronize() ;
+  int rem = __sync_add_and_fetch(&p->c,-1) ;
+  if (rem > 0) {
+    while (p->sense == sense) ;
+    __sync_synchronize() ;
+  } else {
+    p->c = p->n ;
+    __sync_synchronize() ;
+    p->sense = 1-sense ;
+    __sync_synchronize() ;
+  }
+}
+#endif
+/************/
+/* Topology */
+/************/
+
+/*
+ Topology: {{{0}, {1}, {2}, {3}}}
+*/
+
+static const int inst[] = {
+// [[0],[1]]
+1, 1, 0, 0,
+};
+
+static const int role[] = {
+// [[0],[1]]
+1, 0, 1, 0,
+};
+
+static const char *group[] = {
+"[[0],[1]]",
+};
+
+#define SCANSZ 1
+#define SCANLINE 4
+
+typedef struct {
+  ins_t *P1_LC00;
+  ins_t *ret[N_n];
+} labels_t;
+
+/************/
+/* Outcomes */
+/************/
+#define SOME_VARS 1
+typedef struct {
+  intmax_t *y,*x;
+  pteval_t *pte_y,saved_pte_y,*pte_x,saved_pte_x;
+  labels_t labels;
+} vars_t;
+
+
+typedef struct {
+  int out_1_x0;
+  int out_1_x6;
+} log_t;
+
+/* Dump of outcome */
+static void pp_log(FILE *chan,log_t *p) {
+  printf("1:X0=%d;",p->out_1_x0);
+  printf(" 1:X6=%d;",p->out_1_x6);
+}
+
+/* Equality of outcomes */
+static int eq_log(log_t *p,log_t *q) {
+  return
+    p->out_1_x0 == q->out_1_x0 &&
+    p->out_1_x6 == q->out_1_x6 &&
+    1;
+}
+
+/* Fault Handling */
+#define HAVE_FAULT_HANDLER 1
+
+typedef struct { int instance,proc; } who_t;
+
+static count_t nfaults[NTHREADS];
+static who_t whoami[AVAIL];
+
+typedef uint32_t ins_t; /* Type of instructions */
+
+#define PRECISE 1
+
+static vars_t *vars_ptr[NEXE];
+static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)
+{
+  return 0;
+}
+
+
+static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
+#ifdef SEE_FAULTS
+  th_faults_info_t *th_flts = &th_faults[w->instance][w->proc];
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  fault_info_t flt;
+  unsigned long far;
+
+  flt.instr_symb = get_instr_symb_id(lbls, pc);
+  if (get_far(esr, &far)) {
+    flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
+  } else {
+    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+  }
+  flt.type = get_fault_type(esr);
+
+  if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
+    return;
+  }
+
+  if (exists_fault(th_flts, flt.instr_symb, flt.data_symb, flt.type))
+    return;
+
+  if (th_flts->n < MAX_FAULTS_PER_THREAD) {
+    th_flts->faults[th_flts->n++] = flt;
+  }
+#endif
+}
+
+static void fault_handler(struct pt_regs *regs,unsigned int esr) {
+  struct thread_info *ti = current_thread_info();
+  who_t *w = &whoami[ti->cpu];
+  atomic_inc_fetch(&nfaults[w->proc]);
+
+  record_fault(w, regs->pc, esr);
+#ifdef PRECISE
+  labels_t *lbls = &vars_ptr[w->instance]->labels;
+  regs->pc = (u64)lbls->ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
+#endif
+}
+
+static void install_fault_handler(int cpu) {
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+#endif
+}
+
+static void pp_faults(void) {
+  count_t total=0;
+  for (int k=0 ; k < NTHREADS; k++) { total += nfaults[k]; }
+  if (total > 0) {
+    printf("Faults T9B %"PCTR"",total);
+    for (int k = 0 ; k < NTHREADS ; k++) {
+      count_t c = nfaults[k];
+      if (c > 0) printf(" P%d:%"PCTR"",k,c);
+    }
+    printf("\n");
+  }
+}
+
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}
+
+static void set_fault_vector(int role) { }
+
+inline static int final_cond(log_t *p) {
+  switch (p->out_1_x0) {
+  case 1:
+    switch (p->out_1_x6) {
+    case 0:
+      return 1;
+    default:
+      return 0;
+    }
+  default:
+    return 0;
+  }
+}
+
+inline static int final_ok(int cond) {
+  return cond;
+}
+
+
+/**************/
+/* Parameters */
+/**************/
+
+typedef enum { cignore, cflush, ctouch, cmax, } dir_t;
+
+typedef struct {
+  int part;
+  int c_0_x,c_0_y,c_1_x,c_1_y;
+} param_t;
+
+static param_t param = {-1, -1, -1, -1, -1,};
+
+static int id(int x) { return x; }
+
+static parse_param_t parse[] = {
+  {"part",&param.part,id,SCANSZ},
+  {"c_0_x",&param.c_0_x,id,cmax},
+  {"c_0_y",&param.c_0_y,id,cmax},
+  {"c_1_x",&param.c_1_x,id,cmax},
+  {"c_1_y",&param.c_1_y,id,cmax},
+};
+
+#define PARSESZ (sizeof(parse)/sizeof(parse[0]))
+
+static void pp_param(FILE *out,param_t *p) {
+  printf("{part=%d, c_0_x=%d, c_0_y=%d, c_1_x=%d, c_1_y=%d}",p->part,p->c_0_x,p->c_0_y,p->c_1_x,p->c_1_y);
+}
+
+typedef struct {
+  count_t groups[SCANSZ];
+  count_t vars;
+  count_t delays;
+  count_t dirs[cmax][cmax][cmax][cmax];
+} stats_t;
+
+#define HASHSZ 19
+
+
+/* Notice: this file contains public domain code by Bob Jenkins */
+
+typedef struct {
+  log_t key ;
+#ifdef STATS
+  param_t p ;
+#endif
+  count_t c ;
+  int ok ;
+} entry_t ;
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
+
+typedef struct {
+  int nhash ;
+  entry_t t[HASHSZ] ;
+} hash_t ;
+
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0) {
+      pp_entry(fp,p,verbose,group) ;
+    }
+  }
+}
+
+#if 0
+static void pp_hash_ok(FILE *fp,hash_t *t,char **group) {
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = t->t+k ;
+    if (p->c > 0 && p->ok) pp_entry(fp,p,1,group) ;
+  }
+}
+#endif
+
+static void log_init(log_t *p) {
+  uint32_t *q = (uint32_t *)p ;
+
+  for (int k = sizeof(log_t)/sizeof(uint32_t) ; k > 0 ; k--)
+    *q++ = -1 ;
+}
+
+static void hash_init(hash_t *t) {
+  t->nhash = 0 ;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    t->t[k].c = 0 ;
+    log_init(&t->t[k].key) ;
+  }
+}
+
+/*
+ Bob Jenkins hashword function, (Public domain)
+ See <http://burtleburtle.net/bob/hash/doobs.html>
+*/
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+
+#define mix(a,b,c) \
+{ \
+  a -= c;  a ^= rot(c, 4);  c += b; \
+  b -= a;  b ^= rot(a, 6);  a += c; \
+  c -= b;  c ^= rot(b, 8);  b += a; \
+  a -= c;  a ^= rot(c,16);  c += b; \
+  b -= a;  b ^= rot(a,19);  a += c; \
+  c -= b;  c ^= rot(b, 4);  b += a; \
+}
+
+#define final(a,b,c) \
+{ \
+  c ^= b; c -= rot(b,14); \
+  a ^= c; a -= rot(c,11); \
+  b ^= a; b -= rot(a,25); \
+  c ^= b; c -= rot(b,16); \
+  a ^= c; a -= rot(c,4);  \
+  b ^= a; b -= rot(a,14); \
+  c ^= b; c -= rot(b,24); \
+}
+
+static uint32_t hashword(
+const uint32_t *k,                   /* the key, an array of uint32_t values */
+size_t          length)              /* the length of the key, in uint32_ts */
+{
+  uint32_t a,b,c;
+
+  /* Set up the internal state */
+  a = b = c = 0xdeadbeef ;
+
+  /*------------------------------------------------- handle most of the key */
+  while (length > 3)
+  {
+    a += k[0];
+    b += k[1];
+    c += k[2];
+    mix(a,b,c);
+    length -= 3;
+    k += 3;
+  }
+
+  /*------------------------------------------- handle the last 3 uint32_t's */
+  switch(length)                     /* all the case statements fall through */
+  {
+  case 3 : c+=k[2];
+  case 2 : b+=k[1];
+  case 1 : a+=k[0];
+    final(a,b,c);
+  case 0:     /* case 0: nothing left to add */
+    break;
+  }
+  /*------------------------------------------------------ report the result */
+  return c;
+}
+
+static uint32_t hash_log (log_t *key) {
+  return hashword((uint32_t *)key,sizeof(log_t)/sizeof(uint32_t)) ;
+}
+
+#ifdef STATS
+static int hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
+#else
+static int hash_add(hash_t *t,log_t *key, count_t c,int ok) {
+#endif
+  uint32_t h = hash_log(key) ;
+  h = h % HASHSZ ;
+  for (int k = 0 ; k < HASHSZ ;  k++) {
+    entry_t *p = t->t + h ;
+    if (p->c == 0) { /* New entry */
+      p->key = *key ;
+#ifdef STATS
+      p->p = *v ;
+#endif
+      p->c = c ;
+      p->ok = ok ;
+      t->nhash++ ;
+      return 1 ;
+    } else if (eq_log(key,&p->key)) {
+      p->c += c ;
+      return 1;
+    }
+    h++ ;
+    h %= HASHSZ ;
+  }
+  return 0;
+}
+
+static int hash_adds(hash_t *t, hash_t *f) {
+  int r = 1;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *p = f->t+k ;
+    if (p->c > 0) {
+#ifdef STATS
+      int rloc = hash_add(t,&p->key,&p->p,p->c,p->ok) ;
+#else
+      int rloc = hash_add(t,&p->key,p->c,p->ok) ;
+#endif
+      r = r && rloc;
+    }
+  }
+  return r;
+}
+
+static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) {
+  printf("%-6" PCTR "%c>",p->c,p->ok ? '*' : ':');
+  pp_log(out,&p->key);
+  if (verbose) {
+    puts(" # ");
+    pp_param(out,&p->p);
+    puts(" ");
+    puts(group[p->p.part]);
+  }
+  printf("%c",'\n');
+}
+
+static void set_feature(int _role) { }
+/*************/
+/* Test code */
+/*************/
+
+typedef void (*code0_t)(int *x,int *y);
+
+noinline static void code0(int *x,int *y) {
+  int trashed_x0;
+asm __volatile__ (
+"\n"
+"#START _litmus_P0\n"
+"#_litmus_P0_0\n\t"
+"nop\n"
+"#_litmus_P0_1\n\t"
+"mov %w[x0],#1\n"
+"#_litmus_P0_2\n\t"
+"str %w[x0],[%[x1]]\n"
+"#_litmus_P0_3\n\t"
+"stlr %w[x0],[%[x2]]\n"
+"#_litmus_P0_4\n\t"
+"nop\n"
+"#END _litmus_P0\n"
+:[x0] "=&r" (trashed_x0)
+:[x1] "r" (x),[x2] "r" (y)
+:"cc","memory"
+);
+}
+
+typedef void (*code1_t)(int *x,int *y,int *out_1_x0,int *out_1_x6);
+
+noinline static void code1(int *x,int *y,int *out_1_x0,int *out_1_x6) {
+  int trashed_x2;
+asm __volatile__ (
+"\n"
+"#START _litmus_P1\n"
+"#_litmus_P1_0\n\t"
+"nop\n"
+"#_litmus_P1_1\n\t"
+"ldr %w[x0],[%[x1]]\n"
+"#_litmus_P1_2\n\t"
+"cmp %w[x0],#0\n"
+"#_litmus_P1_3\n\t"
+"csel %w[x2],%w[x4],%w[x5],eq\n"
+"#_litmus_P1_4\n\t"
+"cbnz %w[x2],1f\n"
+"#_litmus_P1_5\n"
+"1:\n"
+"#_litmus_P1_6\n\t"
+"isb\n"
+"#_litmus_P1_7\n\t"
+"ldr %w[x6],[%[x3]]\n"
+"#_litmus_P1_8\n\t"
+"nop\n"
+"#END _litmus_P1\n"
+:[x6] "=&r" (*out_1_x6),[x0] "=&r" (*out_1_x0),[x2] "=&r" (trashed_x2)
+:"[x0]" ((int)(0)),[x1] "r" (y),[x3] "r" (x),[x4] "r" (0),[x5] "r" (0),"[x6]" ((int)(0))
+:"cc","memory"
+);
+}
+
+/***************/
+/* Memory size */
+/***************/
+
+/* Page size line */
+#define LINE LITMUS_PAGE_SIZE
+
+static void vars_init(vars_t *_vars,intmax_t *_mem) {
+  const size_t _sz = LINE/sizeof(intmax_t);
+  pteval_t *_p;
+
+  _vars->y = _mem;
+  _vars->pte_y = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_y = *_p;
+  _mem += _sz ;
+  _vars->x = _mem;
+  _vars->pte_x = _p = litmus_tr_pte((void *)_mem);
+  _vars->saved_pte_x = *_p;
+  _mem += _sz ;
+}
+
+static void vars_free(vars_t *_vars) {
+}
+
+static void labels_init(vars_t *_vars) {
+  labels_t *lbls = &_vars->labels;
+  lbls->P1_LC00 = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,0)+5;
+  lbls->ret[0] = ((ins_t *)code0)+find_ins(nop,(ins_t *)code0,1);
+  lbls->ret[1] = ((ins_t *)code1)+find_ins(nop,(ins_t *)code1,1);
+}
+
+
+/************/
+/* Instance */
+/************/
+
+typedef struct {
+  int id ;
+  intmax_t *mem;
+  log_t out;
+#ifdef SOME_PTR
+  log_ptr_t out_ptr;
+#endif
+#ifdef SOME_VARS
+  vars_t v;
+#endif
+#ifdef HAVE_TIMEBASE
+  tb_t next_tb;
+#endif
+  hash_t t;
+  sense_t b;
+  param_t p;
+  int ind[N_n]; /* Indirection for role shuffle */
+} ctx_t ;
+
+
+static void instance_init(ctx_t *p, int id, intmax_t *mem) {
+  p->id = id ;
+  p->mem = mem ;
+  hash_init(&p->t) ;
+  log_init(&p->out) ;
+  barrier_init(&p->b,N_n) ;
+  interval_init((int *)&p->ind,N_n) ;
+#ifdef SOME_VARS
+  vars_init(&p->v,mem);
+  labels_init(&p->v);
+#endif
+}
+
+static void instance_free(ctx_t *p) {
+#ifdef SOME_VARS
+  vars_free(&p->v);
+#endif
+}
+
+/******************/
+/* Global context */
+/******************/
+
+#define LINESZ (LINE/sizeof(intmax_t))
+#define VOFFSZ (VOFF/sizeof(intmax_t))
+#define MEMSZ ((NVARS*NEXE+1)*LINESZ)
+
+#ifndef DYNALLOC
+static intmax_t mem[MEMSZ] ;
+#endif
+
+typedef struct global_t {
+  /* Command-line parameter */
+  param_t *param ;
+  parse_param_t *parse ;
+  /* Topology */
+  const int *inst, *role ;
+  const char **group ;
+  /* memory */
+  intmax_t *mem ;
+  /* Cache control */
+#ifdef ACTIVE
+  active_t *active;
+#endif
+  /* Runtime control */
+  int verbose ;
+  int size,nruns,nexe,noccs ;
+  int delay,step ;
+  int fix ;
+  /* Indirection for shuffling all threads */
+  int ind[AVAIL] ;
+  /* Synchronisation for all threads */
+  sense_t gb ;
+  /* Count 'interesting' outcomes */
+  volatile int ok ;
+  /* Times for timeout */
+  tsc_t start,now ;
+  /* All instance contexts */
+  ctx_t ctx[NEXE] ; /* All test instance contexts */
+  hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
+#ifdef STATS
+  /* statistics */
+  stats_t stats ;
+#endif
+} global_t ;
+
+
+static void init_global(global_t *g) {
+  g->param = &param;
+  g->parse = &parse[0];
+  g->inst = inst;
+  g->role = role;
+  g->group = group;
+#ifdef ACTIVE
+  g->active = active;
+#endif
+#ifdef TIMELIMIT
+  /* Starting time */
+  g->start = timeofday() ;
+#endif
+  /* Global barrier */
+  barrier_init(&g->gb,AVAIL) ;
+  /* Align  to cache line */
+  uintptr_t x = (uintptr_t)(g->mem) ;
+  x += LINE-1 ; x /=  LINE ; x *= LINE ;
+  intmax_t *m = (intmax_t *)x ;
+  /* Instance contexts */
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_init(&g->ctx[k],k,m) ;
+    m += NVARS*LINESZ ;
+  }
+  g->hash_ok = 1;
+}
+
+static void free_global(global_t *g) {
+  for (int k = 0 ; k < NEXE ; k++) {
+    instance_free(&g->ctx[k]);
+  }
+#ifdef DYNALLOC
+  free(g->mem);
+  free(g);
+#endif
+}
+
+/******************/
+/* Thread context */
+/******************/
+
+typedef struct {
+  int id ;
+  st_t seed ;
+  int role,inst ;
+  ctx_t *ctx ;
+#ifdef ACTIVE
+  active_t *act;
+#endif
+} thread_ctx_t ;
+
+
+static void set_role(global_t *g,thread_ctx_t *c,int part) {
+  barrier_wait(&g->gb) ;
+  int idx = SCANLINE*part+g->ind[c->id] ;
+  int inst = g->inst[idx] ;
+  if (0 <= inst && inst < g->nexe) {
+    c->inst = inst ;
+    c->ctx = &g->ctx[inst] ;
+    c->role = g->role[idx] ;
+    if (SCANSZ > 1 && !g->fix) {
+    /* Shuffle roles in case several topological placements are possible. */
+      ctx_t *d = c->ctx ;
+      if (c->role == 0) interval_shuffle(&c->seed,(int *)&d->ind,N_n);
+      barrier_wait(&d->b) ;
+      c->role = d->ind[c->role] ;
+    }
+#ifdef KVM
+    set_feature(c->role) ;
+#ifdef HAVE_FAULT_HANDLER
+    whoami[c->id].instance = inst ;
+    whoami[c->id].proc = c->role ;
+#if defined(SEE_FAULTS) || defined(PRECISE)
+    if (c->role == 0) {
+#ifdef SOME_VARS
+      vars_ptr[inst] = &c->ctx->v;
+#else
+      vars_ptr[inst] = NULL;
+#endif
+#ifdef SEE_FAULTS
+      th_faults[inst] = c->ctx->out.th_faults;
+#endif
+    }
+#endif
+#endif
+#endif
+#ifdef ACTIVE
+    c->act = &g->active[part] ;
+#endif
+  } else {
+    c->ctx = NULL ;
+    c->role = -1 ;
+  }
+#ifdef KVM
+  set_fault_vector(c->role);
+#endif
+  barrier_wait(&g->gb) ;
+}
+
+static void init_getinstrs(void) {
+  nop = getnop();
+}
+
+inline static int do_run(thread_ctx_t *_c, param_t *_p,global_t *_g) {
+  int _ok = 0;
+  int _role = _c->role;
+  if (_role < 0) return _ok;
+  ctx_t *_ctx = _c->ctx;
+  sense_t *_b = &_ctx->b;
+  log_t *_log = &_ctx->out;
+  vars_t *_vars = &_ctx->v;
+  int *y = (int *)_vars->y;
+  int *x = (int *)_vars->x;
+  barrier_wait(_b);
+  switch (_role) {
+  case 0: {
+    *y = 0;
+    litmus_flush_tlb((void *)y);
+    barrier_wait(_b);
+    if (_p->c_0_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_0_x == cflush) cache_flush((void *)x);
+    if (_p->c_0_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_0_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code0(x,y);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(y,_vars->pte_y,_vars->saved_pte_y);
+    litmus_flush_tlb((void *)y);
+    int _cond = final_ok(final_cond(_log));
+    int _added = hash_add(&_ctx->t,_log,_p,1,_cond);
+    if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much.
+    if (_cond) {
+      _ok = 1;
+      (void)__sync_add_and_fetch(&_g->stats.groups[_p->part],1);
+    }
+    break; }
+  case 1: {
+    *x = 0;
+    litmus_flush_tlb((void *)x);
+    barrier_wait(_b);
+    if (_p->c_1_x == ctouch) cache_touch((void *)x);
+    else if (_p->c_1_x == cflush) cache_flush((void *)x);
+    if (_p->c_1_y == ctouch) cache_touch((void *)y);
+    else if (_p->c_1_y == cflush) cache_flush((void *)y);
+    barrier_wait(_b);
+    code1(x,y,&_log->out_1_x0,&_log->out_1_x6);
+    barrier_wait(_b);
+    (void)litmus_set_pte_safe(x,_vars->pte_x,_vars->saved_pte_x);
+    litmus_flush_tlb((void *)x);
+    break; }
+  }
+  return _ok;
+}
+
+/*******************/
+/* Forked function */
+/*******************/
+
+inline static int comp_param (st_t *seed,int *g,int max,int delta) {
+  int tmp = *g;
+  return tmp >= 0 ? tmp : delta+rand_k(seed,max-delta);
+}
+
+static void choose_params(global_t *g,thread_ctx_t *c,int part) {
+  int _role = c->role;
+  if (_role < 0) return;
+  ctx_t *ctx = c->ctx;
+  param_t *q = g->param;
+
+  for (int _s=0 ; _s < g->size ; _s++) {
+    barrier_wait(&ctx->b);
+    switch (_role) {
+    case 0:
+      ctx->p.c_0_x = comp_param(&c->seed,&q->c_0_x,cmax,1);
+      ctx->p.c_1_x = comp_param(&c->seed,&q->c_1_x,cmax,1);
+      break;
+    case 1:
+      ctx->p.part = part;
+      ctx->p.c_0_y = comp_param(&c->seed,&q->c_0_y,cmax,1);
+      ctx->p.c_1_y = comp_param(&c->seed,&q->c_1_y,cmax,1);
+      break;
+    }
+    (void)do_run(c,&ctx->p,g);
+  }
+}
+
+static void choose(int id,global_t *g) {
+  param_t *q = g->param;
+  thread_ctx_t c; c.id = c.seed = id;
+  st_t seed = 0; st_t seed0 = 0;
+
+  for (int nrun = 0; nrun < g->nruns ; nrun++) {
+    if (SCANSZ <= 1 && !g->fix && id == 0) {
+    /* Shuffle all threads in absence of topology information. */
+      interval_shuffle(&seed0,(int *)g->ind,AVAIL);
+    }
+    if (g->verbose>1) fprintf(stderr, "Run %d of %d\r", nrun, g->nruns);
+    /* Select threads partition amounts SCANSZ */
+    int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);
+    set_role(g,&c,part);
+    choose_params(g,&c,part);
+  }
+}
+
+typedef struct {
+  int id;
+  global_t *g;
+} zyva_t;
+
+static void zyva(void *_a) {
+  int id = smp_processor_id();
+  if (id >= AVAIL) return;
+  zyva_t *a = (zyva_t*)_a + id;
+  global_t *g = a->g;
+  install_fault_handler(id);
+  extern ins_t vector_table;
+  exceptions_init_test(&vector_table);
+  choose(id,g);
+}
+
+static int feature_check(void) {
+  return 1;
+}
+
+#define RUN run
+#define MAIN 1
+
+#define ENOUGH 10
+
+static void postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {
+  hash_t *hash = &g->hash ;
+  puts("Test T9B Forbidden\n");
+  printf("Histogram (%d states)\n",hash->nhash);
+  pp_hash(out,hash,g->verbose > 1,g->group);
+  int cond = p_true == 0;
+  puts(cond?"Ok":"No");
+  puts("\n");
+  puts("\nWitnesses\n");
+  printf("Positive: %" PCTR ", Negative: %" PCTR "\n",p_false,p_true);
+  puts("Condition ");
+  puts("~exists (1:X0=1 /\\ 1:X6=0)");
+  puts(" is ");
+  puts(cond ? "" : "NOT ");
+  puts("validated\n");
+  puts("Hash=cf0b4ac5b640a4310c295acabefcba53\n");
+  count_t cond_true = p_true;
+  count_t cond_false = p_false;
+  printf("Observation T9B %s %" PCTR " %" PCTR "\n",!cond_true ? "Never" : !cond_false ? "Always" : "Sometimes",cond_true,cond_false);
+  if (p_true > 0) {
+    count_t *ngroups = &g->stats.groups[0];
+    for (int k = 0 ; k < SCANSZ ; k++) {
+      count_t c = ngroups[k];
+      if ((g->verbose > 1 && c > 0) || (c*100)/p_true > ENOUGH) {
+        printf("Topology %-6" PCTR ":> part=%d %s\n",c,k,g->group[k]);
+      }
+    }
+  }
+  pp_faults();
+  puts("Time T9B ");
+  emit_millions(tsc_millions(total));
+  puts("\n");
+  if (!g->hash_ok) {
+    puts("Warning: some hash table was full, some outcomes were not collected\n");
+  }
+}
+
+
+
+/***************/
+/* Entry point */
+/***************/
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+
+#ifndef DYNALLOC
+static global_t global;
+static zyva_t arg[AVAIL];
+#ifndef KVM
+static pthread_t th[AVAIL];
+#endif
+#endif
+
+static int RUN(int argc,char **argv,FILE *out) ;
+static int RUN(int argc,char **argv,FILE *out) {
+  if (!feature_check()) {
+    return -1;
+  }
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+  alloc_fault_handler();
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  alloc_see_faults();
+#endif
+#endif
+  global_t *glo_ptr = malloc_check(sizeof(global_t));
+  glo_ptr->mem = malloc_check(MEMSZ*sizeof(*glo_ptr->mem));
+  zyva_t *arg = malloc_check(AVAIL*sizeof(*arg));
+#ifndef KVM
+  pthread_t *th = malloc_check(AVAIL*sizeof(*th));
+#endif
+#else
+  global_t *glo_ptr = &global;
+  glo_ptr->mem = mem;
+#endif
+  init_getinstrs();
+  init_global(glo_ptr);
+#ifdef OUT_n
+#ifdef HAVE_TIMEBASE
+  const int delta_tb = DELTA_TB;
+#else
+  const int delta_tb = 0;
+#endif
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t d = def;
+  char *prog = argv[0];
+  char **p = parse_opt(argc,argv,&def,&d);
+  int n_exe = d.n_exe;
+  if (d.avail < AVAIL) n_exe = d.avail / N_n;
+#ifdef HAVE_TIMEBASE
+  if (d.delay < NSTEPS-1) d.delay = NSTEPS-1;
+#endif
+  if (n_exe < 1) n_exe = 1;
+  if (n_exe > NEXE) n_exe = NEXE;
+  glo_ptr->verbose = d.verbose;
+  glo_ptr->nexe = n_exe;
+  glo_ptr->nruns = d.max_run;
+  glo_ptr->size = d.size_of_test;
+#ifdef HAVE_TIMEBASE
+  glo_ptr->delay = d.delay;
+  glo_ptr->step = d.delay/(NSTEPS-1);
+#endif
+  glo_ptr->fix = d.fix;
+  interval_init((int *)&glo_ptr->ind,AVAIL);
+  if (glo_ptr->verbose) {
+#ifdef NOSTDIO
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");
+#else
+    fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
+  }
+  parse_param(prog,glo_ptr->parse,PARSESZ,p);
+#ifdef PRELUDE
+  prelude(out);
+#endif
+  tsc_t start = timeofday();
+#endif
+  for (int id=0; id < AVAIL; id++) {
+    arg[id].id = id;
+    arg[id].g = glo_ptr;
+  }
+#ifdef KVM
+  on_cpus(zyva, arg);
+#else
+  for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
+  for (int id=0; id < AVAIL ; id++) join(&th[id]);
+#endif
+  int nexe = glo_ptr->nexe ;
+  hash_init(&glo_ptr->hash) ;
+  for (int k=0 ; k < nexe ; k++) {
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
+  }
+#ifdef OUT_n
+  tsc_t total = timeofday()-start;
+  count_t p_true = 0, p_false = 0;
+  for (int k = 0 ; k < HASHSZ ; k++) {
+    entry_t *e = &glo_ptr->hash.t[k];
+    if (e->ok) {
+      p_true += e->c;
+    } else {
+      p_false += e->c;
+    }
+  }
+  postlude(out,glo_ptr,p_true,p_false,total);
+#endif
+  free_global(glo_ptr);
+#ifdef DYNALLOC
+#ifdef HAVE_FAULT_HANDLER
+#if defined(SEE_FAULTS) || defined(PRECISE)
+  free_see_faults();
+#endif
+  free_fault_handler();
+#endif
+  free(arg);
+#ifndef KVM
+  free(th);
+#endif
+#endif
+  return EXIT_SUCCESS;
+}
+
+#ifdef MAIN
+int T9B (int argc,char **argv) {
+#ifdef KVM
+  litmus_init();
+#endif
+  return RUN(argc,argv,stdout) ;
+}
+#endif

--- a/mem_test/litmus-tests/kvm-headers.h
+++ b/mem_test/litmus-tests/kvm-headers.h
@@ -1,0 +1,327 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* Copyright 2020-present Institut National de Recherche en Informatique et */
+/* en Automatique and the authors. All rights reserved.                     */
+/*                                                                          */
+/* This software is governed by the CeCILL-B license under French law and   */
+/* abiding by the rules of distribution of free software. You can use,      */
+/* modify and/ or redistribute the software under the terms of the CeCILL-B */
+/* license as circulated by CEA, CNRS and INRIA at the following URL        */
+/* "http://www.cecill.info". We also give a copy in LICENSE.txt.            */
+/****************************************************************************/
+
+#include <vmalloc.h>
+#include <alloc_page.h>
+#include <asm-generic/atomic.h>
+#include <asm/smp.h>
+#include <asm/delay.h>
+#include <asm/mmu.h>
+#include <asm/pgtable-hwdef.h>
+
+#define LITMUS_PAGE_SIZE PAGE_SIZE
+
+static inline pteval_t *litmus_tr_pte(void *p) {
+  return mmu_get_pte(mmu_idmap, (uintptr_t)p);
+}
+
+static inline void litmus_flush_tlb(void *p) {
+  flush_tlb_page((unsigned long)p);
+}
+
+static inline void litmus_flush_tlb_all(void) {
+  flush_tlb_all();
+}
+
+static inline pteval_t litmus_set_pte(pteval_t *p,pteval_t v) {
+  pteval_t w;
+#ifdef NOSWP
+  int t;
+  asm __volatile (
+  "0:\n\t"
+  "ldxr    %[w],[%[p]]\n\t"
+  "stlxr   %w[t], %[v], [%[p]]\n\t"
+  "cbnz    %w[t],0b\n"
+  :[w] "=&r" (w), [t] "=&r" (t)
+  :[p] "r" (p),[v] "r" (v)
+  :"memory") ;
+#else
+  asm __volatile__
+    ("swp %[v],%[w],[%[p]]"
+     :[w] "=r" (w)
+     :[p] "r" (p),[v] "r" (v)
+     :"memory") ;
+#endif
+  return w ;
+}
+
+static const uint64_t msk_valid = 0x1UL;
+
+/* Safe pte update, with BBM sequence */
+static inline pteval_t litmus_set_pte_safe(void *p,pteval_t *q,pteval_t v) {
+  pteval_t w = v & ~msk_valid ;
+  pteval_t r = litmus_set_pte(q,w);
+  litmus_flush_tlb(p);
+  (void)litmus_set_pte(q,v); /* Last flush_tlb to be performed explicitly */
+  return r ;
+}
+
+/* Field access */
+
+static inline uint64_t litmus_get_field(pteval_t x,int low,int sz) {
+  uint64_t y = (uint64_t)x;
+  y >>= low ;
+  int64_t mask = (((uint64_t)1) << sz)-1;
+  return y & mask;
+}
+
+static inline pteval_t litmus_set_field(pteval_t old,int low,int sz,pteval_t v) {
+  pteval_t mask = ((((uint64_t)1) << sz)-1) ;
+  v &= mask ; v <<= low ;
+  mask <<= low ;
+  old &= ~mask ;
+  old |= v ;
+  return old;
+}
+
+
+/* Extract address component of PTE */
+#define FULL_MASK ((((pteval_t)1 << 48)-1) & ~(((pteval_t)1 << 12)-1))
+
+static inline pteval_t litmus_set_pte_physical(pteval_t old,pteval_t v) {
+  return (v & FULL_MASK)|(old & ~FULL_MASK) ;
+}
+
+static inline int litmus_same_oa(pteval_t p,pteval_t q) {
+  return ((p ^ q) & FULL_MASK) == 0 ;
+}
+
+static inline pteval_t litmus_set_pte_invalid(pteval_t old) {
+  return old & ~msk_valid ;
+}
+
+static const uint64_t msk_af = 0x400UL;
+static const uint64_t msk_dbm = 0x8000000000000UL;
+static const uint64_t msk_db = 0x80UL;
+static const uint64_t msk_el0 = 0x40UL;
+#define  msk_full (msk_valid|msk_af|msk_dbm|msk_db|msk_el0)
+
+static inline void unset_el0(pteval_t *p) {
+  *p &= ~msk_el0;
+}
+
+static inline pteval_t litmus_set_pte_flags(pteval_t old,pteval_t flags) {
+  flags ^= msk_db; /* inverse dirty bit -> AF[2] */
+  old &= ~msk_full ;
+  old |= flags ;
+  return old ;
+}
+
+/* Some 'explicit' PTE attributes */
+
+/* set 'global' PTE attributes */
+
+typedef enum
+  { attr_Normal, attr_Inner_2D_write_2D_through,
+    attr_Inner_2D_write_2D_back, attr_Inner_2D_non_2D_cacheable,
+    attr_Outer_2D_write_2D_through,
+    attr_Outer_2D_write_2D_back, attr_Outer_2D_non_2D_cacheable,
+    attr_Device,
+    attr_NGnRnE,attr_NGnRE,
+    attr_NGRE,attr_GRE,
+    attr_Non_2D_shareable,attr_Inner_2D_shareable,attr_Outer_2D_shareable,
+  } pte_attr_key;
+
+/* Act on SH[1:0] ie bits [9:8] */
+static inline pteval_t litmus_set_sh(pteval_t old,pteval_t sh) {
+  return litmus_set_field(old,8,2,sh);
+}
+
+/* Act on MEMATTR[3:0] ie bits [5:2] */
+static inline pteval_t litmus_set_memattr(pteval_t old,pteval_t memattr) {
+  return litmus_set_field(old,2,4,memattr);
+}
+
+static inline void litmus_set_pte_attribute(pteval_t *p,pte_attr_key k) {
+  switch (k) {
+  case attr_Non_2D_shareable:
+    *p = litmus_set_sh(*p,0) ;
+    break;
+  case attr_Inner_2D_shareable:
+    *p = litmus_set_sh(*p,3) ;
+    break;
+  case attr_Outer_2D_shareable:
+    *p = litmus_set_sh(*p,2) ;
+    break;
+  /* For cacheability, set inner-cacheability only,
+     is always non-cacheabke */
+  case attr_Normal:
+  case attr_Inner_2D_write_2D_back:
+  case attr_Outer_2D_write_2D_back:
+    *p = litmus_set_memattr(*p, MT_NORMAL);
+    break;
+  case attr_Inner_2D_write_2D_through:
+  case attr_Outer_2D_write_2D_through:
+#ifdef MT_NORMAL_WT
+    *p = litmus_set_memattr(*p, MT_NORMAL_WT);
+#else
+#pragma message "Normal WT attribute not supported, using NC instead\n"
+    *p = litmus_set_memattr(*p, MT_NORMAL_NC);
+#endif
+    break;
+  case attr_Inner_2D_non_2D_cacheable:
+  case attr_Outer_2D_non_2D_cacheable:
+    *p = litmus_set_memattr(*p, MT_NORMAL_NC);
+    break;
+  case attr_Device:
+  case attr_NGnRE:
+    *p = litmus_set_memattr(*p, MT_DEVICE_nGnRE);
+    break;
+  case attr_NGnRnE:
+    *p = litmus_set_memattr(*p, MT_DEVICE_nGnRnE);
+    break;
+  case attr_NGRE:
+#ifdef MT_DEVICE_nGRE
+    *p = litmus_set_memattr(*p, MT_DEVICE_nGRE);
+#else
+#pragma message "Device nGRE attribute not supported, using nGnRE instead\n"
+    *p = litmus_set_memattr(*p, MT_DEVICE_nGnRE);
+#endif
+    break;
+  case attr_GRE:
+    *p = litmus_set_memattr(*p, MT_DEVICE_GRE);
+    break;
+  }
+}
+
+/* Packed pte */
+#define AF_PACKED 0
+#define DB_PACKED 1
+#define DBM_PACKED 2
+#define VALID_PACKED 3
+#define EL0_PACKED 4
+#define OA_PACKED 5
+
+inline static pteval_t pack_flag(pteval_t v,pteval_t mask,int shift) {
+  return (v & mask ? 1 : 0) << shift;
+}
+
+
+inline static pteval_t pack_pte(int oa,pteval_t v) {
+  return
+    ((pteval_t)oa << OA_PACKED) |
+    pack_flag(v,msk_af,AF_PACKED) |
+    pack_flag(v ^ msk_db,msk_db,DB_PACKED) |
+    pack_flag(v,msk_dbm,DBM_PACKED) |
+    pack_flag(v,msk_valid,VALID_PACKED) |
+    pack_flag(v,msk_el0,EL0_PACKED) ;
+}
+
+inline static pteval_t pack_pack_flag(int f,int shift) {
+  return ((pteval_t)f) << shift ;
+}
+
+inline static pteval_t
+pack_pack(int oa,int af,int db,int dbm,int valid,int el0) {
+  return
+    (((pteval_t)oa) << OA_PACKED) |
+    pack_pack_flag(af,AF_PACKED) |
+    pack_pack_flag(db,DB_PACKED) |
+    pack_pack_flag(dbm,DBM_PACKED) |
+    pack_pack_flag(valid,VALID_PACKED) |
+    pack_pack_flag(el0,EL0_PACKED) ;
+}
+
+/*
+  This is the packed version of zero as pteval
+  - Pointer null -> index NVARS
+  - db set       -> corresponding bit unset
+*/
+
+#define NULL_PACKED (pack_pack(NVARS,0,1,0,0,0))
+
+inline static int unpack_oa(pteval_t v) {
+  return v >> OA_PACKED;
+}
+
+inline static int unpack_flag(pteval_t v,int shift) {
+  return (v >> shift) & 1;
+}
+
+inline static int unpack_af(pteval_t v) { return unpack_flag(v,AF_PACKED); }
+inline static int unpack_db(pteval_t v) { return unpack_flag(v,DB_PACKED); }
+inline static int unpack_dbm(pteval_t v) { return unpack_flag(v,DBM_PACKED); }
+inline static int unpack_valid(pteval_t v) { return unpack_flag(v,VALID_PACKED); }
+inline static int unpack_el0(pteval_t v) { return unpack_flag(v,EL0_PACKED); }
+
+/* Hardware managment of access flag and dirty state */
+
+/* Feature check */
+
+inline static int check_atomic(void) {
+  uint64_t r ;
+  asm volatile("mrs %x0, id_aa64isar0_el1": "=r" (r));
+  r >>= 20 ;
+  r &= 0b1111 ;
+  return r == 0b0010;
+}
+
+inline static uint64_t get_hafdbs(void) {
+  uint64_t r ;
+  asm volatile("mrs %x0, id_aa64mmfr1_el1": "=r" (r));
+  return r & 0b1111;
+}
+
+/* Feature enabling/disabling */
+inline static uint64_t get_tcr_el1(void) {
+  uint64_t r ;
+  asm volatile ("mrs %x0, tcr_el1" : "=r" (r));
+  return r ;
+}
+
+inline static void set_tcr_el1(uint64_t a) {
+  asm volatile
+    (
+     "msr tcr_el1,%x0\n"
+     "\tisb\n"
+     "\ttlbi vmalle1\n"
+     "\tdsb nsh\n"
+     "\tisb"
+     : : "r" (a)
+     );
+}
+
+inline static void set_tcr_el1_bit(unsigned b,uint64_t v) {
+  uint64_t old = get_tcr_el1();
+  uint64_t msk = ((uint64_t)1) << b;
+  set_tcr_el1((old & ~msk)|(v << b));
+}
+
+inline static void set_ha_bit(uint64_t v) {
+  set_tcr_el1_bit(39,v);
+}
+
+inline static void set_hd_bit(uint64_t v) {
+  set_tcr_el1_bit(40,v);
+}
+
+inline static void set_hahd_bits(uint64_t v) {
+  uint64_t old = get_tcr_el1();
+  uint64_t msk = ((uint64_t)0b11) << 39;
+  uint64_t n = (old & ~msk)|(v << 39);
+  set_tcr_el1(n);
+}
+
+inline static void reset_hahd_bits(void) {
+  uint64_t hafdbs = get_hafdbs();
+  if (hafdbs == 0b0001) {
+    set_ha_bit(0);
+  } else if (hafdbs == 0b0010) {
+    set_hahd_bits(0b00);
+  }
+}
+
+static inline void litmus_init(void) { reset_hahd_bits(); }

--- a/mem_test/litmus-tests/kvm_timeofday.c
+++ b/mem_test/litmus-tests/kvm_timeofday.c
@@ -1,0 +1,24 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* Copyright 2020-present Institut National de Recherche en Informatique et */
+/* en Automatique and the authors. All rights reserved.                     */
+/*                                                                          */
+/* This software is governed by the CeCILL-B license under French law and   */
+/* abiding by the rules of distribution of free software. You can use,      */
+/* modify and/ or redistribute the software under the terms of the CeCILL-B */
+/* license as circulated by CEA, CNRS and INRIA at the following URL        */
+/* "http://www.cecill.info". We also give a copy in LICENSE.txt.            */
+/****************************************************************************/
+
+#include <asm/processor.h>
+#include "kvm_timeofday.h"
+
+uint64_t gettimeofday(void) {
+  uint64_t cycles = read_sysreg(cntpct_el0) ;
+  uint64_t freq =  get_cntfrq() ;
+  return (cycles * 1000000UL)/freq ;
+}

--- a/mem_test/litmus-tests/kvm_timeofday.h
+++ b/mem_test/litmus-tests/kvm_timeofday.h
@@ -1,0 +1,18 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* Copyright 2020-present Institut National de Recherche en Informatique et */
+/* en Automatique and the authors. All rights reserved.                     */
+/*                                                                          */
+/* This software is governed by the CeCILL-B license under French law and   */
+/* abiding by the rules of distribution of free software. You can use,      */
+/* modify and/ or redistribute the software under the terms of the CeCILL-B */
+/* license as circulated by CEA, CNRS and INRIA at the following URL        */
+/* "http://www.cecill.info". We also give a copy in LICENSE.txt.            */
+/****************************************************************************/
+#include <stdint.h>
+
+uint64_t gettimeofday(void);

--- a/mem_test/litmus-tests/litmus_rand.c
+++ b/mem_test/litmus-tests/litmus_rand.c
@@ -1,0 +1,64 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* Copyright 2015-present Institut National de Recherche en Informatique et */
+/* en Automatique and the authors. All rights reserved.                     */
+/*                                                                          */
+/* This software is governed by the CeCILL-B license under French law and   */
+/* abiding by the rules of distribution of free software. You can use,      */
+/* modify and/ or redistribute the software under the terms of the CeCILL-B */
+/* license as circulated by CEA, CNRS and INRIA at the following URL        */
+/* "http://www.cecill.info". We also give a copy in LICENSE.txt.            */
+/****************************************************************************/
+#include <stdint.h>
+#include "litmus_rand.h"
+
+/*
+  Simple generator
+  http://en.wikipedia.org/wiki/Linear_congruential_generator
+*/
+
+
+/*
+
+  From ocaml sources: (globroot.c)
+  Linear congruence with modulus = 2^32, multiplier = 69069
+  (Knuth vol 2 p. 106, line 15 of table 1), additive = 25173.
+
+
+  Knuth (vol 2 p. 13) shows that the least significant bits are
+  "less random" than the most significant bits with a modulus of 2^m.
+  We just swap half words, enough? */
+
+static const uint32_t a = 69069;
+static const uint32_t c = 25173 ;
+
+inline static uint32_t unlocked_rand(st_t *st)  {
+  uint32_t r = a * *st + c ;
+  *st = r ;
+  /* Swap high & low bits */
+  uint32_t low = r & 0xffff ;
+  uint32_t high = r >> 16 ;
+  r = high | (low << 16) ;
+  return r ;
+}
+
+int rand_bit(st_t *st)  {
+  uint32_t r = unlocked_rand(st) ;
+  r &= 1 ;
+  return r ;
+}
+
+static const uint32_t r_max = UINT32_MAX ;
+
+uint32_t rand_k (uint32_t *st,uint32_t k) {
+  uint32_t r, v ;
+  do {
+    r = unlocked_rand(st) ;
+    v = r % k ;
+  } while (r-v > r_max-k+1) ;
+  return v ;
+}

--- a/mem_test/litmus-tests/litmus_rand.h
+++ b/mem_test/litmus-tests/litmus_rand.h
@@ -1,0 +1,29 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* Copyright 2015-present Institut National de Recherche en Informatique et */
+/* en Automatique and the authors. All rights reserved.                     */
+/*                                                                          */
+/* This software is governed by the CeCILL-B license under French law and   */
+/* abiding by the rules of distribution of free software. You can use,      */
+/* modify and/ or redistribute the software under the terms of the CeCILL-B */
+/* license as circulated by CEA, CNRS and INRIA at the following URL        */
+/* "http://www.cecill.info". We also give a copy in LICENSE.txt.            */
+/****************************************************************************/
+#ifndef _LITMUS_RAND_H
+#define _LITMUS_RAND_H 1
+
+#include <stdint.h>
+
+/* type of state for pseudorandom  generators */
+typedef uint32_t st_t ;
+
+/* Unlocked random bit */
+
+int rand_bit(st_t *st) ;
+uint32_t rand_k(st_t *st,uint32_t n) ;
+
+#endif

--- a/mem_test/litmus-tests/utils.c
+++ b/mem_test/litmus-tests/utils.c
@@ -1,0 +1,295 @@
+#define KVM 1
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* Copyright 2015-present Institut National de Recherche en Informatique et */
+/* en Automatique and the authors. All rights reserved.                     */
+/*                                                                          */
+/* This software is governed by the CeCILL-B license under French law and   */
+/* abiding by the rules of distribution of free software. You can use,      */
+/* modify and/ or redistribute the software under the terms of the CeCILL-B */
+/* license as circulated by CEA, CNRS and INRIA at the following URL        */
+/* "http://www.cecill.info". We also give a copy in LICENSE.txt.            */
+/****************************************************************************/
+#include <stdlib.h>
+#ifdef KVM
+#include <libcflat.h>
+#else
+#include <stdio.h>
+#include <string.h>
+#include <pthread.h>
+#include <limits.h>
+#include <errno.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#endif
+
+#include "utils.h"
+
+
+#ifdef KVM
+static int errno = 0 ;
+static const int ERANGE = 1 ;
+static const char *strerror(int e) { return "ERROR"; }
+#endif
+
+/********/
+/* Misc */
+/********/
+
+void fatal(const char *msg) {
+#ifndef KVM
+  fprintf(stderr,"Failure: %s\n", msg) ;
+#endif
+  fprintf(stdout,"Failure: %s\n", msg) ;
+  exit(1) ;
+}
+
+void errexit(const char *msg,int err) {
+  fprintf(stderr,"%s: %s\n",msg,strerror(err)) ;
+  exit(2) ;
+}
+
+int max(int n, int m) { return n < m ? m : n ; }
+
+void *do_align(void *p,size_t sz) {
+  uintptr_t x = (uintptr_t)p ;
+  x += sz-1 ;
+  x /= sz ;
+  x *= sz ;
+  return (void *)x ;
+}
+
+#ifdef DYNALLOC
+void* malloc_check(size_t sz) {
+  void *r = malloc(sz) ;
+  if (!r) fatal("malloc");
+  return r ;
+}
+#endif
+
+/* Artithmetic  */
+static long my_add (long x, long y) {
+  long r = x+y ;
+  if (r < x || r < y) { errno = ERANGE ; fatal("overflow") ; }
+  return r ;
+}
+
+static long my_pow10(int p,long x) {
+  long r = x ;
+  for ( ; p > 0 ; p--) {
+    long y2 = my_add(r,r) ;
+    long y4 = my_add(y2,y2) ;
+    long y8 = my_add(y4,y4) ;
+    r = my_add(y8,y2) ;
+  }
+  return r ;
+}
+
+static int do_argint(char *p, char **q) {
+  long r =  strtol(p,q,10) ;
+  if (errno == ERANGE) { fatal("overflow") ; }
+  if (**q == 'k' || **q == 'K') { r = my_pow10(3,r) ; *q += 1; }
+  else if (**q == 'm' || **q == 'M') { r = my_pow10(6,r) ; *q +=1 ; }
+  return r ;
+}
+
+#ifndef KVM
+/*************************/
+/* Concurrency utilities */
+/*************************/
+
+/* Thread launch and join */
+
+void launch(pthread_t *th, f_t *f, void *a) {
+  int e = pthread_create(th,NULL,f,a);
+  if (e) errexit("pthread_create",e);
+}
+
+void *join(pthread_t *th) {
+  void *r ;
+  int e = pthread_join(*th,&r) ;
+  if (e)  errexit("pthread_join",e);
+  return r ;
+}
+#endif
+
+/****************/
+/* Time counter */
+/****************/
+
+#ifdef KVM
+#include "kvm_timeofday.h"
+tsc_t timeofday(void) { return gettimeofday(); }
+#else
+#include <sys/time.h>
+#include <time.h>
+
+tsc_t timeofday(void) {
+  struct timeval tv ;
+  if (gettimeofday(&tv,NULL)) errexit("gettimeoday",errno) ;
+  return tv.tv_sec * ((tsc_t)1000000) + tv.tv_usec ;
+}
+#endif
+
+#ifdef KVM
+sec_t tsc_millions(tsc_t t) {
+  tsc_t a = t / 1000000 ;
+  tsc_t b = t % 1000000 ;
+  b = (b + 5000) / 10000 ;
+  sec_t r = { a, b } ;
+  return r ;
+}
+
+void emit_millions(sec_t f) {
+  printf("%" PRIu64, f.sec) ;
+  puts(".");
+  printf("%02" PRIu64, f.frac) ;
+}
+
+#else
+double tsc_ratio(tsc_t t1, tsc_t t2) {
+  return ((double) t1) / ((double)t2) ;
+}
+
+double tsc_millions(tsc_t t) {
+  return t / 1000000.0 ;
+}
+#endif
+
+/**********/
+/* Pre-Si */
+/**********/
+
+static void usage_opt(char *prog,opt_t *d) {
+  fprintf(stderr,"usage: %s (options)* (parameters)*\n",prog) ;
+  fprintf(stderr,"%s","  -v      be verbose\n") ;
+  fprintf(stderr,"%s","  -q      be quiet\n") ;
+  fprintf(stderr,"  -a <n>  consider that <n> cores are available (default %d)\n",d->avail) ;
+  fprintf(stderr,"  -n <n>  run n tests concurrently (default %d)\n",d->n_exe) ;
+  fprintf(stderr,"  -r <n>  perform n external runs (default %d)\n",d->max_run) ;
+  fprintf(stderr,"  -s <n>  perform n internal runs (default %d)\n",d->size_of_test) ;
+  if (d->delay > 0) {
+    fprintf(stderr,"  -tb <n> time base delay  (default %d)\n",d->delay) ;
+  }
+  fprintf(stderr,"  +fix    do not shuffle threads\n");
+  exit(2) ;
+}
+
+static int argint_opt(char *prog,char *p,opt_t *d) {
+  char *q ;
+  long r = do_argint(p,&q) ;
+  if (*p == '\0' || *q != '\0') {
+    usage_opt(prog,d) ;
+  }
+  return r ;
+}
+
+char **parse_opt(int argc,char **argv,opt_t *d, opt_t *p) {
+  char *prog = argv[0] ;
+  for ( ; ; ) {
+    --argc ; ++argv ;
+    if (!*argv) return argv ;
+    char fst = **argv;
+    if (fst != '-' && fst != '+') return argv ;
+    if (strcmp(*argv,"-q") == 0) p->verbose=0 ;
+    else if (strcmp(*argv,"-v") == 0) p->verbose++ ;
+    else if (strcmp(*argv,"-r") == 0) {
+      --argc ; ++argv ;
+      if (!*argv) usage_opt(prog,d) ;
+      p->max_run = argint_opt(prog,argv[0],d) ;
+    } else if (strcmp(*argv,"-s") == 0) {
+      --argc ; ++argv ;
+      if (!*argv) usage_opt(prog,d) ;
+      p->size_of_test = argint_opt(prog,argv[0],d) ;
+    } else if (strcmp(*argv,"-a") == 0) {
+      --argc ; ++argv ;
+      if (!*argv) usage_opt(prog,d) ;
+      p->avail = argint_opt(prog,argv[0],d) ;
+      if (p->avail < 1) p->n_exe = 1 ;
+    } else if (strcmp(*argv,"-n") == 0) {
+      --argc ; ++argv ;
+      if (!*argv) usage_opt(prog,d) ;
+      p->n_exe = argint_opt(prog,argv[0],d) ;
+      if (p->n_exe < 1) p->n_exe = 1 ;
+    } else if (strcmp(*argv,"-tb") == 0 && d->delay > 0) {
+      --argc ; ++argv ;
+      if (!*argv) usage_opt(prog,d) ;
+      p->delay = argint_opt(prog,argv[0],d) ;
+      if (p->delay < 1) p->delay = 1 ;
+    } else if (strcmp(*argv,"+fix") == 0) {
+      p->fix = 1 ;
+    } else usage_opt(prog,d);
+  }
+}
+
+static char *check_key(const char *key, char *arg) {
+  while (*key) {
+    if (*key != *arg) return NULL ;
+    key++ ; arg++ ;
+  }
+  if (*arg == '=') return arg+1 ;
+  return NULL ;
+}
+
+static void do_parse(char *prog,parse_param_t *p,int sz, char *arg) {
+  for (int k = 0 ; k < sz; k++, p++) {
+    char *rem = check_key(p->tag,arg) ;
+    if (rem != NULL) {
+      long i = strtol(rem,NULL,0) ;
+      *p->dst = p->f(i) ;
+      if (*p->dst >= p->max) {
+        fprintf(stderr,"%s: parameter %s is out of range\n",prog,p->tag) ;
+        exit(2) ;
+      }
+      return ;
+    }
+  }
+}
+
+void parse_param(char *prog,parse_param_t *p,int sz,char **argv) {
+  while (*argv) {
+    do_parse(prog,p,sz,*argv) ;
+    argv++ ;
+  }
+}
+
+#ifndef KVM
+
+/********************/
+/* presi self alloc */
+/********************/
+
+void *mmap_exec(size_t sz) {
+  void * p = mmap(NULL, sz, PROT_READ|PROT_EXEC|PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+  if (p == MAP_FAILED) {
+    errexit("mmap",errno) ;
+  }
+  return p ;
+}
+
+void munmap_exec(void *p,size_t sz) {
+  if (munmap(p,sz)) errexit("munmap",errno);
+}
+
+#endif
+
+/*******************/
+/* Array utilities */
+/*******************/
+
+void interval_init(int *p,size_t sz) {
+  for (int k=0 ; k < sz ; k++) *p++ = k;
+}
+
+void interval_shuffle(st_t *seed,int *p,size_t sz) {
+  for (int k=0 ; k < sz-1 ; k++) {
+    int j = k + rand_k(seed,sz-k) ;
+    int tmp = p[k] ;
+    p[k] = p[j] ;
+    p[j] = tmp ;
+  }
+}

--- a/mem_test/litmus-tests/utils.h
+++ b/mem_test/litmus-tests/utils.h
@@ -1,0 +1,134 @@
+#define KVM 1
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* Copyright 2015-present Institut National de Recherche en Informatique et */
+/* en Automatique and the authors. All rights reserved.                     */
+/*                                                                          */
+/* This software is governed by the CeCILL-B license under French law and   */
+/* abiding by the rules of distribution of free software. You can use,      */
+/* modify and/ or redistribute the software under the terms of the CeCILL-B */
+/* license as circulated by CEA, CNRS and INRIA at the following URL        */
+/* "http://www.cecill.info". We also give a copy in LICENSE.txt.            */
+/****************************************************************************/
+#ifndef _UTILS_H
+#define _UTILS_H 1
+
+#include <stdint.h>
+#ifdef KVM
+#include <libcflat.h>
+typedef void FILE;
+#define stdout NULL
+#define stderr NULL
+#define fprintf(stderr,...) printf(__VA_ARGS__)
+
+#ifndef noinline
+#define noinline __attribute__((noinline))
+#endif
+
+#else
+#include <pthread.h>
+#include <string.h>
+#endif
+
+/********/
+/* Misc */
+/********/
+
+void fatal(const char *msg) ;
+
+/* e is errno */
+void errexit(const char *msg,int e) ;
+
+int max(int n,int m) ;
+
+void *do_align(void *p, size_t sz) ;
+
+#ifdef DYNALLOC
+#ifdef KVM
+#include <alloc.h>
+#endif
+/* Dynamic memory allocation, KVM style */
+void *malloc_check(size_t sz) ;
+#endif
+
+#ifndef KVM
+/********************/
+/* Thread utilities */
+/********************/
+
+/* Thread launch and join */
+
+typedef void* f_t(void *);
+
+void launch(pthread_t *th, f_t *f, void *a) ;
+
+void *join(pthread_t *th) ;
+#endif
+
+
+/*********************/
+/* Real time counter */
+/*********************/
+
+typedef uint64_t tsc_t ;
+#define PTSC "%" PRIu64
+
+/* Result in micro-seconds */
+tsc_t timeofday(void) ;
+#ifdef KVM
+typedef struct { tsc_t sec,frac; } sec_t ;
+sec_t tsc_millions(tsc_t t) ;
+void emit_millions(sec_t f) ;
+#else
+double tsc_ratio(tsc_t t1, tsc_t t2) ;
+double tsc_millions(tsc_t t) ;
+#endif
+
+
+/**********/
+/* Pre-Si */
+/**********/
+
+typedef struct {
+  int verbose;
+  int max_run;
+  int size_of_test;
+  int avail ;
+  int n_exe ;
+  int delay ;
+  int fix ;
+} opt_t ;
+
+char **parse_opt(int argc,char **argv,opt_t *def, opt_t *p) ;
+
+typedef struct {
+  const char* tag;
+  int *dst;
+  int (*f)(int);
+  int max;
+} parse_param_t;
+
+void parse_param(char *prog,parse_param_t *p,int sz,char **argv) ;
+
+#ifndef KVM
+
+/********************/
+/* presi self alloc */
+/********************/
+void *mmap_exec(size_t sz) ;
+void munmap_exec(void *p,size_t sz) ;
+
+#endif
+
+/*******************/
+/* Array utilities */
+/*******************/
+#include "litmus_rand.h"
+void interval_init(int *p,size_t sz) ;
+void interval_shuffle(st_t *seed,int *p,size_t sz) ;
+
+#endif

--- a/mem_test/memTestBsaSupport.S
+++ b/mem_test/memTestBsaSupport.S
@@ -1,0 +1,604 @@
+/*
+ * Boot entry point and assembler functions for aarch64 tests.
+ *
+ * Copyright (C) 2017, Red Hat Inc, Andrew Jones <drjones@redhat.com>
+ * Copyright (C) 2023, Arm Ltd.
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.
+ */
+#define __ASSEMBLY__
+#define BSA_ACS
+#include <auxinfo.h>
+#include <asm/assembler.h>
+#include <asm/ptrace.h>
+#include <asm/page.h>
+#include <asm/pgtable-hwdef.h>
+#include <asm/thread_info.h>
+#include <asm/sysreg.h>
+
+#define S_X0 0 /* offsetof(struct pt_regs, regs[0]) */
+#define S_X1 8 /* offsetof(struct pt_regs, regs[1]) */
+#define S_X2 16 /* offsetof(struct pt_regs, regs[2]) */
+#define S_X3 24 /* offsetof(struct pt_regs, regs[3]) */
+#define S_X4 32 /* offsetof(struct pt_regs, regs[4]) */
+#define S_X5 40 /* offsetof(struct pt_regs, regs[5]) */
+#define S_X6 48 /* offsetof(struct pt_regs, regs[6]) */
+#define S_X7 56 /* offsetof(struct pt_regs, regs[7]) */
+#define S_LR 240 /* offsetof(struct pt_regs, regs[30]) */
+#define S_SP 248 /* offsetof(struct pt_regs, sp) */
+#define S_PC 256 /* offsetof(struct pt_regs, pc) */
+#define S_PSTATE 264 /* offsetof(struct pt_regs, pstate) */
+#define S_ORIG_X0 272 /* offsetof(struct pt_regs, orig_x0) */
+#define S_SYSCALLNO 280 /* offsetof(struct pt_regs, syscallno) */
+#define S_FRAME_SIZE 288 /* sizeof(struct pt_regs) */
+
+    .irp    num,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30
+    .equ    .L__reg_num_x\num, \num
+    .endr
+    .equ    .L__reg_num_xzr, 31
+
+    .macro    mrs_s, rt, sreg
+    .inst    0xd5200000|(\sreg)|(.L__reg_num_\rt)
+    .endm
+
+    .macro    msr_s, sreg, rt
+    .inst    0xd5000000|(\sreg)|(.L__reg_num_\rt)
+    .endm
+
+    .macro    raw_dcache_line_size, reg, tmp
+    mrs    \tmp, ctr_el0            // read CTR
+    ubfx    \tmp, \tmp, #16, #4        // cache line size encoding
+    mov    \reg, #4            // bytes per word
+    lsl    \reg, \reg, \tmp        // actual cache line size
+    .endm
+
+    .macro dcache_by_line_op op, domain, addr, size, tmp1, tmp2
+    raw_dcache_line_size \tmp1, \tmp2
+    add    \size, \addr, \size
+    sub    \tmp2, \tmp1, #1
+    bic    \addr, \addr, \tmp2
+9998:
+    dc    \op, \addr
+    add    \addr, \addr, \tmp1
+    cmp    \addr, \size
+    b.lo    9998b
+    dsb    \domain
+    .endm
+
+
+.text
+
+/*
+ * psci_invoke_hvc / psci_invoke_smc
+ *
+ * Inputs:
+ *   w0 -- function_id
+ *   x1 -- arg0
+ *   x2 -- arg1
+ *   x3 -- arg2
+ *
+ * Outputs:
+ *   x0 -- return code
+ */
+.globl psci_invoke_hvc
+psci_invoke_hvc:
+    hvc    #0
+    ret
+
+.globl psci_invoke_smc
+psci_invoke_smc:
+    smc    #0
+    ret
+
+.globl secondary_entry
+secondary_entry:
+    mrs   x0, CurrentEL
+    cmp   x0, CurrentEL_EL2
+    b.ne  1f
+    bl    asm_setup_el2
+    bl    asm_drop_el1
+1:
+    /* Enable FP/ASIMD */
+    mov    x0, #(3 << 20)
+    msr    cpacr_el1, x0
+
+    /* set up exception handling */
+    bl    exceptions_init
+
+    /* enable the MMU unless requested off */
+    adrp    x0, mmu_idmap
+    ldr    x0, [x0, :lo12:mmu_idmap]
+    bl    asm_mmu_enable
+
+    /* set the stack */
+    adrp    x0, secondary_data
+    ldr    x0, [x0, :lo12:secondary_data]
+    mov    sp, x0
+
+    /* finish init in C code */
+    bl    secondary_cinit
+
+    /* x0 is now the entry function, run it */
+    blr    x0
+    b    do_idle
+
+.globl halt
+halt:
+1:    wfi
+    b    1b
+
+/*
+ * asm_mmu_enable
+ *   Inputs:
+ *     x0 is the base address of the translation table
+ *   Outputs: none
+ *
+ * Adapted from
+ *   arch/arm64/kernel/head.S
+ *   arch/arm64/mm/proc.S
+ */
+
+/*
+ * Memory region attributes for LPAE:
+ *
+ *   n = AttrIndx[2:0]
+ *                      n       MAIR
+ *   DEVICE_nGnRnE      000     00000000
+ *   DEVICE_nGnRE       001     00000100
+ *   DEVICE_GRE         010     00001100
+ *   NORMAL_NC          011     01000100
+ *   NORMAL             100     11111111
+ *   NORMAL_WT          101     10111011
+ *   DEVICE_nGRE        110     00001000
+ */
+#define MAIR(attr, mt) ((attr) << ((mt) * 8))
+
+#if PAGE_SIZE == SZ_64K
+#define TCR_TG_FLAGS    TCR_TG0_64K | TCR_TG1_64K
+#elif PAGE_SIZE == SZ_16K
+#define TCR_TG_FLAGS    TCR_TG0_16K | TCR_TG1_16K
+#elif PAGE_SIZE == SZ_4K
+#define TCR_TG_FLAGS    TCR_TG0_4K | TCR_TG1_4K
+#endif
+
+.globl asm_mmu_enable
+asm_mmu_enable:
+    tlbi    vmalle1            // invalidate I + D TLBs
+    dsb    nsh
+
+    /* TCR */
+    ldr    x1, =TCR_TxSZ(VA_BITS) |        \
+             TCR_TG_FLAGS  |            \
+             TCR_IRGN_WBWA | TCR_ORGN_WBWA |    \
+             TCR_SHARED |            \
+             TCR_EPD1
+    mrs    x2, id_aa64mmfr0_el1
+    bfi    x1, x2, #32, #3
+    msr    tcr_el1, x1
+
+    /* MAIR */
+    ldr    x1, =MAIR(0x00, MT_DEVICE_nGnRnE) |    \
+             MAIR(0x04, MT_DEVICE_nGnRE) |    \
+             MAIR(0x0c, MT_DEVICE_GRE) |    \
+             MAIR(0x44, MT_NORMAL_NC) |        \
+             MAIR(0xff, MT_NORMAL) |            \
+             MAIR(0xbb, MT_NORMAL_WT) |         \
+             MAIR(0x08, MT_DEVICE_nGRE)
+    msr    mair_el1, x1
+
+    /* TTBR0 */
+    msr    ttbr0_el1, x0
+    isb
+
+    /* SCTLR */
+    mrs    x1, sctlr_el1
+    orr    x1, x1, SCTLR_EL1_C
+    orr    x1, x1, SCTLR_EL1_I
+    orr    x1, x1, SCTLR_EL1_M
+    msr    sctlr_el1, x1
+    isb
+
+    ret
+
+.globl asm_mmu_disable
+asm_mmu_disable:
+    /* check current EL */
+    mrs x0, CurrentEL
+    cmp x0, CurrentEL_EL1
+    b.eq 1f
+
+    /* if system is running at EL1 */
+    /* Disable data cache */
+    /* In case of exclusive caches, the line can ping-pong between caches in a way that
+    nullifies Set-Way based CMO, hence disabling data cache */
+    mrs x0, sctlr_el2
+    bic x0, x0, SCTLR_EL1_C
+    msr sctlr_el2, x0
+    isb
+
+    /* Clean + invalidate the entire memory */
+    mov  x0, #0
+    b    asm_dcache_all
+
+    /* disable MMU */
+    mrs x0, sctlr_el2
+    bic x0, x0, SCTLR_EL1_M
+    msr sctlr_el2, x0
+    isb
+
+    /* Clean + invalidate the entire memory */
+    mov  x0, #0
+    b    asm_dcache_all
+
+    /* Invalidate Icache */
+    ic iallu
+    isb
+
+    /* Disable data and instruction caches*/
+    mrs x0, sctlr_el2
+    bic x0, x0, SCTLR_EL1_C
+    bic x0, x0, SCTLR_EL1_I
+    msr sctlr_el2, x0
+    isb
+
+    tlbi    vmalle1
+    dsb    nsh
+    ret
+1:
+    /* if system is running at EL1 */
+    /* Clean + invalidate the entire memory */
+    adrp    x0, __phys_offset
+    ldr    x0, [x0, :lo12:__phys_offset]
+    adrp    x1, __phys_end
+    ldr    x1, [x1, :lo12:__phys_end]
+    sub    x1, x1, x0
+    dcache_by_line_op civac, sy, x0, x1, x2, x3
+
+    /* Invalidate Icache */
+    ic    iallu
+    isb
+
+    /* Disable cache, Icache and MMU */
+    mrs x0, sctlr_el1
+    bic x0, x0, SCTLR_EL1_C
+    bic x0, x0, SCTLR_EL1_I
+    bic x0, x0, SCTLR_EL1_M
+    msr sctlr_el1, x0
+    isb
+
+    /* Invalidate TLB */
+    tlbi    vmalle1
+    dsb    nsh
+    ret
+
+install_el2_stub:
+    ldr    x0, =INIT_SCTLR_EL1_MMU_OFF
+    msr    sctlr_el1, x0
+
+    /* Coprocessor traps. */
+    mov    x0, #0x33ff
+    msr    cptr_el2, x0                    // Disable copro. traps to EL2
+
+    /* SVE register access */
+    mrs    x1, id_aa64pfr0_el1
+    ubfx   x1, x1, #ID_AA64PFR0_SVE_SHIFT, #4
+    cbz    x1, 1f
+
+    bic    x0, x0, #CPTR_EL2_TZ            // Also disable SVE traps
+    msr    cptr_el2, x0                    // Disable copro. traps to EL2
+    isb
+    mov    x1, #ZCR_ELx_LEN_MASK           // SVE: Enable full vector
+    msr_s  SYS_ZCR_EL2, x1                 // length for EL1.
+
+    /* Hypervisor stub */
+1:
+    msr    vbar_el2, xzr
+
+    /* spsr */
+    mov    x0, #(PSR_F_BIT | PSR_I_BIT | PSR_A_BIT | PSR_D_BIT |\
+            PSR_MODE_EL1h)
+    msr    spsr_el2, x0
+    ret
+
+.globl asm_setup_el2
+asm_setup_el2:
+    ldr    x0, =SCTLR_EL2_RES1
+    msr    sctlr_el2, x0
+
+    /* Hyp configuration. */
+    ldr    x0, =HCR_HOST_NVHE_FLAGS
+    msr    hcr_el2, x0
+    isb
+
+    /*
+    * Allow Non-secure EL1 and EL0 to access physical timer and counter.
+    * This is not necessary for VHE, since the host kernel runs in EL2,
+    * Note that when HCR_EL2.E2H == 1, CNTHCTL_EL2 has the same bit layout
+    * as CNTKCTL_EL1, and CNTKCTL_EL1 accessing instructions are redefined
+    * to access CNTHCTL_EL2. This allows the kernel designed to run at EL1
+    * to transparently mess with the EL0 bits via CNTKCTL_EL1 access in
+    * EL2.
+    */
+    mrs    x0, cnthctl_el2
+    /* Enable EL1 physical timers. */
+    orr    x0, x0, #3
+    msr    cnthctl_el2, x0
+
+    /* Clear the timer virtual offset. */
+    msr    cntvoff_el2, xzr
+
+    /* GICv3 system register access */
+    mrs    x0, id_aa64dfr0_el1
+    ubfx   x0, x0, #ID_AA64PFR0_GIC_SHIFT, #4
+    cbz    x0, 1f
+
+    mrs_s  x0, SYS_ICC_SRE_EL2
+    orr    x0, x0, #ICC_SRE_EL2_SRE        // Set ICC_SRE_EL2.SRE==1
+    orr    x0, x0, #ICC_SRE_EL2_ENABLE     // Set ICC_SRE_EL2.Enable==1
+    msr_s  SYS_ICC_SRE_EL2, x0
+    isb                                      // Make sure SRE is now set
+    mrs_s    x0, SYS_ICC_SRE_EL2             // Read SRE back,
+    tbz      x0, #0, 1f                      // and check that it sticks
+    msr_s    SYS_ICH_HCR_EL2, xzr            // Reset ICC_HCR_EL2 to defaults
+1:
+    /* Populate ID registers. */
+    mrs    x0, midr_el1
+    mrs    x1, mpidr_el1
+    msr    vpidr_el2, x0
+    msr    vmpidr_el2, x1
+
+    /* EL2 debug */
+    mrs     x1, id_aa64dfr0_el1
+    sbfx    x0, x1, #ID_AA64DFR0_PMUVER_SHIFT, #4
+    cmp     x0, #1
+    b.lt    1f                              // Skip if no PMU present
+    mrs     x0, pmcr_el0                    // Disable debug access traps
+    ubfx    x0, x0, #11, #5                 // to EL2 and allow access to
+1:
+    csel    x3, xzr, x0, lt                 // all PMU counters from EL1
+
+    /* Statistical profiling */
+    ubfx    x0, x1, #ID_AA64DFR0_PMSVER_SHIFT, #4
+    cbz     x0, 2f                                     // Skip if SPE not present
+    mrs_s   x4, SYS_PMBIDR_EL1                         // If SPE available at EL2,
+    and     x4, x4, #(1 << SYS_PMBIDR_EL1_P_SHIFT)
+    cbnz    x4, 1f                                     // then permit sampling of physical
+    mov     x4, #(1 << SYS_PMSCR_EL2_PCT_SHIFT | \
+             1 << SYS_PMSCR_EL2_PA_SHIFT)
+    msr_s    SYS_PMSCR_EL2, x4                         // addresses and physical counter
+1:
+    mov    x1, #(MDCR_EL2_E2PB_MASK << MDCR_EL2_E2PB_SHIFT)
+    orr    x3, x3, x1                                       // If we don't have VHE, then
+    b    1f                                                 // use EL1&0 translation.
+
+    orr    x3, x3, #MDCR_EL2_TPMS           // and disable access from EL1
+1:
+    msr    mdcr_el2, x3                     // Configure debug traps
+
+    /* LORegions */
+    mrs    x1, id_aa64mmfr1_el1
+    ubfx   x0, x1, #ID_AA64MMFR1_LOR_SHIFT, 4
+    cbz    x0, 2f
+    msr_s  SYS_LORC_EL1, xzr
+2:
+    /* Stage-2 translation */
+    msr    vttbr_el2, xzr
+    isb
+    b install_el2_stub
+
+.globl asm_drop_el1
+asm_drop_el1:
+    msr    elr_el2, lr
+
+    /* enable FP/ASIMD */
+    mov    x0, #(3 << 20)
+    msr    cpacr_el1, x0
+
+    /* set SCTLR_EL1 to a known value */
+    ldr    x0, =INIT_SCTLR_EL1_MMU_OFF
+    msr    sctlr_el1, x0
+
+    # stack for EL1, reuse current
+    mov x0, sp
+    msr sp_el1, x0
+
+    eret
+
+/*
+ * Vectors
+ */
+
+.globl exceptions_init
+exceptions_init:
+    adrp    x4, vector_table
+    add    x4, x4, :lo12:vector_table
+    msr    vbar_el1, x4
+    isb
+    ret
+
+/*
+ * Vector stubs
+ * Adapted from arch/arm64/kernel/entry.S
+ */
+.macro vector_stub, name, vec
+.weak \name
+\name:
+    stp     x0,  x1, [sp, #-S_FRAME_SIZE]!
+    stp     x2,  x3, [sp,  #16]
+    stp     x4,  x5, [sp,  #32]
+    stp     x6,  x7, [sp,  #48]
+    stp     x8,  x9, [sp,  #64]
+    stp    x10, x11, [sp,  #80]
+    stp    x12, x13, [sp,  #96]
+    stp    x14, x15, [sp, #112]
+    stp    x16, x17, [sp, #128]
+    stp    x18, x19, [sp, #144]
+    stp    x20, x21, [sp, #160]
+    stp    x22, x23, [sp, #176]
+    stp    x24, x25, [sp, #192]
+    stp    x26, x27, [sp, #208]
+    stp    x28, x29, [sp, #224]
+
+    str    x30, [sp, #S_LR]
+
+    .if \vec >= 8
+    mrs    x1, sp_el0
+    .else
+    add    x1, sp, #S_FRAME_SIZE
+    .endif
+    str    x1, [sp, #S_SP]
+
+    mrs    x1, elr_el1
+    mrs    x2, spsr_el1
+    stp    x1, x2, [sp, #S_PC]
+
+    mov    x0, \vec
+    mov    x1, sp
+    mrs    x2, esr_el1
+    bl    do_handle_exception
+
+    ldp    x1, x2, [sp, #S_PC]
+    msr    spsr_el1, x2
+    msr    elr_el1, x1
+
+    .if \vec >= 8
+    ldr    x1, [sp, #S_SP]
+    msr    sp_el0, x1
+    .endif
+
+    ldr    x30, [sp, #S_LR]
+
+    ldp    x28, x29, [sp, #224]
+    ldp    x26, x27, [sp, #208]
+    ldp    x24, x25, [sp, #192]
+    ldp    x22, x23, [sp, #176]
+    ldp    x20, x21, [sp, #160]
+    ldp    x18, x19, [sp, #144]
+    ldp    x16, x17, [sp, #128]
+    ldp    x14, x15, [sp, #112]
+    ldp    x12, x13, [sp,  #96]
+    ldp    x10, x11, [sp,  #80]
+    ldp     x8,  x9, [sp,  #64]
+    ldp     x6,  x7, [sp,  #48]
+    ldp     x4,  x5, [sp,  #32]
+    ldp     x2,  x3, [sp,  #16]
+    ldp     x0,  x1, [sp], #S_FRAME_SIZE
+
+    eret
+.endm
+
+vector_stub    el1t_sync,     0
+vector_stub    el1t_irq,      1
+vector_stub    el1t_fiq,      2
+vector_stub    el1t_error,    3
+
+vector_stub    el1h_sync,     4
+vector_stub    el1h_irq,      5
+vector_stub    el1h_fiq,      6
+vector_stub    el1h_error,    7
+
+vector_stub    el0_sync_64,   8
+vector_stub    el0_irq_64,    9
+vector_stub    el0_fiq_64,   10
+vector_stub    el0_error_64, 11
+
+vector_stub    el0_sync_32,  12
+vector_stub    el0_irq_32,   13
+vector_stub    el0_fiq_32,   14
+vector_stub    el0_error_32, 15
+
+.section .text.ex
+
+.macro ventry, label
+.align 7
+    b    \label
+.endm
+
+
+/*
+ * void __asm_dcache_level(level)
+ *
+ * flush or invalidate one level cache.
+ *
+ * x0: cache level
+ * x1: 0 clean & invalidate, 1 invalidate only
+ * x2~x9: clobbered
+ */
+.globl asm_dcache_level
+asm_dcache_level:
+    lsl    x12, x0, #1
+    msr    csselr_el1, x12        /* select cache level */
+    isb                           /* sync change of cssidr_el1 */
+    mrs    x6, ccsidr_el1         /* read the new cssidr_el1 */
+    and    x2, x6, #7             /* x2 <- log2(cache line size)-4 */
+    add    x2, x2, #4             /* x2 <- log2(cache line size) */
+    mov    x3, #0x3ff
+    and    x3, x3, x6, lsr #3     /* x3 <- max number of #ways */
+    clz    w5, w3                 /* bit position of #ways */
+    mov    x4, #0x7fff
+    and    x4, x4, x6, lsr #13    /* x4 <- max number of #sets */
+    /* x12 <- cache level << 1 */
+    /* x2 <- line length offset */
+    /* x3 <- number of cache ways - 1 */
+    /* x4 <- number of cache sets - 1 */
+    /* x5 <- bit position of #ways */
+loop_set:
+    mov    x6, x3            /* x6 <- working copy of #ways */
+loop_way:
+    lsl    x7, x6, x5
+    orr    x9, x12, x7       /* map way and level to cisw value */
+    lsl    x7, x4, x2
+    orr    x9, x9, x7        /* map set number to cisw value */
+    tbz    w1, #0, 1f
+    dc    isw, x9
+    b    2f
+1:  dc      cisw, x9         /* clean & invalidate by set/way */
+2:  subs    x6, x6, #1       /* decrement the way */
+    b.ge    loop_way
+    subs    x4, x4, #1       /* decrement the set */
+    b.ge    loop_set
+
+    ret
+
+/*
+ * void __asm_flush_dcache_all(int invalidate_only)
+ *
+ * x0: 0 clean & invalidate, 1 invalidate only
+ *
+ * flush or invalidate all data cache by SET/WAY.
+ */
+.globl asm_dcache_all
+asm_dcache_all:
+    mov    x1, x0
+    dsb    sy
+    mrs    x10, clidr_el1       /* read clidr_el1 */
+    lsr    x11, x10, #24
+    and    x11, x11, #0x7       /* x11 <- loc */
+    cbz    x11, finished        /* if loc is 0, exit */
+    mov    x15, lr
+    mov    x0, #0               /* start flush at cache level 0 */
+    /* x0  <- cache level */
+    /* x10 <- clidr_el1 */
+    /* x11 <- loc */
+    /* x15 <- return address */
+loop_level:
+    lsl    x12, x0, #1
+    add    x12, x12, x0        /* x0 <- tripled cache level */
+    lsr    x12, x10, x12
+    and    x12, x12, #7        /* x12 <- cache type */
+    cmp    x12, #2
+    b.lt    skip               /* skip if no cache or icache */
+    bl    asm_dcache_level     /* x1 = 0 flush, 1 invalidate */
+skip:
+    add    x0, x0, #1          /* increment cache level */
+    cmp    x11, x0
+    b.gt    loop_level
+
+    mov    x0, #0
+    msr    csselr_el1, x0      /* restore csselr_el1 */
+    dsb    sy
+    isb
+    mov    lr, x15
+
+finished:
+    ret

--- a/mem_test/memory_model_tests_scenario_user_guide.rst
+++ b/mem_test/memory_model_tests_scenario_user_guide.rst
@@ -1,0 +1,389 @@
+******************************************************
+Memory Model Consistency Test Scenario and User Guide
+******************************************************
+.. raw:: pdf
+
+   PageBreak
+
+.. section-numbering::
+
+.. contents::
+      :depth: 4
+
+Introduction
+============
+
+This document provides detailed information on the test scenarios for memory model consistency tests.
+It includes instructions for analyzing the log output of litmus tests to help users infer the memory model.
+Additionally, an overview of the source code directory structure is provided, explaining how the source code
+is structured.
+
+Test Suite Overview
+===================
+
+.. list-table::
+  :widths: 5 25 75
+
+  * - Test number
+    - Test name
+    - Description
+  * - 1
+    - 2+2W+dmb.sys
+    - | Tests the effect of coherence order per location between two PEs.
+      | Validated if there is an execution where: P0 performs a STR of 2 to x
+      | and a STR of 1 to y with a DMB SY between them;  P1 performs a STR of 2
+      | to y and a STR of 1 to y, with a DMB SY between them. At the end, x=2
+      | and y=2.
+
+  * - 2
+    - CO-MIXED-20cc+H
+    - | A test with reads and writes of different sizes to the same location.
+      | Validated if there is an execution where: P0 performs a 8bit STR of 1 to
+      | x and then a 16bit LDR from x reading 0x0201; P1 performs a 16bit STR of
+      | 0x0202 to x. At the end, location x has the value 0x0202.
+
+  * - 3
+    - CoRR
+    - | Tests whether two reads from the same location in program order can be
+      | reordered. Validated if there is an execution where: P0 performs a STR
+      | of 1 to x;  P1 performs a LDR reading 1 and then a LDR x from x reading 0.
+
+  * - 4
+    - CoRW1
+    - | Tests whether a read has to get its value from a write to the same
+      | location that follows in program order. Validated if there is an
+      | execution where: P0 performs a LDR from x, reading 1 and then a STR of 1
+      | to x.
+
+  * - 5
+    - CoRW2+posb1b0+h0
+    - | A test with reads and writes of different sizes to the same location.
+      | Validated if there is an execution where: P0 performs a 16bit STR of
+      | 0x101 to x; P1 performs a 8bit LDR from the address x + 1 reading 0 or
+      | 1, then a 8bit STR of 2 to x, and then a 16bit LDR from x reading 0x102.
+      | At the end, location x has the value 0x101.
+
+  * - 6
+    - CoRW2
+    - | A test with a read and writes to the same location. Validated if there
+      | is an execution where: P0 performs a STR of 1 to x; P1 performs a LDR
+      | from x reading 1, and then a STR of 2 to x. At the end, location x has
+      | the value 1.
+
+  * - 7
+    - CoWR
+    - | Single PE test that shows that a read that is in program order after a
+      | STR to the same location gets its value from that write. Validated if
+      | there is an execution where: P0 performs a STR of 1 to x and then a LDR
+      | from x reading 0.
+
+  * - 8
+    - CoWW
+    - | Single PE test that shows that two writes to the same location cannot be
+      | observed out of order. Validated if there is an execution where: P0
+      | performs a STR of 1 to x and then a STR of 2 to x. At the end, location
+      | x has the value 1.
+
+  * - 9
+    - LB+BEQ4
+    - | Tests the effect of load buffering between two PEs. Validated if there
+      | is an execution where: P0 performs a LDR from y  reading 1 and a STR
+      | release of 1 to x; P1 performs a LDR from x reading 1 and a STR of 1 to
+      | y with a control dependency in between.
+
+  * - 10
+    - LB+CSEL-addr-po+DMB
+    - | Tests the effect of load buffering between two PEs. Validated if there
+      | is an execution where: P0 performs a LDR from x reading 1 and a STR of 1
+      | to a which has a pick address dependency from the preceding LDR, and
+      | finally a STR of 1 to y; P1 performs a LDR from y reading 1, then a dmb
+      | sy, and then a STR of 1 to x.
+
+  * - 11
+    - LB+CSEL-rfi-data+DMB
+    - | Tests the effect of load buffering between two PEs. Validated if there
+      | is an execution where: P0 performs a LDR from x reading 1, then a STR to
+      | z which has a pick data dependency from the preceding LDR, then a LDR
+      | from z, and finally a STR of 1 to y which has a data dependency from the
+      | preceding LDR; P1 performs a LDR from y reading 1, then dmb sy, and then
+      | a STR of 1 to x.
+
+  * - 12
+    - LB+dmb.sy+data-wsi-wsi+MIXED+H
+    - | Tests the effect of load buffering between two PEs. Validated if there
+      | is an execution where: P0 performs an 8bit LDR from x reading 2, then a
+      | dmb sy, and finally a 16bit STR of 1 to y; P1 performs a 8bit LDR from y
+      | reading 1, then an 8bit STR of 1 to the address x+1, then a 16bit STR of
+      | 2 to x, and finally a 16bit STR of 3 to x. At the end, location x has
+      | the value 3.
+
+  * - 13
+    - LB+dmb.sys
+    - | Tests the effect of load buffering between two PEs. Validated if there
+      | is an execution where: P0 performs a LDR from x reading 1 and a STR of 1
+      | to y, with a DMB SY between them; P1 performs a LDR from y reading 1 and
+      | a STR of 1 to x, with a DMB SY between them.
+
+  * - 14
+    - LB+rel+BEQ2
+    - | Tests the effect of load buffering between two PEs. Validated if there
+      | is an execution where: P0 performs a LDR from y reading 1 and a STR
+      | release of 1 to x; P1 performs a LDR from x reading 1 and a STR of 1 to
+      | y with a data dependency in between.
+
+  * - 15
+    - LB+rel+CSEL-CSEL
+    - | Tests the effect of load buffering between two PEs. Validated if there
+      | is an execution where: P0 performs a LDR from x reading 1 and a STR
+      | release of 1 to y; P1 performs a LDR from y reading 1, and finally a STR
+      | of 1 to x which has a pick data dependency from the preceding LDR.
+
+  * - 16
+    - LB+rel+data
+    - | Tests the effect of load buffering between two PEs. Validated if there
+      | is an execution where: P0 performs a LDR from x reading 1 and a STR
+      | release of 1 to y; P1 performs a LDR from y reading 1, and finally a STR
+      | of 1 to x which has a data dependency from the preceding LDR.
+
+  * - 17
+    - MP+dmb.sys
+    - | Tests the effect of message passing between two PEs. Validated if there
+      | is an execution where: P0 performs a STR of 1 to x (message) and a STR
+      | of 1 to y (flag) with a DMB SY between them; P1 performs a LDR from y
+      | (flag) reading 1 and a LDR from x (message) reading 0 with a DMB SY
+      | between them.
+
+  * - 18
+    - MP-Koeln
+    - | Tests the effect of message passing between two PEs. Validated if there
+      | is an execution where: P0 performs a 16bit STR of 0x101 to x, a 8bit STR
+      | release of 1 to y, and a 16bit STR of 0x202 to y; P1 performs a 8bit LDR
+      | from the address y+1 reading 2, and then a 16 bit LDR from x reading 0.
+      | At the end, location y has the value 0x202.
+
+  * - 19
+    - R+dmb.sys
+    - | Tests the effect of communication between two PEs. Validated if there is
+      | an execution where: P0 performs a STR of 1 to x and a STR of 1 to y with
+      | a DMB SY between them; P1 performs a STR of 2 to y and a LDR from x
+      | reading 0 with a DMB SY between them. At the end, y=2.
+
+  * - 20
+    - S+dmb.sys
+    - | Tests the effect of communication between two PEs. Validated if there is
+      | an execution where: P0 performs a STR of 1 to x and a STR of 2 to y with
+      | a DMB SY between them; P1 performs a LDR from y reading 1 and a STR of 1
+      | to x with a DMB SY between them. At the end, y=2.
+
+  * - 21
+    - S+rel+CSEL-data
+    - | Tests the effect of message passing between two PEs. Validated if there
+      | is an execution where: P0 performs a  STR of 1 to x, and a STR release
+      | of 1 to y; P1 performs a LDR from the address y reading 1, then a STR of
+      | 0 to z which has a pick data dependency from the preceding LDR, then a
+      | LDR from z reading 0, and then a STR of 2 to x which has a data
+      | dependency from the preceding LDR. At the end, location x has the value 1.
+
+  * - 22
+    - S+rel+CSEL-rf-reg
+    - | Tests the effect of message passing between two PEs. Validated if there
+      | is an execution where: P0 performs a  STR of 1 to x, and a STR release
+      | of 1 to y; P1 performs a LDR from the y reading 1, then a STR of 0 to x
+      | which has a pick data dependency from the preceding LDR. At the end,
+      | location x has the value 1.
+
+  * - 23
+    - SB+dmb.sys
+    - | Tests the effect of store buffering between two PEs. Validated if there
+      | is an execution where: P0 performs a LDR from y reading 1 and a STR of 1
+      | to x, ordered via a DMB SY; P1 performs a LDR reading 1 from x STR of 1
+      | to y, ordered via a DMB SY.
+
+  * - 24
+    - T10B
+    - | Tests the effect of load buffering between two PEs. Validated if there
+      | is an execution where: P0 performs a LDR from x reading 1 and a STR
+      | release of 1 to y; P1 performs a LDR from y reading 1, then a STR of 0
+      | to za, then a LDR from za reading 0, then a STR of 0 to zb which has a
+      | data dependecy from the predecing LDR, then a LDR from zb and finally a
+      | STR of 1 to x which has an address dependency from the preceding LDR.
+
+  * - 25
+    - T10C
+    - | Tests the effect of load buffering between two PEs. Validated if there
+      | is an execution where: P0 performs a LDR from x reading 1 and a STR
+      | release of 1 to y; P1 performs a LDR from y reading 1, then a STR of 0
+      | to za which has a pick data dependency from the preceding LDR, then a
+      | LDR from za reading 0, and finally, a STR of 1 to x which has an address
+      | dependency from the preceding LDR.
+
+  * - 26
+    - T15-corrected
+    - | Tests the effect of message passing between two PEs. Validated if there
+      | is an execution where: P0 performs a STR of 1 to x and a STR release of
+      | 1 to y; P1 performs a LDR from y reading 1, then a STR of 0 to z which
+      | has a pick data dependency from the preceding LDR, then a LDR from z
+      | reading 0, and finally a LDR from x reading 0 which has a control
+      | dependecy followed by an isb from the preceding LDR.
+
+  * - 27
+    - T15-datadep-corrected
+    - | Tests the effect of message passing between two PEs. Validated if there
+      | is an execution where: P0 performs a STR of 1 to x and a STR release of
+      | 1 to y; P1 performs a LDR from y reading 1, then a STR of 0 to z, then a
+      | LDR from z reading 0, and finally a LDR from x reading 0 which has a
+      | control dependecy followed by an isb from the preceding LDR.
+
+  * - 28
+    - T3-bis
+    - | Tests the effect of load buffering between two PEs. Validated if there
+      | is an execution where: P0 performs a LDR from x reading 1, a STR of 0 to
+      | za which has a pick address dependency from the preceding LDR, a LDR of
+      | 0 from za and a STR of 1 to y; P1 performs a LDR acquire from y reading
+      | 1, then a STR of 0 to x.
+
+  * - 29
+    - T3
+    - | Tests the effect of load buffering between two PEs. Validated if there
+      | is an execution where: P0 performs a LDR from x reading 1, a LDR of 0
+      | from za which has a pick address dependency from the preceding LDR, and
+      | a STR of 1 to y; P1 performs a LDR acquire from y reading 1, then a STR
+      | of 0 to x.
+
+  * - 30
+    - T7
+    - | Tests the effect of load buffering between two PEs. Validated if there
+      | is an execution where: P0 performs a LDR from x reading 1, a STR of 0 to
+      | z which has a pick data dependency from the preceding LDR, a LDR acquire
+      | from z reading 0, a LDR from a reading 0, and finally, a STR of 1 to
+      | y; P1 performs a LDR acquire from y reading 1, then a STR of 0 to x.
+
+  * - 31
+    - T7dep
+    - | Tests the effect of load buffering between two PEs. Validated if there
+      | is an execution where: P0 performs a LDR from x reading 1, a STR of 0 to
+      | z which has a pick data dependency from the preceding LDR, a LDR from z
+      | reading 0, a LDR from a reading 0 which has an address dependecy from
+      | the preceding LDR, and finally, a STR of 1 to y; P1 performs a LDR
+      | acquire from y reading 1, then a STR of 0 to x.
+
+  * - 32
+    - T8+BIS
+    - | Tests the effect of load buffering between two PEs. Validated if there
+      | is an execution where: P0 performs a LDR from x reading 1, a STR of 0 to
+      | z which has a pick data dependency from the preceding LDR, a LDR
+      | exclusive from z reading 0, a LDR from z reading 0, and finally, a STR
+      | of 1 to y which has an address dependecy from the preceding LDR; P1
+      | performs a LDR acquire from y reading 1, then a STR of 0 to x.
+
+  * - 33
+    - T9B
+    - | Tests the effect of message passing between two PEs. Validated if there
+      | is an execution where: P0 performs a STR of 1 to x and a STR release of
+      | 1 to y; P1 performs a LDR from y reading 1, then a LDR from x reading 0
+      | which has a pick control dependency followed by an isb from the
+      | preceding LDR.
+
+Analysing litmus tests log ouput
+================================
+
+Each litmus test outputs a result log in a format similar to the following snippet. The log of the 2+2W+dmb.sys test is taken as an example in the interest
+of providing guidance for analyzing the results.
+
+.. code-block:: text
+
+    1  Test 2+2W+dmb.sys Forbidden
+    2  Histogram (3 states)
+    3  277246:>[x]=1; [y]=2;
+    4  468606:>[x]=2; [y]=1;
+    5  1254148:>[x]=1; [y]=1;
+    6  Ok
+    7  Witnesses
+    8  Positive: 2000000, Negative: 0
+    9  Condition ~exists ([x]=2 /\ [y]=2) is validated
+    10 Hash=9495f1f810a4f034c732242a8a2c3eed
+    11 Cycle=Wse DMB.SYdWW Wse DMB.SYdWW
+    12 Generator=diycross7 (version 7.54+01(dev))
+    13 Com=Ws Ws
+    14 Orig=DMB.SYdWW Wse DMB.SYdWW Wse
+    15 Observation 2+2W+dmb.sys Never 0 2000000
+    16 Time 2+2W+dmb.sys 3.64
+
+Each litmus test validates a post-condition, and Line 9 echoes this post-condition and states whether the condition was validated or not on the target memory model.
+(For example, in the above scenario, it is validating the post condition whether not in their final state  both the memory location x and y had the value 2.
+
+Line 1 provides the test name and specifies the type of test it is. The format is 'Test <name> <kind>', where <kind> can be 'Allowed', 'Forbidden', or 'Required'.
+'Allowed' indicates that there can be an execution where the post-condition is validated. 'Forbidden' means that there cannot be any executions where the post-condition
+is validated, and 'Required' indicates that all executions must validate the post-condition. If the user hasn’t provided any information, then the default is 'Allowed'.
+
+Line 2-5 provides histogram of observations, each of the line captures the values of the memory locations and registers that the post-condition contains and the number
+of executions that each state was observed. (For example, in the above scenario, out of 277246 executions, it was found that in their final state, location x had the value
+1 and location 2 had the value 2.)
+
+Line 6 provides the outcome of the test. 'Ok' if the expected outcome is observed. (For example, for an allowed post condition, test will print 'Ok' if there is at least
+one execution that validates the post-condition), otherwise it prints 'No'.
+
+Line 7-8 provides the observations of post condition, number of executions that validate the post-condition and number of executions that didn’t validate the post-condition.
+
+Line 9 provides the hash of the litmus test which includes the initial state, the code and the post-condition. Two different files with potentially different names can have
+the same signature which means they are the same test.
+
+Line 11-14 contain metadata for other memory model tools, which are not relevent here.
+
+Line 16 provides wall clock time of the execution of the test.
+
+Source Code Directory Structure
+===============================
+
+The following structure shows the source code directory of memory model consistency tests
+inside bsa-acs repository and infra required to build them into BSA ACS EFI application.
+
+::
+
+    📂 bsa-acs
+    ├── .
+    ├── 📂 uefi_app
+    │  ├── BsaAcsMem.inf
+    ├── 📂 mem_test
+    │  ├── LibCFlat.inf
+    |  ├── README.md
+    |  ├── bsa_acs_litmus.h
+    |  ├── efi_bsa_entry.c
+    |  ├── 📂 litmus-tests
+    |  ├── memTestBsaSupport.S
+    |  ├── 📂 patches
+    |  └── memory_model_tests_scenario_user_guide.rst
+    ├── .
+    └── .
+
+.. list-table::
+  :widths: 25 75
+
+  * - Directory/File name
+    - Description
+  * - BsaAcsMem.inf
+    - | EDK-II INF file describing memory model consistency tests source files,
+      | libraries, and compiler flags.
+  * - LibCFlat.inf
+    - EDK-II INF file describing kvm-unit-tests source files and compiler flags.
+  * - README.md
+    - README file provides with build and run steps.
+  * - bsa_acs_litmus.h
+    - Contains test entry prototypes.
+  * - efi_bsa_entry.c
+    - Contains test entry function calls and initialization of test infrastructure.
+  * - litmus-tests
+    - Contains memory model consistency test source files.
+  * - memTestBsaSupport.S
+    - assembly function definitions
+  * - patches
+    - Contains edk2 repository patches.
+  * - memory_model_tests_scenario_user_guide.rst
+    - This document captures test scenario and instructions for analyzing the log output of litmus tests.
+
+
+.. _footer:
+
+.. container:: footer
+
+  Copyright © 2023-2024, Arm Limited and Contributors. All rights reserved.

--- a/mem_test/patches/mem_test_edk2.patch
+++ b/mem_test/patches/mem_test_edk2.patch
@@ -1,0 +1,58 @@
+diff --git a/BaseTools/Scripts/GccBase.lds b/BaseTools/Scripts/GccBase.lds
+index 9f27e83bb0..79e8c9f023 100644
+--- a/BaseTools/Scripts/GccBase.lds
++++ b/BaseTools/Scripts/GccBase.lds
+@@ -21,6 +21,7 @@ SECTIONS {
+   . = PECOFF_HEADER_SIZE;
+ 
+   .text : ALIGN(CONSTANT(COMMONPAGESIZE)) {
++    _textbsa = .;
+     *(.text .text.* .stub .gnu.linkonce.t.*)
+     *(.rodata .rodata.* .gnu.linkonce.r.*)
+     *(.got .got.*)
+diff --git a/ShellPkg/Library/UefiShellCEntryLib/UefiShellCEntryLib.c b/ShellPkg/Library/UefiShellCEntryLib/UefiShellCEntryLib.c
+index 17e48443ac..a2b3adefdf 100644
+--- a/ShellPkg/Library/UefiShellCEntryLib/UefiShellCEntryLib.c
++++ b/ShellPkg/Library/UefiShellCEntryLib/UefiShellCEntryLib.c
+@@ -16,6 +16,9 @@
+ #include <Library/ShellCEntryLib.h>
+ #include <Library/DebugLib.h>
+ 
++EFI_SYSTEM_TABLE *mySystemTable;
++EFI_HANDLE myImageHandle;
++
+ /**
+   UEFI entry point for an application that will in turn call the
+   ShellAppMain function which has parameters similar to a standard C
+@@ -51,6 +54,9 @@ ShellCEntryLib (
+   EfiShellParametersProtocol = NULL;
+   EfiShellInterface          = NULL;
+ 
++  mySystemTable = SystemTable;
++  myImageHandle = ImageHandle;
++
+   Status = SystemTable->BootServices->OpenProtocol (
+                                         ImageHandle,
+                                         &gEfiShellParametersProtocolGuid,
+diff --git a/ShellPkg/ShellPkg.dsc b/ShellPkg/ShellPkg.dsc
+index 557b0ec0f3..bccbed89b5 100644
+--- a/ShellPkg/ShellPkg.dsc
++++ b/ShellPkg/ShellPkg.dsc
+@@ -27,6 +27,9 @@
+   UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf
+   UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
+   DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLibOptionalDevicePathProtocol.inf
++  BsaValLib|ShellPkg/Application/bsa-acs/val/BsaValLib.inf
++  BsaPalLib|ShellPkg/Application/bsa-acs/pal/uefi_acpi/BsaPalLib.inf
++  LibCFlat|ShellPkg/Application/bsa-acs/mem_test/LibCFlat.inf
+ !if $(TARGET) == RELEASE
+   DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
+ !else
+@@ -102,6 +105,7 @@
+   ShellPkg/Library/UefiShellDebug1CommandsLib/UefiShellDebug1CommandsLib.inf
+   ShellPkg/Library/UefiShellNetwork1CommandsLib/UefiShellNetwork1CommandsLib.inf
+   ShellPkg/Library/UefiShellNetwork2CommandsLib/UefiShellNetwork2CommandsLib.inf
++  ShellPkg/Application/bsa-acs/uefi_app/BsaAcsMem.inf
+ 
+   ShellPkg/Application/Shell/Shell.inf {
+     <PcdsFixedAtBuild>

--- a/tools/scripts/acsbuild.sh
+++ b/tools/scripts/acsbuild.sh
@@ -1,3 +1,21 @@
+## @file
+#  Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+#  SPDX-License-Identifier : Apache-2.0
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+##
+
+
 if [ $(uname -m) != "aarch64" ] && [ -v $GCC49_AARCH64_PREFIX ]
 then
     echo "GCC49_AARCH64_PREFIX is not set"
@@ -7,6 +25,11 @@ fi
 
 if [ "$1" == "ENABLE_OOB" ]; then
     build -a AARCH64 -t GCC49 -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/bsa-acs/baremetal_app/BsaAcs.inf -D ENABLE_OOB
+    return 0;
+fi
+
+if [ "$1" == "ENABLE_MEMTEST" ]; then
+    build -a AARCH64 -t GCC49 -n 1 -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/bsa-acs/uefi_app/BsaAcsMem.inf
     return 0;
 fi
 

--- a/uefi_app/BsaAcsMain.c
+++ b/uefi_app/BsaAcsMain.c
@@ -62,6 +62,14 @@ UINT32  g_el1physkip = FALSE;
 SHELL_FILE_HANDLE g_acs_log_file_handle;
 SHELL_FILE_HANDLE g_dtb_log_file_handle;
 
+#ifdef ENABLE_MEMTEST
+extern EFI_SYSTEM_TABLE *mySystemTable;
+extern EFI_HANDLE myImageHandle;
+extern char _textbsa;
+typedef unsigned long efi_status_t;
+efi_status_t  mem_model_execute_tests(EFI_HANDLE myImageHandle, EFI_SYSTEM_TABLE *mySystemTable);
+#endif
+
 STATIC VOID FlushImage (VOID)
 {
   EFI_LOADED_IMAGE_PROTOCOL   *ImageInfo;
@@ -649,6 +657,14 @@ print_test_status:
   }
 
   val_print(ACS_PRINT_TEST, "\n      *** BSA tests complete. Reset the system. ***\n\n", 0);
+
+#ifdef ENABLE_MEMTEST
+  /***  Starting memory model consistency tests ***/
+  val_print(ACS_PRINT_TEST, "\n\n      *** Starting memory model consistency tests ***  \n", 0);
+  val_print(ACS_PRINT_TEST, "\nInitializing kvm-unit-tests framework ...", 0);
+  val_print(ACS_PRINT_TEST, "\nLoad address of the image is: 0x%lx\n", (unsigned long)&_textbsa);
+  mem_model_execute_tests(myImageHandle, mySystemTable);
+#endif
 
   if (g_acs_log_file_handle) {
     ShellCloseFile(&g_acs_log_file_handle);

--- a/uefi_app/BsaAcsMem.inf
+++ b/uefi_app/BsaAcsMem.inf
@@ -1,0 +1,203 @@
+## @file
+#  Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+#  SPDX-License-Identifier : Apache-2.0
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+##
+
+
+[Defines]
+  INF_VERSION                    = 0x00010006
+  BASE_NAME                      = Bsa
+  FILE_GUID                      = f7571f11-0ee6-47ea-930f-255261676708
+  MODULE_TYPE                    = UEFI_APPLICATION
+  VERSION_STRING                 = 0.1
+  ENTRY_POINT                    = ShellCEntryLib
+
+#
+#  VALID_ARCHITECTURES           = AARCH64
+#
+
+[Sources.AARCH64]
+  ../
+  BsaAcsMain.c
+  ../test_pool/pe/operating_system/test_os_c001.c
+  ../test_pool/pe/operating_system/test_os_c002.c
+  ../test_pool/pe/operating_system/test_os_c003.c
+  ../test_pool/pe/operating_system/test_os_c004.c
+  ../test_pool/pe/operating_system/test_os_c006.c
+  ../test_pool/pe/operating_system/test_os_c007.c
+  ../test_pool/pe/operating_system/test_os_c008.c
+  ../test_pool/pe/operating_system/test_os_c009.c
+  ../test_pool/pe/operating_system/test_os_c010.c
+  ../test_pool/pe/operating_system/test_os_c011.c
+  ../test_pool/pe/operating_system/test_os_c012.c
+  ../test_pool/pe/operating_system/test_os_c013.c
+  ../test_pool/pe/operating_system/test_os_c014.c
+  ../test_pool/pe/hypervisor/test_hyp_c001.c
+  ../test_pool/pe/hypervisor/test_hyp_c002.c
+  ../test_pool/pe/hypervisor/test_hyp_c003.c
+  ../test_pool/pe/hypervisor/test_hyp_c004.c
+  ../test_pool/pe/hypervisor/test_hyp_c005.c
+  ../test_pool/pe/platform_security/test_ps_c001.c
+  ../test_pool/memory_map/operating_system/test_os_m001.c
+  ../test_pool/memory_map/operating_system/test_os_m002.c
+  ../test_pool/memory_map/operating_system/test_os_m003.c
+  ../test_pool/gic/operating_system/test_os_g001.c
+  ../test_pool/gic/operating_system/test_os_g002.c
+  ../test_pool/gic/operating_system/test_os_g003.c
+  ../test_pool/gic/operating_system/test_os_g004.c
+  ../test_pool/gic/operating_system/test_os_g005.c
+  ../test_pool/gic/operating_system/test_os_g006.c
+  ../test_pool/gic/operating_system/test_os_g007.c
+  ../test_pool/gic/operating_system/test_os_v2m001.c
+  ../test_pool/gic/operating_system/test_os_v2m002.c
+  ../test_pool/gic/operating_system/test_os_v2m003.c
+  ../test_pool/gic/operating_system/test_os_v2m004.c
+  ../test_pool/gic/operating_system/test_os_its001.c
+  ../test_pool/gic/operating_system/test_os_its002.c
+  ../test_pool/gic/operating_system/test_os_its003.c
+  ../test_pool/gic/operating_system/test_os_its004.c
+  ../test_pool/gic/hypervisor/test_hyp_g001.c
+  ../test_pool/gic/hypervisor/test_hyp_g002.c
+  ../test_pool/gic/hypervisor/test_hyp_g003.c
+  ../test_pool/timer/operating_system/test_os_t001.c
+  ../test_pool/timer/operating_system/test_os_t002.c
+  ../test_pool/timer/operating_system/test_os_t003.c
+  ../test_pool/timer/operating_system/test_os_t004.c
+  ../test_pool/timer/operating_system/test_os_t005.c
+  ../test_pool/watchdog/operating_system/test_os_w001.c
+  ../test_pool/watchdog/operating_system/test_os_w002.c
+  ../test_pool/pcie/operating_system/test_os_p001.c
+  ../test_pool/pcie/operating_system/test_os_p002.c
+  ../test_pool/pcie/operating_system/test_os_p003.c
+  ../test_pool/pcie/operating_system/test_os_p006.c
+  ../test_pool/pcie/operating_system/test_os_p008.c
+  ../test_pool/pcie/operating_system/test_os_p009.c
+  ../test_pool/pcie/operating_system/test_os_p011.c
+  ../test_pool/pcie/operating_system/test_os_p017.c
+  ../test_pool/pcie/operating_system/test_os_p018.c
+  ../test_pool/pcie/operating_system/test_os_p019.c
+  ../test_pool/pcie/operating_system/test_os_p020.c
+  ../test_pool/pcie/operating_system/test_os_p021.c
+  ../test_pool/pcie/operating_system/test_os_p022.c
+  ../test_pool/pcie/operating_system/test_os_p024.c
+  ../test_pool/pcie/operating_system/test_os_p025.c
+  ../test_pool/pcie/operating_system/test_os_p026.c
+  ../test_pool/pcie/operating_system/test_os_p030.c
+  ../test_pool/pcie/operating_system/test_os_p031.c
+  ../test_pool/pcie/operating_system/test_os_p032.c
+  ../test_pool/pcie/operating_system/test_os_p033.c
+  ../test_pool/pcie/operating_system/test_os_p035.c
+  ../test_pool/pcie/operating_system/test_os_p036.c
+  ../test_pool/pcie/operating_system/test_os_p037.c
+  ../test_pool/pcie/operating_system/test_os_p038.c
+  ../test_pool/pcie/operating_system/test_os_p039.c
+  ../test_pool/pcie/operating_system/test_os_p040.c
+  ../test_pool/pcie/operating_system/test_os_p042.c
+  ../test_pool/smmu/operating_system/test_os_i001.c
+  ../test_pool/smmu/operating_system/test_os_i002.c
+  ../test_pool/smmu/operating_system/test_os_i003.c
+  ../test_pool/smmu/operating_system/test_os_i004.c
+  ../test_pool/smmu/hypervisor/test_hyp_i002.c
+  ../test_pool/smmu/hypervisor/test_hyp_i003.c
+  ../test_pool/smmu/hypervisor/test_hyp_i004.c
+  ../test_pool/power_wakeup/operating_system/test_os_u001.c
+  ../test_pool/power_wakeup/operating_system/test_os_u002.c
+  ../test_pool/peripherals/operating_system/test_os_d001.c
+  ../test_pool/peripherals/operating_system/test_os_d002.c
+  ../test_pool/peripherals/operating_system/test_os_d003.c
+  ../test_pool/peripherals/operating_system/test_os_d005.c
+  ../test_pool/exerciser/operating_system/test_os_e001.c
+  ../test_pool/exerciser/operating_system/test_os_e002.c
+  ../test_pool/exerciser/operating_system/test_os_e003.c
+  ../test_pool/exerciser/operating_system/test_os_e004.c
+  ../test_pool/exerciser/operating_system/test_os_e005.c
+  ../test_pool/exerciser/operating_system/test_os_e006.c
+  ../test_pool/exerciser/operating_system/test_os_e007.c
+  ../test_pool/exerciser/operating_system/test_os_e008.c
+  ../test_pool/exerciser/operating_system/test_os_e010.c
+  ../test_pool/exerciser/operating_system/test_os_e011.c
+  ../test_pool/exerciser/operating_system/test_os_e012.c
+  ../test_pool/exerciser/operating_system/test_os_e013.c
+  ../test_pool/exerciser/operating_system/test_os_e014.c
+  ../test_pool/exerciser/operating_system/test_os_e015.c
+  ../test_pool/exerciser/operating_system/test_os_e016.c
+  ../test_pool/exerciser/operating_system/test_os_e017.c
+  ../mem_test/litmus-tests/2+2W+dmb.sys.c
+  ../mem_test/litmus-tests/CO-MIXED-20cc+H.c
+  ../mem_test/litmus-tests/CoRR.c
+  ../mem_test/litmus-tests/CoRW1.c
+  ../mem_test/litmus-tests/CoRW2+posb1b0+h0.c
+  ../mem_test/litmus-tests/CoRW2.c
+  ../mem_test/litmus-tests/CoWR.c
+  ../mem_test/litmus-tests/CoWW.c
+  ../mem_test/litmus-tests/LB+BEQ4.c
+  ../mem_test/litmus-tests/LB+CSEL-addr-po+DMB.c
+  ../mem_test/litmus-tests/LB+CSEL-rfi-data+DMB.c
+  ../mem_test/litmus-tests/LB+dmb.sy+data-wsi-wsi+MIXED+H.c
+  ../mem_test/litmus-tests/LB+dmb.sys.c
+  ../mem_test/litmus-tests/LB+rel+BEQ2.c
+  ../mem_test/litmus-tests/LB+rel+CSEL-CSEL.c
+  ../mem_test/litmus-tests/LB+rel+data.c
+  ../mem_test/litmus-tests/MP+dmb.sys.c
+  ../mem_test/litmus-tests/MP-Koeln.c
+  ../mem_test/litmus-tests/R+dmb.sys.c
+  ../mem_test/litmus-tests/S+dmb.sys.c
+  ../mem_test/litmus-tests/S+rel+CSEL-data.c
+  ../mem_test/litmus-tests/S+rel+CSEL-rf-reg.c
+  ../mem_test/litmus-tests/SB+dmb.sys.c
+  ../mem_test/litmus-tests/T10B.c
+  ../mem_test/litmus-tests/T10C.c
+  ../mem_test/litmus-tests/T15-corrected.c
+  ../mem_test/litmus-tests/T15-datadep-corrected.c
+  ../mem_test/litmus-tests/T3-bis.c
+  ../mem_test/litmus-tests/T3.c
+  ../mem_test/litmus-tests/T7.c
+  ../mem_test/litmus-tests/T7dep.c
+  ../mem_test/litmus-tests/T8+BIS.c
+  ../mem_test/litmus-tests/T9B.c
+
+[Packages]
+  StdLib/StdLib.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  ShellPkg/ShellPkg.dec
+
+[LibraryClasses]
+  BsaValLib
+  BsaPalLib
+  LibCFlat
+  UefiLib
+  ShellLib
+  DebugLib
+  BaseMemoryLib
+  ShellCEntryLib
+  UefiBootServicesTableLib
+  UefiRuntimeServicesTableLib
+
+[Protocols]
+  gEfiAcpiTableProtocolGuid                     ## CONSUMES
+  gHardwareInterruptProtocolGuid                ## CONSUMES
+  gEfiCpuArchProtocolGuid                       ## CONSUMES
+  gEfiPciIoProtocolGuid                         ## CONSUMES
+  gEfiLoadedImageProtocolGuid                   ## CONSUMES
+
+[Guids]
+  gEfiAcpi20TableGuid
+  gEfiAcpiTableGuid
+
+[BuildOptions]
+  GCC:*_*_*_ASM_FLAGS  =  -march=armv8.2-a
+  GCC:*_*_*_CC_FLAGS   = -g -gdwarf-4 -mstrict-align -march=armv8.2-a -O0 -DNOSWP -I${WORKSPACE}/ShellPkg/Application/bsa-acs/mem_test/kvm-unit-tests/lib/arm64 -I${WORKSPACE}/ShellPkg/Application/bsa-acs/mem_test/kvm-unit-tests/lib -DBSA_ACS -DENABLE_MEMTEST


### PR DESCRIPTION
 - added support to compile kvm-unit-tests test framework as a lib to provide required infra to run the litmus tests.
 - added 34 litmus tests to bsa-acs test suite.
 - tests can be built into bsa by passing ENABLE_MEMTEST flag to build command.
 - test scenario, log analysis instructions and README is added for user to build and run litmus tests