### PR TITLE
Fixes #337:  val_dma_create_info_table in BM

### DIFF
--- a/baremetal_app/BsaAcsMain.c
+++ b/baremetal_app/BsaAcsMain.c
@@ -17,10 +17,11 @@
 
 #include "val/common/include/pal_interface.h"
 #include "val/common/include/val_interface.h"
-#include "val/bsa/include/bsa_val_interface.h"
 #include "val/common/include/acs_pe.h"
 #include "val/common/include/acs_val.h"
 #include "val/common/include/acs_memory.h"
+#include "val/bsa/include/bsa_val_interface.h"
+#include "val/bsa/include/bsa_acs_dma.h"
 #include "BsaAcs.h"
 
 uint32_t  g_print_level;
@@ -146,6 +147,17 @@ createPeripheralInfoTable(
 }
 
 void
+createDmaInfoTable(
+)
+{
+  uint64_t  *DmaInfoTable;
+
+  DmaInfoTable = val_aligned_alloc(SIZE_4K, sizeof(DMA_INFO_TABLE)
+                 + (PLATFORM_OVERRIDE_DMA_CNT * sizeof(DMA_INFO_BLOCK)));
+  val_dma_create_info_table(DmaInfoTable);
+}
+
+void
 freeBsaAcsMem()
 {
 
@@ -156,6 +168,7 @@ freeBsaAcsMem()
   val_pcie_free_info_table();
   val_iovirt_free_info_table();
   val_peripheral_free_info_table();
+  val_dma_free_info_table();
   val_free_shared_mem();
 }
 
@@ -240,6 +253,7 @@ ShellAppMainbsa(
   createWatchdogInfoTable();
   createPcieVirtInfoTable();
   createPeripheralInfoTable();
+  createDmaInfoTable();
 
   val_allocate_shared_mem();
 

--- a/val/bsa/src/bsa_acs_dma.c
+++ b/val/bsa/src/bsa_acs_dma.c
@@ -47,6 +47,12 @@ void
 val_dma_create_info_table(uint64_t *dma_info_ptr)
 {
 
+  if (dma_info_ptr == NULL) {
+      val_print(ACS_PRINT_ERR, "Input for Create Info table cannot be NULL\n", 0);
+      return;
+  }
+  val_print(ACS_PRINT_INFO, " Creating DMA INFO table\n", 0);
+
   g_dma_info_table = (DMA_INFO_TABLE *)dma_info_ptr;
 
   pal_dma_create_info_table(g_dma_info_table);


### PR DESCRIPTION
Fixes #337 
- Call to DMA create info table is needed in BM to populate the DMA table
- The details to be populated in the platform config files