### PR TITLE
Add support for PCCT based MPAM  MSC

### DIFF
--- a/pal/baremetal/sbsa/include/pal_sbsa_common_support.h
+++ b/pal/baremetal/sbsa/include/pal_sbsa_common_support.h
@@ -291,4 +291,85 @@ typedef struct {
 
 void pal_hmat_create_info_table(HMAT_INFO_TABLE *HmatTable);
 
+/* Platform Communication Channel (PCC) info table */
+typedef struct {
+  uint8_t   addr_space_id;
+  uint8_t   reg_bit_width;
+  uint8_t   reg_bit_offset;
+  uint8_t   access_size;
+  uint64_t  addr;
+} ACPI_GENERIC_ADDRESS_STRUCTURE;
+
+typedef struct {
+  uint64_t                         base_addr;               /* base addr of shared mem-region */
+  ACPI_GENERIC_ADDRESS_STRUCTURE   doorbell_reg;            /* doorbell register */
+  uint64_t                         doorbell_preserve;       /* doorbell register preserve mask */
+  uint64_t                         doorbell_write;          /* doorbell register set mask */
+  uint32_t                         min_req_turnaround_usec; /* minimum request turnaround time */
+  ACPI_GENERIC_ADDRESS_STRUCTURE   cmd_complete_chk_reg;    /* command complete check register */
+  uint64_t                         cmd_complete_chk_mask;   /* command complete check mask */
+  ACPI_GENERIC_ADDRESS_STRUCTURE   cmd_complete_update_reg; /* command complete update register */
+  uint64_t                         cmd_complete_update_preserve;
+                                                            /* command complete update preserve */
+  uint64_t                         cmd_complete_update_set; /* command complete update set mask */
+} PCC_SUBSPACE_TYPE_3;
+
+typedef union {
+  PCC_SUBSPACE_TYPE_3 pcc_ss_type_3;
+} PCC_TYPE_SPECIFIC_INFO;
+
+typedef struct {
+  uint32_t                 subspace_idx;    /* PCC subspace index in PCCT ACPI table */
+  uint32_t                 subspace_type;   /* type of PCC subspace */
+  PCC_TYPE_SPECIFIC_INFO   type_spec_info;  /* PCC subspace type specific info */
+} PCC_INFO;
+
+typedef struct {
+  uint32_t  subspace_cnt; /* number of PCC subspace info stored */
+  PCC_INFO  pcc_info[];   /* array of PCC info blocks */
+} PCC_INFO_TABLE;
+
+
+typedef struct {
+  uint32_t reserved : 4;        /* Bits [31:28] Reserved must be zero */
+  uint32_t token : 10;          /* Bits [27:18] Token Caller-defined value */
+  uint32_t protocol_id : 8;     /* Bits [17:10] Protocol ID */
+  uint32_t message_type : 2;    /* Bits [09:08] Message Type */
+  uint32_t message_id : 8;      /* Bits [07:00] Message ID */
+} SCMI_PROTOCOL_MESSAGE_HEADER;
+
+typedef struct {
+  uint32_t msc_id;            /* Identifier of the MSC */
+  uint32_t flags;             /* Reserved, must be zero */
+  uint32_t offset;            /* MPAM register offset to read from */
+} PCC_MPAM_MSC_READ_CMD_PARA;
+
+typedef struct {
+  int32_t  status;             /* command response status code */
+  uint32_t val;                /* value read from the register */
+} PCC_MPAM_MSC_READ_RESP_PARA;
+
+typedef struct {
+  uint32_t msc_id;            /* Identifier of the MSC */
+  uint32_t flags;             /* Reserved, must be zero */
+  uint32_t val;               /* value to be written to the register */
+  uint32_t offset;            /* MPAM register offset to write */
+} PCC_MPAM_MSC_WRITE_CMD_PARA;
+
+typedef struct {
+  int32_t  status;             /* command response status code */
+} PCC_MPAM_MSC_WRITE_RESP_PARA;
+
+#define MPAM_FB_PROTOCOL_ID    0x1A
+#define MPAM_MSG_TYPE_CMD      0x0
+#define MPAM_MSC_READ_CMD_ID   0x4
+#define MPAM_MSC_WRITE_CMD_ID  0x5
+#define MPAM_PCC_CMD_SUCCESS   0x0
+#define MPAM_PCC_SAFE_RETURN   0x0
+#define RETURN_FAILURE         0xFFFFFFFF
+#define PCC_TY3_CMD_OFFSET     12
+#define PCC_TY3_COMM_SPACE     16
+
+void pal_pcc_create_info_table(PCC_INFO_TABLE *PccInfoTable);
+
 #endif

--- a/pal/baremetal/sbsa/src/pal_sbsa_pcc.c
+++ b/pal/baremetal/sbsa/src/pal_sbsa_pcc.c
@@ -1,0 +1,46 @@
+/** @file
+ * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include "pal_common_support.h"
+#include "pal_sbsa_common_support.h"
+
+static PCC_INFO_TABLE *g_pcc_info_table;
+
+/**
+  @brief  This API initialises the static global pointer to PCC
+          info table.
+
+  @param  PccInfoTable  - Address where the PCC information needs to be filled.
+
+  @return  None
+**/
+void
+pal_pcc_create_info_table(PCC_INFO_TABLE *PccInfoTable)
+{
+
+    /* store address to PCC info table in static global variable */
+    g_pcc_info_table = PccInfoTable;
+
+    /* initialise pcc info count */
+    g_pcc_info_table->subspace_cnt = 0;
+
+    /* this API doesn't parse PCC structure, pal_pcc_store_info API should be
+       called by component (e.g, MPAM) which defines PCC shared memory region, to
+       populate PCC info table  */
+
+    return;
+}

--- a/pal/uefi_acpi/SbsaPalLib.inf
+++ b/pal/uefi_acpi/SbsaPalLib.inf
@@ -47,6 +47,7 @@
   sbsa/src/pal_sbsa_pptt.c
   sbsa/src/pal_sbsa_pmu.c
   sbsa/src/pal_sbsa_exerciser.c
+  sbsa/src/pal_sbsa_pcc.c
 
 [Packages]
   ArmPkg/ArmPkg.dec

--- a/pal/uefi_acpi/SbsaPalNistLib.inf
+++ b/pal/uefi_acpi/SbsaPalNistLib.inf
@@ -47,6 +47,7 @@
   sbsa/src/pal_sbsa_pptt.c
   sbsa/src/pal_sbsa_pmu.c
   sbsa/src/pal_sbsa_exerciser.c
+  sbsa/src/pal_sbsa_pcc.c
   sbsa/src/pal_sbsa_nist.c
 
 [Packages]

--- a/pal/uefi_acpi/sbsa/src/pal_sbsa_mpam.c
+++ b/pal/uefi_acpi/sbsa/src/pal_sbsa_mpam.c
@@ -156,6 +156,13 @@ pal_mpam_create_info_table(MPAM_INFO_TABLE *MpamTable)
       curr_entry->msc_addr_len  =  msc_node->mmio_size;
       curr_entry->max_nrdy = msc_node->max_nrdy_usec;
       curr_entry->rsrc_count = msc_node->num_resource_nodes;
+      curr_entry->intrf_type = msc_node->InterfaceType;
+      curr_entry->identifier = msc_node->identifier;
+
+      /* if MSC interface type is PCC (0x0A), store PCC information in pcc_info_table */
+      if (curr_entry->identifier == MPAM_INTERFACE_TYPE_PCC) {
+          pal_pcc_store_info(curr_entry->msc_base_addr);
+      }
 
       /* Each MSC can have multiple resource node, Populate info table resource
         node from acpi table resource node*/

--- a/pal/uefi_acpi/sbsa/src/pal_sbsa_pcc.c
+++ b/pal/uefi_acpi/sbsa/src/pal_sbsa_pcc.c
@@ -1,0 +1,124 @@
+
+/** @file
+ * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+#include <Library/UefiLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include "Include/IndustryStandard/Acpi65.h"
+
+#include "common/include/pal_uefi.h"
+#include "sbsa/include/pal_sbsa_uefi.h"
+
+#define ADD_PTR(t, p, l) ((t *)((UINT8 *)p + l))
+
+static PCC_INFO_TABLE *g_pcc_info_table;
+
+/**
+  @brief  This API initialises the static global pointer to PCC
+          info table.
+
+  @param  PccInfoTable  - Address where the PCC information needs to be filled.
+
+  @return  None
+**/
+VOID
+pal_pcc_create_info_table(PCC_INFO_TABLE *PccInfoTable)
+{
+
+    /* store address to PCC info table in static global variable */
+    g_pcc_info_table = PccInfoTable;
+
+    /* initialise pcc info count */
+    g_pcc_info_table->subspace_cnt = 0;
+
+    /* this API doesn't parse PCC structure, pal_pcc_store_info API should be
+       called by component (e.g, MPAM) which defines PCC shared memory region, to
+       populate PCC info table  */
+
+    return;
+}
+
+/**
+  @brief  This API parses PCCT ACPI structures and stores info required by
+          ACS in PCC info table.
+
+  @param  subspace_idx  - Subspace id, used to index PCCT array.
+
+  @return  None
+**/
+VOID
+pal_pcc_store_info(UINT32 subspace_idx)
+{
+  EFI_ACPI_6_5_PLATFORM_COMMUNICATION_CHANNEL_TABLE_HEADER *pcct;
+  EFI_ACPI_6_5_PCCT_SUBSPACE_GENERIC *pcct_subspace, *pcct_end;
+  EFI_ACPI_6_5_PCCT_SUBSPACE_3_EXTENDED_PCC *pcct_type_3;
+  PCC_SUBSPACE_TYPE_3 *ptr_to_pcc_ss_type_3;
+
+  UINT32 index = 0;
+
+  /* get pointer to PCCT ACPI table*/
+  pcct = (EFI_ACPI_6_5_PLATFORM_COMMUNICATION_CHANNEL_TABLE_HEADER *)
+          pal_get_acpi_table_ptr(EFI_ACPI_6_5_PLATFORM_COMMUNICATIONS_CHANNEL_TABLE_SIGNATURE);
+
+  /* pointer to start of PCC subspace structure entries */
+  pcct_subspace = ADD_PTR(EFI_ACPI_6_5_PCCT_SUBSPACE_GENERIC, pcct,
+                          sizeof(EFI_ACPI_6_5_PLATFORM_COMMUNICATION_CHANNEL_TABLE_HEADER));
+  pcct_end =  ADD_PTR(EFI_ACPI_6_5_PCCT_SUBSPACE_GENERIC, pcct,
+                          pcct->Header.Length);
+  while (pcct_subspace < pcct_end) {
+    if (index == subspace_idx) {
+        /* this API only supports parsing of type 3 PCC structure info */
+        if (pcct_subspace->Type != EFI_ACPI_6_5_PCCT_SUBSPACE_TYPE_3_EXTENDED_PCC) {
+            acs_print(ACS_PRINT_ERR,
+                      L"\n    pal_pcc_store_info API doesn't support PCC structure type : 0x%x",
+                      pcct_subspace->Type);
+        }
+
+        /* parse PCC structure type 3 */
+        pcct_type_3 = (EFI_ACPI_6_5_PCCT_SUBSPACE_3_EXTENDED_PCC *)pcct_subspace;
+        g_pcc_info_table->pcc_info[g_pcc_info_table->subspace_cnt].subspace_idx  = subspace_idx;
+        g_pcc_info_table->pcc_info[g_pcc_info_table->subspace_cnt].subspace_type
+                                                               = pcct_type_3->Type;
+        ptr_to_pcc_ss_type_3 =
+        &(g_pcc_info_table->pcc_info[g_pcc_info_table->subspace_cnt].type_spec_info.pcc_ss_type_3);
+        ptr_to_pcc_ss_type_3->doorbell_reg
+                    = pcct_type_3->DoorbellRegister;
+        ptr_to_pcc_ss_type_3->cmd_complete_chk_reg
+                    = pcct_type_3->CommandCompleteCheckRegister;
+        ptr_to_pcc_ss_type_3->cmd_complete_update_reg
+                    = pcct_type_3->CommandCompleteUpdateRegister;
+        ptr_to_pcc_ss_type_3->cmd_complete_update_preserve
+                                            =  pcct_type_3->CommandCompleteUpdatePreserve;
+        ptr_to_pcc_ss_type_3->min_req_turnaround_usec
+                                            =  pcct_type_3->MinimumRequestTurnaroundTime;
+        ptr_to_pcc_ss_type_3->base_addr                 =  pcct_type_3->BaseAddress;
+        ptr_to_pcc_ss_type_3->doorbell_preserve         =  pcct_type_3->DoorbellPreserve;
+        ptr_to_pcc_ss_type_3->doorbell_write            =  pcct_type_3->DoorbellWrite;
+        ptr_to_pcc_ss_type_3->cmd_complete_chk_mask     =  pcct_type_3->CommandCompleteCheckMask;
+        ptr_to_pcc_ss_type_3->cmd_complete_update_set   =  pcct_type_3->CommandCompleteUpdateSet;
+        g_pcc_info_table->subspace_cnt++;
+
+        break;
+    }
+    /* point to next PCC subspace entry */
+    pcct_subspace = ADD_PTR(EFI_ACPI_6_5_PCCT_SUBSPACE_GENERIC, pcct_subspace,
+                          pcct_subspace->Length);
+    index++;
+  }
+
+}
+

--- a/val/SbsaValLib.inf
+++ b/val/SbsaValLib.inf
@@ -70,6 +70,7 @@
   sbsa/src/sbsa_acs_pmu.c
   sbsa/src/sbsa_acs_mpam.c
   sbsa/src/sbsa_acs_ete.c
+  sbsa/src/sbsa_acs_pcc.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/val/SbsaValNistLib.inf
+++ b/val/SbsaValNistLib.inf
@@ -70,6 +70,7 @@
   sbsa/src/sbsa_execute_test.c
   sbsa/src/sbsa_acs_pmu.c
   sbsa/src/sbsa_acs_mpam.c
+  sbsa/src/sbsa_acs_pcc.c
   sbsa/src/sbsa_acs_nist.c
 
  [Packages]

--- a/val/sbsa/include/sbsa_acs_mpam.h
+++ b/val/sbsa/include/sbsa_acs_mpam.h
@@ -99,7 +99,12 @@ void val_mpam_csumon_enable(uint32_t msc_index);
 void val_mpam_csumon_disable(uint32_t msc_index);
 uint32_t val_mpam_read_csumon(uint32_t msc_index);
 uint64_t val_srat_get_prox_domain(uint64_t mem_range_index);
-
+uint32_t val_mpam_mmr_read(uint32_t msc_index, uint32_t reg_offset);
+uint64_t val_mpam_mmr_read64(uint32_t msc_index, uint32_t reg_offset);
+void     val_mpam_mmr_write(uint32_t msc_index, uint32_t reg_offset, uint32_t data);
+void     val_mpam_mmr_write64(uint32_t msc_index, uint32_t reg_offset, uint64_t data);
+uint32_t val_mpam_pcc_read(uint32_t msc_index, uint32_t reg_offset);
+void     val_mpam_pcc_write(uint32_t msc_index, uint32_t reg_offset, uint32_t data);
 
 
 uint32_t mpam001_entry(uint32_t num_pe);

--- a/val/sbsa/include/sbsa_pal_interface.h
+++ b/val/sbsa/include/sbsa_pal_interface.h
@@ -208,13 +208,19 @@ typedef struct {
  * @brief MPAM MSC Node
  */
 typedef struct {
-    uint64_t           msc_base_addr; /* base addr of mem-map MSC reg */
-    uint32_t           msc_addr_len;  /*  MSC mem map size */
+    uint8_t            intrf_type;    /* type of interface to this MPAM MSC */
+    uint32_t           identifier;     /* unique id to reference the node */
+    uint64_t           msc_base_addr; /* base addr of mem-mapped reg space or PCC
+                                         subspace ID based on interface type. */
+    uint32_t           msc_addr_len;  /* MSC mem map size */
     uint32_t           max_nrdy;      /* max time in microseconds that MSC not ready
                                          after config change */
     uint32_t           rsrc_count;    /* number of resource nodes */
-    MPAM_RESOURCE_NODE rsrc_node[]; /* Details of resource node */
+    MPAM_RESOURCE_NODE rsrc_node[];   /* Details of resource node */
 } MPAM_MSC_NODE;
+
+#define MPAM_INTERFACE_TYPE_MMIO 0x00
+#define MPAM_INTERFACE_TYPE_PCC  0x0A
 
 /*
  * @brief Mpam info table
@@ -227,6 +233,88 @@ typedef struct {
 void pal_mpam_create_info_table(MPAM_INFO_TABLE *MpamTable);
 void *pal_mem_alloc_at_address(uint64_t mem_base, uint64_t size);
 void pal_mem_free_at_address(uint64_t mem_base, uint64_t size);
+
+/* Platform Communication Channel (PCC) info table */
+typedef struct {
+  uint8_t   addr_space_id;
+  uint8_t   reg_bit_width;
+  uint8_t   reg_bit_offset;
+  uint8_t   access_size;
+  uint64_t  addr;
+} ACPI_GENERIC_ADDRESS_STRUCTURE;
+
+typedef struct {
+  uint64_t                         base_addr;               /* base addr of shared mem-region */
+  ACPI_GENERIC_ADDRESS_STRUCTURE   doorbell_reg;            /* doorbell register */
+  uint64_t                         doorbell_preserve;       /* doorbell register preserve mask */
+  uint64_t                         doorbell_write;          /* doorbell register set mask */
+  uint32_t                         min_req_turnaround_usec; /* minimum request turnaround time */
+  ACPI_GENERIC_ADDRESS_STRUCTURE   cmd_complete_chk_reg;    /* command complete check register */
+  uint64_t                         cmd_complete_chk_mask;   /* command complete check mask */
+  ACPI_GENERIC_ADDRESS_STRUCTURE   cmd_complete_update_reg; /* command complete update register */
+  uint64_t                         cmd_complete_update_preserve;
+                                                            /* command complete update preserve */
+  uint64_t                         cmd_complete_update_set; /* command complete update set mask */
+} PCC_SUBSPACE_TYPE_3;
+
+typedef union {
+  PCC_SUBSPACE_TYPE_3 pcc_ss_type_3;
+} PCC_TYPE_SPECIFIC_INFO;
+
+typedef struct {
+  uint32_t                 subspace_idx;    /* PCC subspace index in PCCT ACPI table */
+  uint32_t                 subspace_type;   /* type of PCC subspace */
+  PCC_TYPE_SPECIFIC_INFO   type_spec_info;  /* PCC subspace type specific info */
+} PCC_INFO;
+
+typedef struct {
+  uint32_t  subspace_cnt; /* number of PCC subspace info stored */
+  PCC_INFO  pcc_info[];   /* array of PCC info blocks */
+} PCC_INFO_TABLE;
+
+
+typedef struct {
+  uint32_t reserved : 4;        /* Bits [31:28] Reserved must be zero */
+  uint32_t token : 10;          /* Bits [27:18] Token Caller-defined value */
+  uint32_t protocol_id : 8;     /* Bits [17:10] Protocol ID */
+  uint32_t message_type : 2;    /* Bits [09:08] Message Type */
+  uint32_t message_id : 8;      /* Bits [07:00] Message ID */
+} SCMI_PROTOCOL_MESSAGE_HEADER;
+
+typedef struct {
+  uint32_t msc_id;            /* Identifier of the MSC */
+  uint32_t flags;             /* Reserved, must be zero */
+  uint32_t offset;            /* MPAM register offset to read from */
+} PCC_MPAM_MSC_READ_CMD_PARA;
+
+typedef struct {
+  int32_t  status;             /* command response status code */
+  uint32_t val;                /* value read from the register */
+} PCC_MPAM_MSC_READ_RESP_PARA;
+
+typedef struct {
+  uint32_t msc_id;            /* Identifier of the MSC */
+  uint32_t flags;             /* Reserved, must be zero */
+  uint32_t val;               /* value to be written to the register */
+  uint32_t offset;            /* MPAM register offset to write */
+} PCC_MPAM_MSC_WRITE_CMD_PARA;
+
+typedef struct {
+  int32_t  status;             /* command response status code */
+} PCC_MPAM_MSC_WRITE_RESP_PARA;
+
+#define MPAM_FB_PROTOCOL_ID    0x1A
+#define MPAM_MSG_TYPE_CMD      0x0
+#define MPAM_MSC_READ_CMD_ID   0x4
+#define MPAM_MSC_WRITE_CMD_ID  0x5
+#define MPAM_PCC_CMD_SUCCESS   0x0
+#define MPAM_PCC_SAFE_RETURN   0x0
+#define RETURN_FAILURE         0xFFFFFFFF
+#define PCC_TY3_CMD_OFFSET     12
+#define PCC_TY3_COMM_SPACE     16
+
+void pal_pcc_create_info_table(PCC_INFO_TABLE *PccInfoTable);
+void pal_pcc_store_info(uint32_t subspace_idx);
 
 /* RAS INFO table */
 

--- a/val/sbsa/include/sbsa_val_interface.h
+++ b/val/sbsa/include/sbsa_val_interface.h
@@ -105,7 +105,9 @@ typedef enum {
   MPAM_MSC_ADDR_LEN,
   MPAM_MSC_RSRC_DESC1,
   MPAM_MSC_RSRC_DESC2,
-  MPAM_MSC_NRDY
+  MPAM_MSC_NRDY,
+  MPAM_MSC_ID,
+  MPAM_MSC_INTERFACE_TYPE
 } MPAM_INFO_e;
 
 /* RAS APIs */
@@ -171,5 +173,11 @@ uint32_t val_sbsa_pmu_execute_tests(uint32_t level, uint32_t num_pe);
 uint32_t val_sbsa_mpam_execute_tests(uint32_t level, uint32_t num_pe);
 uint32_t val_sbsa_ras_execute_tests(uint32_t level, uint32_t num_pe);
 uint32_t val_sbsa_nist_execute_tests(uint32_t level, uint32_t num_pe);
+
+/* PCC related APIs */
+void val_pcc_create_info_table(uint64_t *pcc_info_table);
+void *val_pcc_cmd_response(uint32_t subspace_id, uint32_t command, void *data, uint32_t data_size);
+uint32_t val_pcc_get_ss_info_idx(uint32_t subspace_id);
+void val_pcc_free_info_table(void);
 
 #endif

--- a/val/sbsa/src/sbsa_acs_mpam.c
+++ b/val/sbsa/src/sbsa_acs_mpam.c
@@ -129,6 +129,10 @@ val_mpam_get_info(MPAM_INFO_e type, uint32_t msc_index, uint32_t rsrc_index)
               return msc_entry->msc_addr_len;
           case MPAM_MSC_NRDY:
               return msc_entry->max_nrdy;
+          case MPAM_MSC_ID:
+              return msc_entry->identifier;
+          case MPAM_MSC_INTERFACE_TYPE:
+              return msc_entry->intrf_type;
           default:
               val_print(ACS_PRINT_ERR,
                        "\n   This MPAM info option for type %d is not supported", type);
@@ -273,10 +277,7 @@ val_mpam_get_msc_count(void)
 uint32_t
 val_mpam_msc_get_version(uint32_t msc_index)
 {
-    addr_t base;
-
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
-    return BITFIELD_READ(AIDR_VERSION, val_mmio_read(base + REG_MPAMF_AIDR));
+    return BITFIELD_READ(AIDR_VERSION, val_mpam_mmr_read(msc_index, REG_MPAMF_AIDR));
 }
 
 /**
@@ -287,10 +288,7 @@ val_mpam_msc_get_version(uint32_t msc_index)
 uint32_t
 val_mpam_msc_supports_mon(uint32_t msc_index)
 {
-    addr_t base;
-
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
-    return BITFIELD_READ(IDR_HAS_MSMON, val_mmio_read64(base + REG_MPAMF_IDR));
+    return BITFIELD_READ(IDR_HAS_MSMON, val_mpam_mmr_read64(msc_index, REG_MPAMF_IDR));
 }
 
 /**
@@ -301,10 +299,7 @@ val_mpam_msc_supports_mon(uint32_t msc_index)
 uint32_t
 val_mpam_supports_cpor(uint32_t msc_index)
 {
-    addr_t base;
-
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
-    return BITFIELD_READ(IDR_HAS_CPOR_PART, val_mmio_read64(base + REG_MPAMF_IDR));
+    return BITFIELD_READ(IDR_HAS_CPOR_PART, val_mpam_mmr_read64(msc_index, REG_MPAMF_IDR));
 }
 
 /**
@@ -316,10 +311,7 @@ val_mpam_supports_cpor(uint32_t msc_index)
 uint32_t
 val_mpam_msc_supports_ris(uint32_t msc_index)
 {
-    addr_t base;
-
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
-    return BITFIELD_READ(IDR_HAS_RIS, val_mmio_read64(base + REG_MPAMF_IDR));
+    return BITFIELD_READ(IDR_HAS_RIS, val_mpam_mmr_read64(msc_index, REG_MPAMF_IDR));
 }
 
 /**
@@ -333,11 +325,9 @@ val_mpam_msc_supports_ris(uint32_t msc_index)
 uint32_t
 val_mpam_msc_supports_mbwumon(uint32_t msc_index)
 {
-    addr_t base;
-
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
     if (val_mpam_msc_supports_mon(msc_index))
-        return BITFIELD_READ(MSMON_IDR_MSMON_MBWU, val_mmio_read(base + REG_MPAMF_MSMON_IDR));
+        return BITFIELD_READ(MSMON_IDR_MSMON_MBWU,
+                   val_mpam_mmr_read(msc_index, REG_MPAMF_MSMON_IDR));
     else
         return 0;
 }
@@ -378,10 +368,8 @@ val_mpam_msc_get_mscbw(uint32_t msc_index, uint32_t rsrc_index)
 uint32_t
 val_mpam_mbwu_supports_long(uint32_t msc_index)
 {
-    addr_t base;
-
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
-    return BITFIELD_READ(MBWUMON_IDR_HAS_LONG, val_mmio_read(base + REG_MPAMF_MBWUMON_IDR));
+    return BITFIELD_READ(MBWUMON_IDR_HAS_LONG,
+                val_mpam_mmr_read(msc_index, REG_MPAMF_MBWUMON_IDR));
 }
 
 /**
@@ -392,10 +380,7 @@ val_mpam_mbwu_supports_long(uint32_t msc_index)
 uint32_t
 val_mpam_mbwu_supports_lwd(uint32_t msc_index)
 {
-    addr_t base;
-
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
-    return BITFIELD_READ(MBWUMON_IDR_LWD, val_mmio_read(base + REG_MPAMF_MBWUMON_IDR));
+    return BITFIELD_READ(MBWUMON_IDR_LWD, val_mpam_mmr_read(msc_index, REG_MPAMF_MBWUMON_IDR));
 }
 
 /**
@@ -409,11 +394,9 @@ val_mpam_mbwu_supports_lwd(uint32_t msc_index)
 uint32_t
 val_mpam_supports_csumon(uint32_t msc_index)
 {
-    addr_t base;
-
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
     if (val_mpam_msc_supports_mon(msc_index))
-        return BITFIELD_READ(MSMON_IDR_MSMON_CSU, val_mmio_read(base + REG_MPAMF_MSMON_IDR));
+        return BITFIELD_READ(MSMON_IDR_MSMON_CSU,
+                   val_mpam_mmr_read(msc_index, REG_MPAMF_MSMON_IDR));
     else
         return 0;
 }
@@ -429,10 +412,7 @@ val_mpam_supports_csumon(uint32_t msc_index)
 uint32_t
 val_mpam_get_csumon_count(uint32_t msc_index)
 {
-    addr_t base;
-
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
-    return BITFIELD_READ(CSUMON_IDR_NUM_MON, val_mmio_read(base + REG_MPAMF_CSUMON_IDR));
+    return BITFIELD_READ(CSUMON_IDR_NUM_MON, val_mpam_mmr_read(msc_index, REG_MPAMF_CSUMON_IDR));
 }
 
 /**
@@ -448,23 +428,21 @@ val_mpam_get_csumon_count(uint32_t msc_index)
 void
 val_mpam_memory_configure_ris_sel(uint32_t msc_index, uint32_t rsrc_index)
 {
-    addr_t base;
     uint32_t data;
     uint8_t ris_index;
 
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
     ris_index = val_mpam_get_info(MPAM_MSC_RSRC_RIS, msc_index, rsrc_index);
 
     /*configure MSMON_CFG_MON_SEL.RIS field and write MSMON_CFG_MON_SEL.MON_SEL
        field to be 0 */
     data = BITFIELD_SET(MON_SEL_RIS, ris_index);
-    val_mmio_write(base + REG_MSMON_CFG_MON_SEL, data);
+    val_mpam_mmr_write(msc_index, REG_MSMON_CFG_MON_SEL, data);
 
     /* configure MPAMCFG_PART_SEL.RIS field and write MPAMCFG_PART_SEL.
        PARTID_SEL field to DEFAULT PARTID*/
     data = BITFIELD_SET(PART_SEL_RIS, ris_index)
                            | BITFIELD_SET(PART_SEL_PARTID_SEL, DEFAULT_PARTID);
-    val_mmio_write(base + REG_MPAMCFG_PART_SEL, data);
+    val_mpam_mmr_write(msc_index, REG_MPAMCFG_PART_SEL, data);
 }
 
 /**
@@ -482,26 +460,23 @@ void
 val_mpam_memory_configure_mbwumon(uint32_t msc_index)
 {
     uint32_t data = 0;
-    addr_t base;
-
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
 
     /* select monitor instance zero by writing zero to MSMON_CFG_MON_SEL.MON_SEL */
-    data = val_mmio_read(base + REG_MSMON_CFG_MON_SEL);
+    data = val_mpam_mmr_read(msc_index, REG_MSMON_CFG_MON_SEL);
     /* retaining other configured fields e.g, RIS index if supported */
     data = BITFIELD_WRITE(data, MON_SEL_MON_SEL, 0);
-    val_mmio_write(base + REG_MSMON_CFG_MON_SEL, data);
+    val_mpam_mmr_write(msc_index, REG_MSMON_CFG_MON_SEL, data);
 
     /* disable monitor instance before configuration */
     val_mpam_memory_mbwumon_disable(msc_index);
 
     /* configure monitor ctrl reg for default partid and default pmg */
     data = BITFIELD_SET(MBWU_CTL_MATCH_PARTID, 1) | BITFIELD_SET(MBWU_CTL_MATCH_PMG, 1);
-    val_mmio_write(base + REG_MSMON_CFG_MBWU_CTL, data);
+    val_mpam_mmr_write(msc_index, REG_MSMON_CFG_MBWU_CTL, data);
 
     /* configure monitor filter reg for default partid and default pmg */
     data = BITFIELD_SET(MBWU_FLT_PARTID, DEFAULT_PARTID) | BITFIELD_SET(MBWU_FLT_PMG, DEFAULT_PMG);
-    val_mmio_write(base + REG_MSMON_CFG_MBWU_FLT, data);
+    val_mpam_mmr_write(msc_index, REG_MSMON_CFG_MBWU_FLT, data);
 
     /* reset the MBWU monitor count */
     val_mpam_memory_mbwumon_reset(msc_index);
@@ -520,11 +495,8 @@ val_mpam_memory_configure_mbwumon(uint32_t msc_index)
 void
 val_mpam_memory_mbwumon_enable(uint32_t msc_index)
 {
-    addr_t base;
-
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
     /* enable the monitor instance to collect information according to the configuration */
-    val_mmio_write(base + REG_MSMON_CFG_MBWU_CTL, BITFIELD_SET(MBWU_CTL_EN, 1));
+    val_mpam_mmr_write(msc_index, REG_MSMON_CFG_MBWU_CTL, BITFIELD_SET(MBWU_CTL_EN, 1));
 }
 
 /**
@@ -540,11 +512,8 @@ val_mpam_memory_mbwumon_enable(uint32_t msc_index)
 void
 val_mpam_memory_mbwumon_disable(uint32_t msc_index)
 {
-    addr_t base;
-
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
     /* disable the monitor */
-    val_mmio_write(base + REG_MSMON_CFG_MBWU_CTL, BITFIELD_SET(MBWU_CTL_EN, 0));
+    val_mpam_mmr_write(msc_index, REG_MSMON_CFG_MBWU_CTL, BITFIELD_SET(MBWU_CTL_EN, 0));
 }
 
 /**
@@ -559,34 +528,34 @@ val_mpam_memory_mbwumon_disable(uint32_t msc_index)
 uint64_t
 val_mpam_memory_mbwumon_read_count(uint32_t msc_index)
 {
-    addr_t base;
     uint64_t count = MPAM_MON_NOT_READY;
 
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
-
     /*if MSMON_MBWU_L is implemented*/
-    if (BITFIELD_READ(MBWUMON_IDR_LWD, val_mmio_read64(base + REG_MPAMF_MBWUMON_IDR))) {
-        if (BITFIELD_READ(MBWUMON_IDR_HAS_LONG, val_mmio_read64(base + REG_MPAMF_MBWUMON_IDR))) {
+    if (BITFIELD_READ(MBWUMON_IDR_LWD, val_mpam_mmr_read64(msc_index, REG_MPAMF_MBWUMON_IDR))) {
+        if (BITFIELD_READ(MBWUMON_IDR_HAS_LONG,
+            val_mpam_mmr_read64(msc_index, REG_MPAMF_MBWUMON_IDR))) {
             // (63 bits)
-            if (BITFIELD_READ(MSMON_MBWU_L_NRDY, val_mmio_read64(base + REG_MSMON_MBWU_L)) == 0)
+            if (BITFIELD_READ(MSMON_MBWU_L_NRDY,
+                val_mpam_mmr_read64(msc_index, REG_MSMON_MBWU_L)) == 0)
                 count = BITFIELD_READ(MSMON_MBWU_L_63BIT_VALUE,
-                                      val_mmio_read64(base + REG_MSMON_MBWU_L));
+                                      val_mpam_mmr_read64(msc_index, REG_MSMON_MBWU_L));
         }
         else {
             // (44 bits)
-            if (BITFIELD_READ(MSMON_MBWU_L_NRDY, val_mmio_read64(base + REG_MSMON_MBWU_L)) == 0)
+            if (BITFIELD_READ(MSMON_MBWU_L_NRDY,
+                val_mpam_mmr_read64(msc_index, REG_MSMON_MBWU_L)) == 0)
                 count = BITFIELD_READ(MSMON_MBWU_L_44BIT_VALUE,
-                                      val_mmio_read64(base + REG_MSMON_MBWU_L));
+                                      val_mpam_mmr_read64(msc_index, REG_MSMON_MBWU_L));
         }
     }
     else {
         // (31 bits)
-        if (BITFIELD_READ(MSMON_MBWU_NRDY, val_mmio_read(base + REG_MSMON_MBWU)) == 0) {
+        if (BITFIELD_READ(MSMON_MBWU_NRDY, val_mpam_mmr_read(msc_index, REG_MSMON_MBWU)) == 0) {
             count = BITFIELD_READ(MSMON_MBWU_VALUE,
-                                  val_mmio_read(base + REG_MSMON_MBWU));
+                                  val_mpam_mmr_read(msc_index, REG_MSMON_MBWU));
             /* shift the count if scaling is enabled */
             count = count << BITFIELD_READ(MBWUMON_IDR_SCALE,
-                                  val_mmio_read(base + REG_MPAMF_MBWUMON_IDR));
+                                  val_mpam_mmr_read(msc_index, REG_MPAMF_MBWUMON_IDR));
         }
     }
     return(count);
@@ -603,15 +572,11 @@ val_mpam_memory_mbwumon_read_count(uint32_t msc_index)
 void
 val_mpam_memory_mbwumon_reset(uint32_t msc_index)
 {
-    addr_t base;
-
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
-
     /*if MSMON_MBWU_L is implemented*/
-    if (BITFIELD_READ(MBWUMON_IDR_LWD, val_mmio_read64(base + REG_MPAMF_MBWUMON_IDR)))
-        val_mmio_write64(base + REG_MSMON_MBWU_L, 0);
+    if (BITFIELD_READ(MBWUMON_IDR_LWD, val_mpam_mmr_read64(msc_index, REG_MPAMF_MBWUMON_IDR)))
+        val_mpam_mmr_write64(msc_index, REG_MSMON_MBWU_L, 0);
     else
-       val_mmio_write(base + REG_MSMON_MBWU, 0);
+       val_mpam_mmr_write(msc_index, REG_MSMON_MBWU, 0);
 }
 
 
@@ -800,10 +765,7 @@ val_srat_free_info_table(void)
 uint32_t
 val_mpam_get_max_pmg(uint32_t msc_index)
 {
-    addr_t base;
-
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
-    return BITFIELD_READ(IDR_PMG_MAX, val_mmio_read64(base + REG_MPAMF_IDR));
+    return BITFIELD_READ(IDR_PMG_MAX, val_mpam_mmr_read64(msc_index, REG_MPAMF_IDR));
 }
 
 /**
@@ -814,10 +776,7 @@ val_mpam_get_max_pmg(uint32_t msc_index)
 uint32_t
 val_mpam_get_max_partid(uint32_t msc_index)
 {
-    addr_t base;
-
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
-    return BITFIELD_READ(IDR_PARTID_MAX, val_mmio_read64(base + REG_MPAMF_IDR));
+    return BITFIELD_READ(IDR_PARTID_MAX, val_mpam_mmr_read64(msc_index, REG_MPAMF_IDR));
 }
 
 /**
@@ -835,24 +794,21 @@ val_mpam_get_max_partid(uint32_t msc_index)
 void
 val_mpam_configure_cpor(uint32_t msc_index, uint16_t partid, uint32_t cpbm_percentage)
 {
-    addr_t base;
     uint16_t index;
     uint32_t unset_bitmask;
     uint32_t num_unset_bits;
     uint16_t num_cpbm_bits;
     uint32_t data;
 
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
-
     /* Get CPBM width */
     num_cpbm_bits = val_mpam_get_cpbm_width(msc_index);
 
     /* retaining other configured fields e.g, RIS index if supported */
-    data = val_mmio_read(base + REG_MPAMCFG_PART_SEL);
+    data = val_mpam_mmr_read(msc_index, REG_MPAMCFG_PART_SEL);
 
     /* Select PARTID */
     data = BITFIELD_WRITE(data, PART_SEL_PARTID_SEL, partid);
-    val_mmio_write(base + REG_MPAMCFG_PART_SEL, partid);
+    val_mpam_mmr_write(msc_index, REG_MPAMCFG_PART_SEL, partid);
 
     /*
      * Configure CPBM register to have a 1 in cpbm_percentage
@@ -860,13 +816,13 @@ val_mpam_configure_cpor(uint32_t msc_index, uint16_t partid, uint32_t cpbm_perce
      */
     num_cpbm_bits = (num_cpbm_bits * cpbm_percentage) / 100 ;
     for (index = 0; index < num_cpbm_bits - 31; index += 32)
-        val_mmio_write(base + REG_MPAMCFG_CPBM + index, CPOR_BITMAP_DEF_VAL);
+        val_mpam_mmr_write(msc_index, REG_MPAMCFG_CPBM + index, CPOR_BITMAP_DEF_VAL);
 
     /* Unset bits from above step are set */
     num_unset_bits = num_cpbm_bits - index;
     unset_bitmask = (1 << num_unset_bits) - 1;
     if (unset_bitmask)
-        val_mmio_write(base + REG_MPAMCFG_CPBM + index, unset_bitmask);
+        val_mpam_mmr_write(msc_index, REG_MPAMCFG_CPBM + index, unset_bitmask);
 
     /* Issue a DSB instruction */
     val_mem_issue_dsb();
@@ -882,11 +838,8 @@ val_mpam_configure_cpor(uint32_t msc_index, uint16_t partid, uint32_t cpbm_perce
 uint32_t
 val_mpam_get_cpbm_width(uint32_t msc_index)
 {
-    addr_t base;
-
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
     if (val_mpam_supports_cpor(msc_index))
-        return BITFIELD_READ(CPOR_IDR_CPBM_WD, val_mmio_read(base + REG_MPAMF_CPOR_IDR));
+        return BITFIELD_READ(CPOR_IDR_CPBM_WD, val_mpam_mmr_read(msc_index, REG_MPAMF_CPOR_IDR));
     else
         return 0;
 }
@@ -916,27 +869,24 @@ val_mem_issue_dsb(void)
 void
 val_mpam_configure_csu_mon(uint32_t msc_index, uint16_t partid, uint8_t pmg, uint16_t mon_sel)
 {
-    addr_t base;
     uint32_t data;
 
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
-
     /* retaining other configured fields e.g, RIS index if supported */
-    data = val_mmio_read(base + REG_MSMON_CFG_MON_SEL);
+    data = val_mpam_mmr_read(msc_index, REG_MSMON_CFG_MON_SEL);
     /* Select the monitor instance */
     data = BITFIELD_WRITE(data, MON_SEL_MON_SEL, mon_sel);
-    val_mmio_write(base + REG_MSMON_CFG_MON_SEL, data);
+    val_mpam_mmr_write(msc_index, REG_MSMON_CFG_MON_SEL, data);
 
     /* Configure the CSU monitor filter register for input PARTID & PMG */
     data = BITFIELD_SET(CSU_FLT_PARTID, partid) | BITFIELD_SET(CSU_FLT_PMG, pmg);
-    val_mmio_write(base + REG_MSMON_CFG_CSU_FLT, data);
+    val_mpam_mmr_write(msc_index, REG_MSMON_CFG_CSU_FLT, data);
 
     /*Disable the monitor */
     val_mpam_csumon_disable(msc_index);
 
     /* Configure the CSU monitor control register to match input PARTID & PMG */
     data = BITFIELD_SET(CSU_CTL_MATCH_PARTID, 1) | BITFIELD_SET(CSU_CTL_MATCH_PMG, 1);
-    val_mmio_write(base + REG_MSMON_CFG_CSU_CTL, data);
+    val_mpam_mmr_write(msc_index, REG_MSMON_CFG_CSU_CTL, data);
 
     /* Issue a DSB instruction */
     val_mem_issue_dsb();
@@ -957,13 +907,11 @@ val_mpam_configure_csu_mon(uint32_t msc_index, uint16_t partid, uint8_t pmg, uin
 void
 val_mpam_csumon_enable(uint32_t msc_index)
 {
-    addr_t base;
     uint32_t data;
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
 
     /* enable the monitor instance to collect information according to the configuration */
-    data = BITFIELD_WRITE(val_mmio_read(base + REG_MSMON_CFG_CSU_CTL), CSU_CTL_EN, 1);
-    val_mmio_write(base + REG_MSMON_CFG_CSU_CTL, data);
+    data = BITFIELD_WRITE(val_mpam_mmr_read(msc_index, REG_MSMON_CFG_CSU_CTL), CSU_CTL_EN, 1);
+    val_mpam_mmr_write(msc_index, REG_MSMON_CFG_CSU_CTL, data);
 }
 
 /**
@@ -980,13 +928,11 @@ val_mpam_csumon_enable(uint32_t msc_index)
 void
 val_mpam_csumon_disable(uint32_t msc_index)
 {
-    addr_t base;
     uint32_t data;
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
 
     /* enable the monitor instance to collect information according to the configuration */
-    data = BITFIELD_WRITE(val_mmio_read(base + REG_MSMON_CFG_CSU_CTL), CSU_CTL_EN, 0);
-    val_mmio_write(base + REG_MSMON_CFG_CSU_CTL, data);
+    data = BITFIELD_WRITE(val_mpam_mmr_read(msc_index, REG_MSMON_CFG_CSU_CTL), CSU_CTL_EN, 0);
+    val_mpam_mmr_write(msc_index, REG_MSMON_CFG_CSU_CTL, data);
 }
 
 /**
@@ -1001,14 +947,232 @@ val_mpam_csumon_disable(uint32_t msc_index)
 uint32_t
 val_mpam_read_csumon(uint32_t msc_index)
 {
-    addr_t base;
     uint32_t count;
 
-    base = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
-    if (BITFIELD_READ(MSMON_CSU_NRDY, val_mmio_read(base + REG_MSMON_CSU)) == 0) {
+    if (BITFIELD_READ(MSMON_CSU_NRDY, val_mpam_mmr_read(msc_index, REG_MSMON_CSU)) == 0) {
         count = BITFIELD_READ(MSMON_CSU_VALUE,
-                                      val_mmio_read(base + REG_MSMON_CSU));
+                                      val_mpam_mmr_read(msc_index, REG_MSMON_CSU));
         return count;
     }
     return 0;
+}
+
+/**
+  @brief   This API reads 32bit MPAM memory mapped register either
+           via MMIO or PCC interface.
+
+  @param   msc_index  - MPAM feature page index for this MSC.
+  @param   reg_offset - Register offset address.
+
+  @return  Read 32 bit value.
+**/
+uint32_t
+val_mpam_mmr_read(uint32_t msc_index, uint32_t reg_offset)
+{
+  uint64_t base_addr;
+  uint32_t intrf_type;
+
+  base_addr  = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
+  intrf_type = val_mpam_get_info(MPAM_MSC_INTERFACE_TYPE, msc_index, 0);
+
+  if (intrf_type == MPAM_INTERFACE_TYPE_MMIO) {
+      return val_mmio_read(base_addr + reg_offset);
+  } else if (intrf_type == MPAM_INTERFACE_TYPE_PCC) {
+      return val_mpam_pcc_read(msc_index, reg_offset);
+  } else {
+    val_print(ACS_PRINT_ERR,
+              "\n    Invalid interface type reported for MPAM MSC index = %x", msc_index);
+    return 0;  /* zero considered as safe return */
+    }
+}
+
+/**
+  @brief   This API reads 64bit MPAM memory mapped register either
+           via MMIO or PCC interface.
+
+  @param   msc_index  - MPAM feature page index for this MSC.
+  @param   reg_offset - Register offset address.
+
+  @return  Read 64 bit value.
+**/
+uint64_t
+val_mpam_mmr_read64(uint32_t msc_index, uint32_t reg_offset)
+{
+  uint64_t base_addr;
+  uint32_t intrf_type;
+
+  base_addr  = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
+  intrf_type = val_mpam_get_info(MPAM_MSC_INTERFACE_TYPE, msc_index, 0);
+
+  if (intrf_type == MPAM_INTERFACE_TYPE_MMIO) {
+      return val_mmio_read64(base_addr + reg_offset);
+  } else if (intrf_type == MPAM_INTERFACE_TYPE_PCC) {
+      /* PCC supports only supports 32 bit read at a time, hence reading twice
+         and concating */
+      return ((uint64_t)val_mpam_pcc_read(msc_index, reg_offset + 4) << 32)
+                                | val_mpam_pcc_read(msc_index, reg_offset);
+  } else {
+    val_print(ACS_PRINT_ERR,
+              "\n    Invalid interface type reported for MPAM MSC index = %x", msc_index);
+    return 0;  /* zero considered as safe return */
+  }
+}
+
+/**
+  @brief   This API writes 32bit MPAM memory mapped register either
+           via MMIO or PCC interface.
+
+  @param   msc_index  - MPAM feature page index for this MSC.
+  @param   reg_offset - Register offset address.
+  @param   data       - Data to be written to register.
+
+  @return  None
+**/
+void
+val_mpam_mmr_write(uint32_t msc_index, uint32_t reg_offset, uint32_t data)
+{
+  uint64_t base_addr;
+  uint32_t intrf_type;
+
+  base_addr  = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
+  intrf_type = val_mpam_get_info(MPAM_MSC_INTERFACE_TYPE, msc_index, 0);
+
+  if (intrf_type == MPAM_INTERFACE_TYPE_MMIO) {
+      val_mmio_write(base_addr + reg_offset, data);
+  } else if (intrf_type == MPAM_INTERFACE_TYPE_PCC) {
+      val_mpam_pcc_write(msc_index, reg_offset, data);
+  } else {
+    val_print(ACS_PRINT_ERR,
+              "\n    Invalid interface type reported for MPAM MSC index = %x", msc_index);
+  }
+}
+
+/**
+  @brief   This API writes 64bit MPAM memory mapped register either
+           via MMIO or PCC interface.
+
+  @param   msc_index  - MPAM feature page index for this MSC.
+  @param   reg_offset - Register offset address.
+  @param   data       - Data to be written to register.
+
+  @return  None
+**/
+void
+val_mpam_mmr_write64(uint32_t msc_index, uint32_t reg_offset, uint64_t data)
+{
+  uint64_t base_addr;
+  uint32_t intrf_type;
+
+  base_addr  = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
+  intrf_type = val_mpam_get_info(MPAM_MSC_INTERFACE_TYPE, msc_index, 0);
+
+  if (intrf_type == MPAM_INTERFACE_TYPE_MMIO) {
+      val_mmio_write64(base_addr + reg_offset, data);
+  } else if (intrf_type == MPAM_INTERFACE_TYPE_PCC) {
+      val_mpam_pcc_write(msc_index, reg_offset, (uint32_t)(data & 0xFFFFFFFF));
+      val_mpam_pcc_write(msc_index, reg_offset + 4, (uint32_t)(data >> 32));
+  } else {
+    val_print(ACS_PRINT_ERR,
+              "\n    Invalid interface type reported for MPAM MSC index = %x", msc_index);
+  }
+}
+
+/**
+  @brief   This API constructs header and parameter for the
+           MPAM_MSC_READ PCC command and calls doorbell protocol.
+
+  @param   msc_index  - MPAM feature page index for this MSC.
+  @param   reg_offset - Register offset address.
+
+  @return  None
+**/
+uint32_t
+val_mpam_pcc_read(uint32_t msc_index, uint32_t reg_offset)
+{
+  SCMI_PROTOCOL_MESSAGE_HEADER header;
+  PCC_MPAM_MSC_READ_CMD_PARA parameter;
+  PCC_MPAM_MSC_READ_RESP_PARA *response;
+  uint32_t subspace_id;
+
+  /* if MSC interface type is PCC (0x0A), the Base address field
+     captures index to PCCT ACPI structure */
+  subspace_id = (uint32_t)val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
+
+  /* construct the message header */
+  header.reserved = 0;
+  header.protocol_id = MPAM_FB_PROTOCOL_ID;
+  header.message_type = MPAM_MSG_TYPE_CMD;
+  header.message_id = MPAM_MSC_READ_CMD_ID;
+  /* token is user defined value for book keeping */
+  header.token = 1;
+
+  /* construct parameter payload */
+  parameter.msc_id = val_mpam_get_info(MPAM_MSC_ID, msc_index, 0);
+  parameter.flags = 0;
+  parameter.offset = reg_offset;
+
+  response = (PCC_MPAM_MSC_READ_RESP_PARA *) val_pcc_cmd_response(
+              (uint32_t)subspace_id, *(uint32_t *)&header, (void *)&parameter, sizeof(parameter));
+
+  if (response == NULL || response->status != MPAM_PCC_CMD_SUCCESS) {
+      val_print(ACS_PRINT_ERR,
+                "\n    Failed to read MPAM register with offset (0x%x) via PCC", reg_offset);
+      val_print(ACS_PRINT_ERR, " for MSC index = 0x%x", msc_index);
+      if (response != NULL) {
+          val_print(ACS_PRINT_ERR, "\n    PCC command response code = 0x%x", response->status);
+      }
+      return MPAM_PCC_SAFE_RETURN;
+  } else {
+      return response->val;
+  }
+}
+
+/**
+  @brief   This API constructs header and parameter for the
+           MPAM_MSC_WRITE PCC command and calls doorbell protocol.
+
+  @param   msc_index  - MPAM feature page index for this MSC.
+  @param   reg_offset - Register offset address.
+
+  @return  None
+**/
+void
+val_mpam_pcc_write(uint32_t msc_index, uint32_t reg_offset, uint32_t data)
+{
+  SCMI_PROTOCOL_MESSAGE_HEADER header;
+  PCC_MPAM_MSC_WRITE_CMD_PARA parameter;
+  PCC_MPAM_MSC_WRITE_RESP_PARA *response;
+  uint32_t subspace_id;
+
+  /* if MSC interface type is PCC (0x0A), the Base address field
+     captures index to PCCT ACPI structure */
+  subspace_id = val_mpam_get_info(MPAM_MSC_BASE_ADDR, msc_index, 0);
+
+  /* construct the message header */
+  header.reserved = 0;
+  header.protocol_id = MPAM_FB_PROTOCOL_ID;
+  header.message_type = MPAM_MSG_TYPE_CMD;
+  header.message_id = MPAM_MSC_WRITE_CMD_ID;
+  /* token is user defined value for book keeping */
+  header.token = 1;
+
+  /* construct parameter payload */
+  parameter.msc_id = val_mpam_get_info(MPAM_MSC_ID, msc_index, 0);
+  parameter.flags = 0;
+  parameter.val = data;
+  parameter.offset = reg_offset;
+
+  response = (PCC_MPAM_MSC_WRITE_RESP_PARA *) val_pcc_cmd_response(
+              (uint32_t)subspace_id, *(uint32_t *)&header, (void *)&parameter, sizeof(parameter));
+
+  if (response == NULL || response->status != MPAM_PCC_CMD_SUCCESS) {
+      val_print(ACS_PRINT_ERR,
+                "\n    Failed to read MPAM register with offset (0x%x) via PCC", reg_offset);
+      val_print(ACS_PRINT_ERR, " for MSC index = 0x%x", msc_index);
+      if (response != NULL) {
+          val_print(ACS_PRINT_ERR, "\n    PCC command response code = 0x%x", response->status);
+      }
+      return;
+  }
+  return;
 }

--- a/val/sbsa/src/sbsa_acs_pcc.c
+++ b/val/sbsa/src/sbsa_acs_pcc.c
@@ -1,0 +1,189 @@
+/** @file
+ * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+/* This file contains APIs used by other SBSA modules/components */
+
+#include "common/include/acs_val.h"
+#include "common/include/acs_common.h"
+#include "sbsa/include/sbsa_val_interface.h"
+
+static PCC_INFO_TABLE *g_pcc_info_table;
+
+/* PCCT related APIs */
+
+/**
+  @brief   This API will call PAL layer to initialise PCC table information
+           into the g_pcc_info_table pointer.
+           1. Caller       -  Application layer.
+           2. Prerequisite -  Memory allocated and passed as argument.
+  @param   pcc_info_table  pre-allocated memory pointer for pcc info.
+  @return  None
+**/
+void
+val_pcc_create_info_table(uint64_t *pcc_info_table)
+{
+    /* store pointer to pcc info table */
+    g_pcc_info_table = (PCC_INFO_TABLE *)pcc_info_table;
+
+    pal_pcc_create_info_table(g_pcc_info_table);
+
+    return;
+}
+
+/**
+  @brief  This API return index to PCC info block in PCC info table for
+          corresponding subspace id input.
+
+  @param  subspace_idx  - Subspace id, used to index PCCT array.
+
+  @return  index of the pcc info.
+**/
+uint32_t
+val_pcc_get_ss_info_idx(uint32_t subspace_id)
+{
+
+  PCC_INFO *entry;
+  uint32_t i;
+
+  entry = g_pcc_info_table->pcc_info;
+
+  for (i = 0; i < g_pcc_info_table->subspace_cnt; i++) {
+      if (entry->subspace_idx == subspace_id) {
+          return i;
+      }
+      entry++;
+  }
+
+  return RETURN_FAILURE;
+}
+
+/**
+  @brief  This API implements ACPI Doorbell protocol.
+
+  @param  subspace_idx  - Subspace id, used to index PCCT array.
+  @param  command       - PCC command header
+  @param  data          - pointer to data to be written to communication
+                          subspace.
+  @param  data_size     - size of data to be written to subspace
+
+  @return pointer to communication subspace with response.
+**/
+void
+*val_pcc_cmd_response(uint32_t subspace_id, uint32_t command, void *data, uint32_t data_size)
+{
+
+  uint32_t pcc_idx;
+  uint32_t loop_cnt;
+  uint32_t cmd_complete;
+  uint64_t shared_mem_addr;
+  uint64_t cmd_complete_upd_reg;
+  uint64_t doorbell_val;
+  PCC_SUBSPACE_TYPE_3 *ptr_to_pcc_ss_type_3;
+
+
+  /* get pcc info block index */
+  pcc_idx = val_pcc_get_ss_info_idx(subspace_id);
+
+  /* return if failed to get index */
+  if (pcc_idx == RETURN_FAILURE) {
+      return NULL;
+  }
+
+  /* pointer to PCC info */
+  ptr_to_pcc_ss_type_3 = &(g_pcc_info_table->pcc_info[pcc_idx].type_spec_info.pcc_ss_type_3);
+
+  /* Note : For information on Doorbell Protocol refer ACPI 6.5 specification; section 14.5 */
+
+  /* ensuring command complete check is set, indicating shared memory
+     exclusively owned by OSPM */
+  loop_cnt = 3;
+  do {
+      /* wait for minimum request turnaround time * 3 to provide time for platform */
+      val_time_delay_ms(ptr_to_pcc_ss_type_3->min_req_turnaround_usec);
+      /* read command complete check register */
+      cmd_complete = val_mmio_read(ptr_to_pcc_ss_type_3->cmd_complete_chk_reg.addr) &
+                                ptr_to_pcc_ss_type_3->cmd_complete_chk_mask;
+      loop_cnt--;
+  } while (cmd_complete == 0 || loop_cnt != 0);
+
+  /* if platform not setting complete, return with failure */
+  if (loop_cnt == 0) {
+      val_print(ACS_PRINT_ERR,
+                "\n    Platform fails to set command complete reg for PCC subspace id : 0x%x",
+                subspace_id);
+      return NULL;
+  }
+
+  /* write command and parameters to PCC shared memory region */
+  shared_mem_addr = ptr_to_pcc_ss_type_3->base_addr;
+  /* write command */
+  val_mmio_write(shared_mem_addr + PCC_TY3_CMD_OFFSET, command);
+  /* write parameters */
+  val_memcpy((void *)(shared_mem_addr + PCC_TY3_COMM_SPACE), data, data_size);
+
+  /* clear command complete indicating platform to process the command
+     using command complete update register */
+  cmd_complete_upd_reg = val_mmio_read(ptr_to_pcc_ss_type_3->cmd_complete_update_reg.addr);
+  /* modify data as specified in doorbell protocol */
+  cmd_complete_upd_reg =
+                        (cmd_complete_upd_reg & ptr_to_pcc_ss_type_3->cmd_complete_update_preserve)
+                        | ptr_to_pcc_ss_type_3->cmd_complete_update_set;
+  /* write command complete update register to clear the complete bit */
+  val_mmio_write(ptr_to_pcc_ss_type_3->cmd_complete_update_reg.addr, cmd_complete_upd_reg);
+
+  /* ring doorbell by performing read/modify/write cycle */
+  doorbell_val = val_mmio_read(ptr_to_pcc_ss_type_3->doorbell_reg.addr);
+  doorbell_val = (doorbell_val & ptr_to_pcc_ss_type_3->doorbell_preserve)
+                    | ptr_to_pcc_ss_type_3->doorbell_write;
+  val_mmio_write(ptr_to_pcc_ss_type_3->doorbell_reg.addr, doorbell_val);
+
+  /* wait for minimum request turnaround time and poll on the command complete bit for set */
+  loop_cnt = 3;
+  do {
+      /* wait for minimum request turnaround time * 3 to provide time for platform */
+      val_time_delay_ms(ptr_to_pcc_ss_type_3->min_req_turnaround_usec);
+      /* read command complete check register */
+      cmd_complete = val_mmio_read(ptr_to_pcc_ss_type_3->cmd_complete_chk_reg.addr) &
+                                ptr_to_pcc_ss_type_3->cmd_complete_chk_mask;
+      loop_cnt--;
+  } while (cmd_complete == 0 || loop_cnt != 0);
+
+  /* if platform not setting complete, return with failure */
+  if (loop_cnt == 0) {
+      val_print(ACS_PRINT_ERR,
+          "\n    Platform fails to set command complete, post command for PCC subspace id : 0x%x",
+          subspace_id);
+      return NULL;
+  }
+
+  /* process response from platform */
+  /* return pointer to communication subspace with response data */
+  return (void *)(shared_mem_addr + PCC_TY3_COMM_SPACE);
+}
+
+/**
+  @brief  Free the memory allocated for the pcc_info_table
+
+  @param  None
+
+  @return None
+**/
+void
+val_pcc_free_info_table(void)
+{
+  pal_mem_free((void *)g_pcc_info_table);
+}


### PR DESCRIPTION
- parsing PCCT structure on demand basis.
- implemented doorbell protocol to do PCC transactions.
- MPAM mem-map register API modified to support both mmio and PCC MSC interfaces

Fixes: https://github.com/ARM-software/sbsa-acs/issues/454
