### PR TITLE
Errata 607: Rule PMU_SYS_5 is moved to recommended

### DIFF
--- a/val/sbsa/include/sbsa_acs_pmu.h
+++ b/val/sbsa/include/sbsa_acs_pmu.h
@@ -49,7 +49,6 @@ uint32_t pmu004_entry(uint32_t num_pe);
 uint32_t pmu005_entry(uint32_t num_pe);
 uint32_t pmu006_entry(uint32_t num_pe);
 uint32_t pmu007_entry(uint32_t num_pe);
-uint32_t pmu008_entry(uint32_t num_pe);
 uint32_t pmu009_entry(uint32_t num_pe);
 
 #endif /*__SBSA_ACS_PMU_H__ */

--- a/val/sbsa/src/sbsa_execute_test.c
+++ b/val/sbsa/src/sbsa_execute_test.c
@@ -652,7 +652,6 @@ val_sbsa_pmu_execute_tests(uint32_t level, uint32_t num_pe)
       status |= pmu004_entry(num_pe);
       status |= pmu005_entry(num_pe);
       status |= pmu007_entry(num_pe);
-      status |= pmu008_entry(num_pe);
       status |= pmu009_entry(num_pe);
   }
   val_print_test_end(status, "PMU");


### PR DESCRIPTION
The PMU_SYS_5 will not be present in default run