### PR TITLE
Fix for issue #352

### DIFF
--- a/test_pool/exerciser/operating_system/test_os_e001.c
+++ b/test_pool/exerciser/operating_system/test_os_e001.c
@@ -243,13 +243,6 @@ payload(void)
     return;
   }
 
-  if (val_pcie_p2p_support())
-  {
-    val_print(ACS_PRINT_DEBUG, "\n       PCIe hierarchy does not support P2P ", 0);
-    val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 2));
-    return;
-  }
-
   /* Store ACS Control reg bits in an array for every Exerciser and reset them
      to default at the end. */
   val_pcie_read_acsctrl(acsctrl_default);
@@ -325,7 +318,7 @@ payload(void)
   val_pcie_write_acsctrl(acsctrl_default);
 
   if (test_skip == 1)
-      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 3));
+      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 2));
   else if (fail_cnt)
       val_set_status(pe_index, RESULT_FAIL(TEST_NUM, fail_cnt));
   else

--- a/test_pool/exerciser/operating_system/test_os_e002.c
+++ b/test_pool/exerciser/operating_system/test_os_e002.c
@@ -370,13 +370,6 @@ payload(void)
     return;
   }
 
-  if (val_pcie_p2p_support())
-  {
-    val_print(ACS_PRINT_DEBUG, "\n       PCIe Heirarchy does not support P2P", 0);
-    val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 2));
-    return;
-  }
-
   /* Store ACS Control reg bits in an array for every BDF and reset them to default at the end. */
   val_pcie_read_acsctrl(acsctrl_default);
 
@@ -485,7 +478,7 @@ payload(void)
   val_pcie_write_acsctrl(acsctrl_default);
 
   if (test_skip == 1)
-      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 3));
+      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 2));
   else if (fail_cnt)
       val_set_status(pe_index, RESULT_FAIL(TEST_NUM, fail_cnt));
   else

--- a/test_pool/pcie/operating_system/test_os_p017.c
+++ b/test_pool/pcie/operating_system/test_os_p017.c
@@ -41,6 +41,16 @@ payload(void)
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
+
+  /* Check If PCIe Hierarchy supports P2P */
+  if (val_pcie_p2p_support() == NOT_IMPLEMENTED) {
+    val_print(ACS_PRINT_DEBUG, "\n       The test is applicable only if the system supports", 0);
+    val_print(ACS_PRINT_DEBUG, "\n       P2P traffic. If the system supports P2P, pass the", 0);
+    val_print(ACS_PRINT_DEBUG, "\n       command line option '-p2p' while running the binary", 0);
+    val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
+    return;
+  }
+
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
 
   test_fails = 0;
@@ -90,7 +100,7 @@ payload(void)
   if (test_skip == 1) {
       val_print(ACS_PRINT_DEBUG,
            "\n       No RP type device found with P2P and ATS Support. Skipping test", 0);
-      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
+      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 2));
   }
   else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(TEST_NUM, test_fails));

--- a/test_pool/pcie/operating_system/test_os_p018.c
+++ b/test_pool/pcie/operating_system/test_os_p018.c
@@ -49,13 +49,6 @@ payload(void)
     return;
   }
 
-  if (val_pcie_p2p_support())
-  {
-      val_print(ACS_PRINT_DEBUG, "\n       PCIe hierarchy does not support P2P. Skipping test", 0);
-      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 2));
-      return;
-  }
-
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
   test_fails = 0;
 
@@ -68,6 +61,10 @@ payload(void)
       /* Check entry is RP */
       if (dp_type == RP)
       {
+          /* Check If RP supports P2P with other RP's. */
+          if (val_pcie_dev_p2p_support(bdf))
+              continue;
+
           /* Test runs for atleast an endpoint */
           test_skip = 0;
           val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
@@ -89,7 +86,7 @@ payload(void)
 
   if (test_skip == 1) {
       val_print(ACS_PRINT_DEBUG, "\n       No RP type device found. Skipping test", 0);
-      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 3));
+      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 2));
   }
   else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(TEST_NUM, test_fails));

--- a/test_pool/pcie/operating_system/test_os_p019.c
+++ b/test_pool/pcie/operating_system/test_os_p019.c
@@ -43,11 +43,12 @@ payload(void)
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   /* Check If PCIe Hierarchy supports P2P */
-  if (val_pcie_p2p_support())
-  {
-      val_print(ACS_PRINT_DEBUG, "\n       PCIe hierarchy does not support P2P. Skipping test", 0);
-      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
-      return;
+  if (val_pcie_p2p_support() == NOT_IMPLEMENTED) {
+    val_print(ACS_PRINT_DEBUG, "\n       The test is applicable only if the system supports", 0);
+    val_print(ACS_PRINT_DEBUG, "\n       P2P traffic. If the system supports P2P, pass the", 0);
+    val_print(ACS_PRINT_DEBUG, "\n       command line option '-p2p' while running the binary", 0);
+    val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
+    return;
   }
 
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();

--- a/test_pool/pcie/operating_system/test_os_p043.c
+++ b/test_pool/pcie/operating_system/test_os_p043.c
@@ -44,11 +44,12 @@ payload(void)
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   /* Check If PCIe Hierarchy supports P2P */
-  if (val_pcie_p2p_support())
-  {
-      val_print(ACS_PRINT_DEBUG, "\n       PCIe hierarchy does not support P2P. Skipping test", 0);
-      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
-      return;
+  if (val_pcie_p2p_support() == NOT_IMPLEMENTED) {
+    val_print(ACS_PRINT_DEBUG, "\n       The test is applicable only if the system supports", 0);
+    val_print(ACS_PRINT_DEBUG, "\n       P2P traffic. If the system supports P2P, pass the", 0);
+    val_print(ACS_PRINT_DEBUG, "\n       command line option '-p2p' while running the binary", 0);
+    val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
+    return;
   }
 
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();


### PR DESCRIPTION
- val_pcie_p2p_support API either return non_implemented or 0. having it twice is redundant, hence removed it in tests
- In addition to the devices, the PCIe hierarchy also need to support P2P. hence added P2P check for PCIe hierarchy as well
Fixes #352 