### PR TITLE
Fixes #351:  Check MSI(X) vectors uniqueness

### DIFF
--- a/val/common/include/acs_pcie_spec.h
+++ b/val/common/include/acs_pcie_spec.h
@@ -49,6 +49,7 @@
 #define MAS_CC       0x1
 #define CNTRL_CC     0x2
 #define DP_CNTRL_CC  0x3
+#define RES_CC       0x13
 
 /* Command register shifts */
 #define CR_MSE_SHIFT   1


### PR DESCRIPTION
Fixes #351 
- This rule to be verified for all devices and not only the Peripheral devices.
- Skipping the Ethernet devices and the devices with the class code greater than 13h as they are reserved.