### PR TITLE
SMMU test 3 updates for mantis #624

### DIFF
--- a/val/common/include/acs_memory.h
+++ b/val/common/include/acs_memory.h
@@ -36,5 +36,6 @@ void *val_memory_alloc_pages(uint32_t num_pages);
 void val_memory_free_pages(void *page_base, uint32_t num_pages);
 void *val_aligned_alloc(uint32_t alignment, uint32_t size);
 void val_memory_free_aligned(void *addr);
+uint32_t val_memory_region_has_52bit_addr(void);
 
 #endif // __ACS_PERIPHERAL_H__

--- a/val/common/src/acs_memory.c
+++ b/val/common/src/acs_memory.c
@@ -367,8 +367,7 @@ uint32_t val_memory_region_has_52bit_addr(void)
 
   while (g_memory_info_table->info[index].type != MEMORY_TYPE_LAST_ENTRY) {
       val_print(ACS_PRINT_INFO, " \n       Mem Phy Addr %lx",
-		      g_memory_info_table->info[index].phy_addr);
-
+                                   g_memory_info_table->info[index].phy_addr);
       if (CHECK_ADDR_52BIT(g_memory_info_table->info[index].phy_addr))
           return 1;
       index++;

--- a/val/common/src/acs_memory.c
+++ b/val/common/src/acs_memory.c
@@ -27,6 +27,11 @@ MEMORY_INFO_TABLE  *g_memory_info_table;
 
 #define SIZE_4KB   0x00001000
 
+#define ADDR_52BIT_MASK 0xFFFFFFFFFFFFULL
+
+#define CHECK_ADDR_52BIT(addr) (((uint64_t)(addr)) & ~ADDR_52BIT_MASK)
+
+
 #ifdef TARGET_BM_BOOT
 /**
  *   @brief    Add regions assigned to host into its translation table data structure.
@@ -349,4 +354,25 @@ void
 val_memory_free_aligned(void *addr)
 {
   pal_mem_free_aligned(addr);
+}
+
+/**
+ * @brief Checks if uefi memory map has 52 bit addr
+ * @param void
+ * @return 1 52 bit addr present, else 0
+**/
+uint32_t val_memory_region_has_52bit_addr(void)
+{
+  uint32_t index = 0;
+
+  while (g_memory_info_table->info[index].type != MEMORY_TYPE_LAST_ENTRY) {
+      val_print(ACS_PRINT_INFO, " \n       Mem Phy Addr %lx",
+		      g_memory_info_table->info[index].phy_addr);
+
+      if (CHECK_ADDR_52BIT(g_memory_info_table->info[index].phy_addr))
+          return 1;
+      index++;
+  }
+
+  return 0;
 }

--- a/val/common/src/acs_mmu.c
+++ b/val/common/src/acs_mmu.c
@@ -342,3 +342,5 @@ uint32_t val_enable_mmu(void)
     return ACS_STATUS_PASS;
 }
 #endif // TARGET_BM_BOOT
+
+


### PR DESCRIPTION

Fixes #162

  B_SMMU_06 rule is updated to also account for system physical address
 space.If SPAS is 52-bit, then PE and SMMU should also support it.

 There is no architecture method to know if SPAS is 52 bit or not, test
 is **only** checking uefi memory map to know if any address is 52 bit.

 Test updated to
  * PASS : if both PE and SMMU supports 52 bit
  * FAIL : if PE or SMMU not support 52 bit, but uefi mem map has some 52 bit addr mem region

Other cases will be treated as SKIP, and require manual check to verify if system SPAS is 52 bit or not.