### PR TITLE
Remove PASID ECap fail check in e005

### DIFF
--- a/test_pool/exerciser/operating_system/test_os_e005.c
+++ b/test_pool/exerciser/operating_system/test_os_e005.c
@@ -191,8 +191,9 @@ payload(void)
     status = val_pcie_get_max_pasid_width(e_bdf, &exerciser_ssid_bits);
     if (status == PCIE_CAP_NOT_FOUND)
     {
-        val_print(ACS_PRINT_ERR, "\n       PASID extended capability not found for BDF: %x", e_bdf);
-        goto test_fail;
+        val_print(ACS_PRINT_DEBUG,
+                  "\n       PASID extended capability not found for BDF: %x", e_bdf);
+        continue;
     }
     else if (status)
     {


### PR DESCRIPTION
 - If the system doesn't support PASID Extended Cap, don't fail the test.