### PR TITLE
Update test_os_u005.c

### DIFF
--- a/test_pool/power_wakeup/operating_system/test_os_u005.c
+++ b/test_pool/power_wakeup/operating_system/test_os_u005.c
@@ -149,6 +149,7 @@ payload5()
 	      val_gic_clear_interrupt(intid);
               val_set_status(index, RESULT_SKIP(TEST_NUM, 4));
               val_print(ACS_PRINT_DEBUG, "\n       PE wakeup by some other events/int or didn't enter WFI", 0);
+	      return;
           }
           val_print(ACS_PRINT_INFO, "\n       delay loop remainig value %d", delay_loop);
 

--- a/test_pool/power_wakeup/operating_system/test_os_u005.c
+++ b/test_pool/power_wakeup/operating_system/test_os_u005.c
@@ -149,9 +149,9 @@ payload5()
 	      val_gic_clear_interrupt(intid);
               val_set_status(index, RESULT_SKIP(TEST_NUM, 4));
               val_print(ACS_PRINT_DEBUG, "\n       PE wakeup by some other events/int or didn't enter WFI", 0);
-	      return;
           }
           val_print(ACS_PRINT_INFO, "\n       delay loop remainig value %d", delay_loop);
+	  return;
 
       } else{
           val_print(ACS_PRINT_WARN, "\n       GIC Install Handler Failed...", 0);


### PR DESCRIPTION
We've encountered an issue where the program skips the test at line 150 and doesn't properly exit the function. As a result, the control doesn't return to the while loop, causing the device reset to fail even after completing the BSA test."