### PR TITLE
Skipping Ethernet device for FLR test

### DIFF
--- a/test_pool/pcie/operating_system/test_os_p035.c
+++ b/test_pool/pcie/operating_system/test_os_p035.c
@@ -86,11 +86,17 @@ payload(void)
       dp_type = val_pcie_device_port_type(bdf);
 
       /* Skip check for Storage devices as the
-       * logs will not be stored if FLR is done*/
+       * logs will not be stored if FLR is done
+       * Skip for ethernet controller as device
+       * init can get corrupted when FLR is done */
       val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
       base_cc = reg_value >> TYPE01_BCC_SHIFT;
-      if (base_cc == MAS_CC)
+      if ((base_cc == MAS_CC) || (base_cc == CNTRL_CC))
+      {
+          val_print(ACS_PRINT_DEBUG, "\n       Skipping for BDF - 0x%x ", bdf);
+          val_print(ACS_PRINT_DEBUG, " Classcode is : 0x%x ", base_cc);
           continue;
+      }
 
       /* Check entry is normal EP */
       if (dp_type == EP)


### PR DESCRIPTION
- Skipped the FLR check for ethernet devices as FLR might cause data corruption and disrupt the init of the device