### PR TITLE
Alinging dt pal and val pe and smmu info table struct

### DIFF
--- a/pal/uefi_dt/bsa/include/pal_uefi.h
+++ b/pal/uefi_dt/bsa/include/pal_uefi.h
@@ -91,6 +91,9 @@ typedef struct {
   UINT32 num_of_pe;
 }PE_INFO_HDR;
 
+#define DEFAULT_CACHE_IDX 0xFFFFFFFF
+#define MAX_L1_CACHE_RES 2 /* Generally PE Level 1 have a data and a instruction cache */
+
 /**
   @brief  structure instance for PE entry
 **/
@@ -100,6 +103,9 @@ typedef struct {
   UINT64   mpidr;     ///< PE MPIDR
   UINT32   pmu_gsiv;  ///< PMU Interrupt ID
   UINT32   gmain_gsiv;  ///< GIC Maintenance Interrupt ID
+  UINT32   acpi_proc_uid;                 /* ACPI Processor UID */
+  UINT32   level_1_res[MAX_L1_CACHE_RES]; /* index of level 1 cache(s) in cache_info_table */
+  UINT32   trbe_interrupt;                /* TRBE Interrupt */
 }PE_INFO_ENTRY;
 
 typedef struct {
@@ -300,8 +306,14 @@ typedef union {
 
 #define MAX_NAMED_COMP_LENGTH 256
 
+typedef struct {
+  UINT64 smmu_base;                     /* SMMU base to which component is attached, else NULL */
+  UINT32 cca;                           /* Cache Coherency Attribute */
+  CHAR8 name[MAX_NAMED_COMP_LENGTH];    /* Device object name */
+} IOVIRT_NAMED_COMP_INFO_BLOCK;
+
 typedef union {
-  CHAR8 name[MAX_NAMED_COMP_LENGTH];
+  IOVIRT_NAMED_COMP_INFO_BLOCK named_comp;
   IOVIRT_RC_INFO_BLOCK rc;
   IOVIRT_PMCG_INFO_BLOCK pmcg;
   UINT32 its_count;
@@ -419,7 +431,11 @@ typedef struct {
 UINT32 pal_pcie_get_root_port_bdf(UINT32 *seg, UINT32 *bus, UINT32 *dev, UINT32 *func);
 UINT32 pal_pcie_max_pasid_bits(UINT32 bdf);
 
+
 /* Memory INFO table */
+#define MEM_MAP_SUCCESS  0x0
+#define MEM_MAP_NO_MEM   0x10000001
+#define MEM_MAP_FAILURE  0x2
 
 #define MEM_INFO_TBL_MAX_ENTRY  500 /* Maximum entries to be added in Mem info table*/
 
@@ -428,6 +444,7 @@ typedef enum {
   MEMORY_TYPE_NORMAL,
   MEMORY_TYPE_RESERVED,
   MEMORY_TYPE_NOT_POPULATED,
+  MEMORY_TYPE_PERSISTENT,
   MEMORY_TYPE_LAST_ENTRY
 }MEM_INFO_TYPE_e;
 

--- a/pal/uefi_dt/bsa/src/pal_iovirt.c
+++ b/pal/uefi_dt/bsa/src/pal_iovirt.c
@@ -80,7 +80,7 @@ dump_block(IOVIRT_BLOCK *block) {
       acs_print(ACS_PRINT_INFO, L"\n");
       return;
       case IOVIRT_NODE_NAMED_COMPONENT:
-      acs_print(ACS_PRINT_INFO, L"\n Named Component:\n Device Name:%a\n", block->data.name);
+      acs_print(ACS_PRINT_INFO, L"\n Named Component:\n Device Name:%a\n", block->data.named_comp.name);
       break;
       case IOVIRT_NODE_PCI_ROOT_COMPLEX:
       acs_print(ACS_PRINT_INFO, L"\n Root Complex:\n PCI segment number:%d\n",
@@ -287,7 +287,7 @@ iort_add_block(IORT_TABLE *iort, IORT_NODE *iort_node, IOVIRT_INFO_TABLE *IoVirt
       count = &IoVirtTable->num_its_groups;
       break;
     case IOVIRT_NODE_NAMED_COMPONENT:
-      AsciiStrnCpyS((CHAR8*)(*data).name, MAX_NAMED_COMP_LENGTH,
+      AsciiStrnCpyS((CHAR8*)(*data).named_comp.name, MAX_NAMED_COMP_LENGTH,
                     (CHAR8*)((IORT_NAMED_COMPONENT*)node_data)->device_name, (MAX_NAMED_COMP_LENGTH -1));
       count = &IoVirtTable->num_named_components;
       break;


### PR DESCRIPTION
- DT pal layer PE and SMMU info table struct were missing some VAL info table members.