### PR TITLE
S_PCIe_11: Steering Tag properties

### DIFF
--- a/pal/baremetal/target/RDN2/sbsa/src/pal_sbsa_bm_pcie.c
+++ b/pal/baremetal/target/RDN2/sbsa/src/pal_sbsa_bm_pcie.c
@@ -1,0 +1,34 @@
+/** @file
+ * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include "pal_common_support.h"
+#include "pal_pcie_enum.h"
+
+#define NOT_IMPLEMENTED  0x4B1D
+
+/**
+  @brief  Check for the _DSM method to obtain the STE value
+
+  @param  None
+
+  @return 0 - Failure, NOT_IMPLEMENTED - DSM Method not implemented, Other values - PASS
+**/
+uint32_t pal_pcie_dsm_ste_tags(void)
+{
+
+    return NOT_IMPLEMENTED;
+}

--- a/val/sbsa/include/sbsa_acs_pcie.h
+++ b/val/sbsa/include/sbsa_acs_pcie.h
@@ -231,4 +231,7 @@ p064_entry(uint32_t num_pe);
 uint32_t
 p065_entry(uint32_t num_pe);
 
+uint32_t
+p066_entry(uint32_t num_pe);
+
 #endif

--- a/val/sbsa/include/sbsa_pal_interface.h
+++ b/val/sbsa/include/sbsa_pal_interface.h
@@ -28,6 +28,7 @@ uint32_t pal_smmu_is_etr_behind_catu(char *etr_path);
 /* PCIe related PAL APIs */
 uint32_t pal_pcie_get_rp_transaction_frwd_support(uint32_t seg, uint32_t bus,
                                                             uint32_t dev, uint32_t fn);
+uint32_t pal_pcie_dsm_ste_tags(void);
 
 /* Exerciser related PAL APIs */
 void     pal_exerciser_disable_rp_pio_register(uint32_t bdf);

--- a/val/sbsa/include/sbsa_val_interface.h
+++ b/val/sbsa/include/sbsa_val_interface.h
@@ -51,6 +51,7 @@ uint32_t val_smmu_is_etr_behind_catu(char *etr_path);
 /* PCIE VAL APIs */
 void val_pcie_enable_ordering(uint32_t bdf);
 void val_pcie_disable_ordering(uint32_t bdf);
+uint32_t val_pcie_dsm_ste_tags(void);
 
 /* NIST VAL APIs */
 uint32_t val_nist_generate_rng(uint32_t *rng_buffer);

--- a/val/sbsa/src/sbsa_acs_pcie.c
+++ b/val/sbsa/src/sbsa_acs_pcie.c
@@ -15,11 +15,12 @@
  * limitations under the License.
  **/
 
-#include "sbsa/include/sbsa_val_interface.h"
 #include "common/include/acs_val.h"
 #include "common/include/acs_common.h"
 #include "common/include/acs_pcie.h"
 #include "sbsa/include/sbsa_acs_pcie.h"
+#include "sbsa/include/sbsa_val_interface.h"
+#include "sbsa/include/sbsa_pal_interface.h"
 
 uint64_t
 pal_get_mcfg_ptr(void);
@@ -210,4 +211,16 @@ val_pcie_disable_ordering(uint32_t bdf)
   dis_mask = ~(1 << DCTLR_ERE_SHIFT);
   val_pcie_write_cfg(bdf, pciecs_base + DCTLR_OFFSET, reg_value & dis_mask);
 
+}
+
+/**
+  @brief  Returns the Steering Tag value discovered
+
+  @param  None
+  @return Returns the steering tag value
+**/
+uint32_t val_pcie_dsm_ste_tags(void)
+{
+
+    return pal_pcie_dsm_ste_tags();
 }

--- a/val/sbsa/src/sbsa_execute_test.c
+++ b/val/sbsa/src/sbsa_execute_test.c
@@ -363,6 +363,11 @@ val_sbsa_pcie_execute_tests(uint32_t level, uint32_t num_pe)
   }
 #endif
 
+#if defined(TARGET_LINUX) || defined(TARGET_EMULATION)
+  if (((level > 7) && (g_sbsa_only_level == 0)) || (g_sbsa_only_level == 8))
+    status |= p066_entry(num_pe);
+#endif
+
   val_print_test_end(status, "PCIe");
 
   return status;


### PR DESCRIPTION
- Use _DSM Method to obtain the STE values from table