### PR TITLE
Fix in Timer parsing for DT Platform

### DIFF
--- a/pal/uefi_dt/bsa/src/pal_timer_wd.c
+++ b/pal/uefi_dt/bsa/src/pal_timer_wd.c
@@ -624,7 +624,9 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
       else
         GtEntry->GtCntBase[GtEntry->timer_count] = fdt32_to_cpu(Preg[index]);
 
-      GtEntry->GtCntBase[GtEntry->timer_count] += GtEntry->block_cntl_base;
+      if (GtEntry->GtCntBase[GtEntry->timer_count] < GtEntry->block_cntl_base)
+        GtEntry->GtCntBase[GtEntry->timer_count] += GtEntry->block_cntl_base;
+
       GtEntry->frame_num[GtEntry->timer_count] = frame_number;
 
       index = 0;


### PR DESCRIPTION
- Added logic to compare the baseaddress with offset, because timer frame node reg value may have baseaddress or offset.