### PR TITLE
Errata 743 and 663

### DIFF
--- a/val/sbsa/include/sbsa_acs_pe.h
+++ b/val/sbsa/include/sbsa_acs_pe.h
@@ -47,7 +47,6 @@ uint32_t c026_entry(uint32_t num_pe);
 uint32_t c027_entry(uint32_t num_pe);
 uint32_t c028_entry(uint32_t num_pe);
 uint32_t c029_entry(uint32_t num_pe);
-uint32_t c030_entry(uint32_t num_pe);
 uint32_t c031_entry(uint32_t num_pe);
 uint32_t c032_entry(uint32_t num_pe);
 uint32_t c033_entry(uint32_t num_pe);

--- a/val/sbsa/include/sbsa_acs_pe.h
+++ b/val/sbsa/include/sbsa_acs_pe.h
@@ -51,8 +51,6 @@ uint32_t c031_entry(uint32_t num_pe);
 uint32_t c032_entry(uint32_t num_pe);
 uint32_t c033_entry(uint32_t num_pe);
 uint32_t c034_entry(uint32_t num_pe);
-uint32_t c035_entry(uint32_t num_pe);
-uint32_t c036_entry(uint32_t num_pe);
 uint32_t c037_entry(uint32_t num_pe);
 uint32_t c038_entry(uint32_t num_pe);
 uint32_t c039_entry(uint32_t num_pe);

--- a/val/sbsa/src/sbsa_execute_test.c
+++ b/val/sbsa/src/sbsa_execute_test.c
@@ -112,7 +112,6 @@ val_sbsa_pe_execute_tests(uint32_t level, uint32_t num_pe)
   if (((level > 6)  && (g_sbsa_only_level == 0)) || (g_sbsa_only_level == 7)) {
       status |= c028_entry(num_pe);
       status |= c029_entry(num_pe);
-      status |= c030_entry(num_pe);
       status |= c031_entry(num_pe);
       status |= c032_entry(num_pe);
       status |= c033_entry(num_pe);

--- a/val/sbsa/src/sbsa_execute_test.c
+++ b/val/sbsa/src/sbsa_execute_test.c
@@ -116,8 +116,6 @@ val_sbsa_pe_execute_tests(uint32_t level, uint32_t num_pe)
       status |= c032_entry(num_pe);
       status |= c033_entry(num_pe);
       status |= c034_entry(num_pe);
-      status |= c035_entry(num_pe);
-      status |= c036_entry(num_pe);
   }
 
   if (((level > 7)  && (g_sbsa_only_level == 0)) || (g_sbsa_only_level == 8)) {


### PR DESCRIPTION
The rule and test case for S_L7PE_03 is removed. 
It is duplicate of S_L5PE_04 in level 5.
The function c030_entry is removed.

The test case for S_L7PE_08, S_L7PE_09 will not compile.
The above rule is also removed from checklist, but the test file is there.
The function c035_entry, c036_entry is removed.
    