### PR TITLE
free file pointer if BSA app exit due to no PE or GIC found.

### DIFF
--- a/mem_test/README.md
+++ b/mem_test/README.md
@@ -6,7 +6,7 @@ handles memory synchronization, caching, and reordering. By analyzing the outcom
 insights into the reliability of the memory model implementation and identify any subtle bugs or inconsistencies that
 might lead to unpredictable behavior in concurrent programs.
 
- - NOTE: Running and passing Memory Model consistenct tests are not required for SystemReady Certifications and they are not part of BSA Certification Image binary.
+ - NOTE: Running and passing Memory Model consistency tests are not required for SystemReady Certifications and they are not part of BSA Certification Image binary.
 
 ## Release details
  - Code quality: v1.0.0 EAC

--- a/pal/uefi_acpi/common/include/pal_uefi.h
+++ b/pal/uefi_acpi/common/include/pal_uefi.h
@@ -86,6 +86,7 @@ typedef struct {
 #define CONDUIT_HVC       1
 #define CONDUIT_UNKNOWN  -1
 #define CONDUIT_NONE     -2
+#define CONDUIT_NO_TABLE -3
 
 typedef struct {
   UINT32 num_of_pe;
@@ -474,7 +475,7 @@ VOID    pal_mem_free_cacheable(UINT32 bdf, UINT32 size, VOID *va, VOID *pa);
 VOID    *pal_mem_virt_to_phys(VOID *va);
 VOID    *pal_mem_phys_to_virt(UINT64 pa);
 UINT64  pal_memory_get_unpopulated_addr(UINT64 *addr, UINT32 instance);
-
+UINT64 pal_get_xsdt_ptr();
 VOID    pal_mem_free(VOID *buffer);
 UINT32  pal_pe_get_num();
 

--- a/pal/uefi_acpi/common/src/pal_pe.c
+++ b/pal/uefi_acpi/common/src/pal_pe.c
@@ -67,7 +67,14 @@ pal_psci_get_conduit (
   VOID
   )
 {
+  EFI_ACPI_DESCRIPTION_HEADER   *Xsdt;
   EFI_ACPI_6_1_FIXED_ACPI_DESCRIPTION_TABLE  *Fadt;
+
+  Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
+  if (Xsdt == NULL) {
+      acs_print(ACS_PRINT_ERR, L" XSDT not found\n");
+      return CONDUIT_NO_TABLE;
+  }
 
   Fadt = (EFI_ACPI_6_1_FIXED_ACPI_DESCRIPTION_TABLE *)pal_get_fadt_ptr ();
   if (!Fadt) {

--- a/pal/uefi_dt/bsa/include/pal_uefi.h
+++ b/pal/uefi_dt/bsa/include/pal_uefi.h
@@ -86,6 +86,7 @@ typedef struct {
 #define CONDUIT_HVC       1
 #define CONDUIT_UNKNOWN  -1
 #define CONDUIT_NONE     -2
+#define CONDUIT_NO_TABLE -3
 
 typedef struct {
   UINT32 num_of_pe;

--- a/pal/uefi_dt/bsa/src/pal_pe.c
+++ b/pal/uefi_dt/bsa/src/pal_pe.c
@@ -99,7 +99,7 @@ pal_psci_get_conduit (
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
       acs_print(ACS_PRINT_ERR, L" dt_ptr is NULL\n");
-      return CONDUIT_NONE;
+      return CONDUIT_NO_TABLE;
   }
 
   /* Search for psci node*/

--- a/uefi_app/BsaAcsMain.c
+++ b/uefi_app/BsaAcsMain.c
@@ -587,16 +587,19 @@ ShellAppMain (
   val_print(ACS_PRINT_TEST, "\n Creating Platform Information Tables\n", 0);
 
 
-
-
-
   Status = createPeInfoTable();
-  if (Status)
-    return Status;
+  if (Status) {
+      if (g_acs_log_file_handle)
+        ShellCloseFile(&g_acs_log_file_handle);
+     return Status;
+  }
 
   Status = createGicInfoTable();
-  if (Status)
-    return Status;
+  if (Status) {
+      if (g_acs_log_file_handle)
+        ShellCloseFile(&g_acs_log_file_handle);
+      return Status;
+  }
 
   /* Initialise exception vector, so any unexpected exception gets handled by default
      BSA exception handler */

--- a/val/common/include/pal_interface.h
+++ b/val/common/include/pal_interface.h
@@ -180,6 +180,7 @@
 #define CONDUIT_HVC       1
 #define CONDUIT_UNKNOWN  -1
 #define CONDUIT_NONE     -2
+#define CONDUIT_NO_TABLE -3
 int32_t pal_psci_get_conduit(void);
 
 /**

--- a/val/common/src/acs_pe_infra.c
+++ b/val/common/src/acs_pe_infra.c
@@ -52,6 +52,9 @@ uint32_t
 val_pe_create_info_table(uint64_t *pe_info_table)
 {
   gPsciConduit = pal_psci_get_conduit();
+  if (gPsciConduit == CONDUIT_NO_TABLE)
+      return ACS_STATUS_ERR;
+
   if (gPsciConduit == CONDUIT_UNKNOWN) {
       val_print(ACS_PRINT_WARN, " FADT not found, assuming SMC as PSCI conduit\n", 0);
       gPsciConduit = CONDUIT_SMC;


### PR DESCRIPTION
When running BSA app compiled for ACPI on DT or (compiled for DT and running on ACPI), due to desired platform tables not found app will exit.
In such cases, the file pointer was not getting free...add code to free the pointer