### PR TITLE
Fix for timer test 403 on IR system

### DIFF
--- a/pal/uefi_dt/bsa/src/pal_timer_wd.c
+++ b/pal/uefi_dt/bsa/src/pal_timer_wd.c
@@ -624,6 +624,7 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
       else
         GtEntry->GtCntBase[GtEntry->timer_count] = fdt32_to_cpu(Preg[index]);
 
+      GtEntry->GtCntBase[GtEntry->timer_count] += GtEntry->block_cntl_base;
       GtEntry->frame_num[GtEntry->timer_count] = frame_number;
 
       index = 0;


### PR DESCRIPTION
Fix for timer test 403 on IR system

- Changes to add timer base address to the offset for all timers