### PR TITLE
Test 01 over verbose

### DIFF
--- a/val/common/src/acs_pe_infra.c
+++ b/val/common/src/acs_pe_infra.c
@@ -84,6 +84,11 @@ val_pe_create_info_table(uint64_t *pe_info_table)
       return ACS_STATUS_ERR;
   }
 
+  #ifndef TARGET_LINUX
+  val_print(ACS_PRINT_TEST, " Primary PE: MIDR_EL1                 :    0x%llx \n",
+                                                                     val_pe_reg_read(MIDR_EL1));
+  #endif
+
   /* store primary PE index for debug message printing purposes on
      multi PE tests */
   g_primary_pe_index = val_pe_get_index_mpid(val_pe_get_mpid());


### PR DESCRIPTION
- Only different MIDR_EL1 values will be printed in default level
- All core values of MIDR_EL1 will be printed only at verbose mode
Fixes #340 