### PR TITLE
Renaming of the VAL API's

### DIFF
--- a/val/bsa/src/bsa_acs_gic.c
+++ b/val/bsa/src/bsa_acs_gic.c
@@ -81,7 +81,7 @@ void val_gic_clear_interrupt(uint32_t int_id)
     uint32_t reg_shift  = int_id % 32;
 
     if (val_gic_is_valid_espi(int_id))
-      val_bsa_gic_clear_espi_interrupt(int_id);
+      val_gic_clear_espi_interrupt(int_id);
     else if ((int_id > 31) && (int_id < 1020)) {
         val_mmio_write(val_get_gicd_base() + GICD_ICPENDR0 + (4 * reg_offset),
                         ((uint32_t)1 << reg_shift));

--- a/val/common/src/acs_gic.c
+++ b/val/common/src/acs_gic.c
@@ -73,10 +73,10 @@ val_gic_create_info_table(uint64_t *gic_info_table)
 
 #if !defined(SBSA) && !defined(DRTM)
   if (pal_target_is_dt())
-      val_bsa_gic_init();
+      val_gic_init();
 #endif
   if (pal_target_is_bm())
-      val_bsa_gic_init();
+      val_gic_init();
 
   return ACS_STATUS_PASS;
 }
@@ -418,26 +418,10 @@ val_gic_espi_supported(void)
 {
   uint32_t espi_support;
 
-  espi_support = val_bsa_gic_espi_support();
+  espi_support = val_gic_espi_support();
 
   val_print(ACS_PRINT_INFO, "\n    ESPI supported %d  ", espi_support);
   return espi_support;
-}
-
-/**
-  @brief   This API returns max extended SPI interrupt value
-  @param   None
-  @return  max extended spi int value
-**/
-uint32_t
-val_gic_max_espi_val(void)
-{
-  uint32_t max_espi_val;
-
-  max_espi_val = val_bsa_gic_max_espi_val();
-
-  val_print(ACS_PRINT_INFO, "\n    max ESPI value %d  ", max_espi_val);
-  return max_espi_val;
 }
 
 /**
@@ -448,7 +432,7 @@ val_gic_max_espi_val(void)
 uint32_t
 val_gic_is_valid_espi(uint32_t int_id)
 {
-  return val_bsa_gic_check_espi_interrupt(int_id);
+  return val_gic_check_espi_interrupt(int_id);
 }
 
 /**
@@ -459,7 +443,7 @@ val_gic_is_valid_espi(uint32_t int_id)
 uint32_t
 val_gic_is_valid_eppi(uint32_t int_id)
 {
-  return val_bsa_gic_check_eppi_interrupt(int_id);
+  return val_gic_check_eppi_interrupt(int_id);
 }
 
 /**
@@ -470,6 +454,6 @@ val_gic_is_valid_eppi(uint32_t int_id)
 uint32_t
 val_gic_is_valid_ppi(uint32_t int_id)
 {
-  return val_bsa_gic_check_ppi(int_id);
+  return val_gic_check_ppi(int_id);
 }
 

--- a/val/common/src/acs_gic_support.c
+++ b/val/common/src/acs_gic_support.c
@@ -143,10 +143,10 @@ val_gic_install_isr(uint32_t int_id, void (*isr)(void))
 
 #ifndef SBSA
   if (pal_target_is_dt())
-      return val_gic_bsa_install_isr(int_id, isr);
+      return val_acs_install_isr(int_id, isr);
 #endif
   if (pal_target_is_bm())
-      return val_gic_bsa_install_isr(int_id, isr);
+      return val_acs_install_isr(int_id, isr);
   else {
       ret_val = pal_gic_install_isr(int_id, isr);
 #ifndef TARGET_LINUX
@@ -198,10 +198,10 @@ uint32_t val_gic_end_of_interrupt(uint32_t int_id)
 
 #ifndef SBSA
   if (pal_target_is_dt())
-      val_bsa_gic_endofInterrupt(int_id);
+      val_gic_endofInterrupt(int_id);
 #endif
   if (pal_target_is_bm())
-      val_bsa_gic_endofInterrupt(int_id);
+      val_gic_endofInterrupt(int_id);
   else
       pal_gic_end_of_interrupt(int_id);
 

--- a/val/common/src/acs_pe_infra.c
+++ b/val/common/src/acs_pe_infra.c
@@ -302,10 +302,10 @@ val_pe_install_esr(uint32_t exception_type, void (*esr)(uint64_t, void *))
 #ifndef TARGET_LINUX
 #if !defined(SBSA) && !defined(DRTM)
   if (pal_target_is_dt())
-      return val_gic_bsa_install_esr(exception_type, esr);
+      return val_acs_install_esr(exception_type, esr);
 #endif
   if (pal_target_is_bm())
-      return val_gic_bsa_install_esr(exception_type, esr);
+      return val_acs_install_esr(exception_type, esr);
   else
       return pal_pe_install_esr(exception_type, esr);
 #endif

--- a/val/common/sys_arch_src/gic/acs_exception.c
+++ b/val/common/sys_arch_src/gic/acs_exception.c
@@ -35,7 +35,7 @@ static void default_irq_handler(uint64_t exception_type, void *context)
   (void) exception_type;
   (void) context;
 
-  iar_ack_val = val_bsa_gic_acknowledgeInterrupt();
+  iar_ack_val = val_gic_acknowledgeInterrupt();
   ack_interrupt = iar_ack_val & 0xFFFFFF;
 
   /* Call Interrupt handler if installed otherwise print err. */
@@ -48,7 +48,7 @@ static void default_irq_handler(uint64_t exception_type, void *context)
   }
 
   /* End Of Interrupt */
-  val_bsa_gic_endofInterrupt(ack_interrupt);
+  val_gic_endofInterrupt(ack_interrupt);
 
   return;
 }
@@ -61,24 +61,24 @@ void bsa_gic_vector_table_init(void)
   bsa_gic_set_el2_vector_table();
 
   /* Install Default handler for IRQ */
-  val_gic_bsa_install_esr(EXCEPT_AARCH64_IRQ, default_irq_handler);
+  val_acs_install_esr(EXCEPT_AARCH64_IRQ, default_irq_handler);
 }
 
-uint32_t val_gic_bsa_install_isr(uint32_t interrupt_id, void (*isr)(void))
+uint32_t val_acs_install_isr(uint32_t interrupt_id, void (*isr)(void))
 {
   /* Step 1: Disable Interrupt before registering Handler */
-  val_bsa_gic_disableInterruptSource(interrupt_id);
+  val_gic_disableInterruptSource(interrupt_id);
 
   /* Step 2: Register ISR for the particular interrupt */
   g_intr_handler[interrupt_id] = (irq_handler) isr;
 
   /* Step 3: Enable Interrupt */
-  val_bsa_gic_enableInterruptSource(interrupt_id);
+  val_gic_enableInterruptSource(interrupt_id);
 
   return 0;
 }
 
-uint32_t val_gic_bsa_install_esr(uint32_t exception_type, void (*esr)(uint64_t, void *))
+uint32_t val_acs_install_esr(uint32_t exception_type, void (*esr)(uint64_t, void *))
 {
   g_esr_handler[exception_type] = (bsa_fp) esr;
   return 0;

--- a/val/common/sys_arch_src/gic/acs_exception.h
+++ b/val/common/sys_arch_src/gic/acs_exception.h
@@ -32,7 +32,7 @@ void bsa_gic_end_intr(uint32_t interrupt_id);
 void bsa_gic_vector_table_init(void);
 uint32_t common_exception_handler(uint32_t exception_type);
 
-uint32_t val_gic_bsa_install_esr(uint32_t exception_type, void (*esr)(uint64_t, void *));
-uint32_t val_gic_bsa_install_isr(uint32_t interrupt_id, void (*isr)(void));
+uint32_t val_acs_install_esr(uint32_t exception_type, void (*esr)(uint64_t, void *));
+uint32_t val_acs_install_isr(uint32_t interrupt_id, void (*isr)(void));
 
 

--- a/val/common/sys_arch_src/gic/gic.c
+++ b/val/common/sys_arch_src/gic/gic.c
@@ -27,7 +27,7 @@
   @return init success or failure
 **/
 void
-val_bsa_gic_init(void)
+val_gic_init(void)
 {
   uint32_t gic_version;
 
@@ -44,7 +44,7 @@ val_bsa_gic_init(void)
   @return none
 **/
 void
-val_bsa_gic_enableInterruptSource(uint32_t int_id)
+val_gic_enableInterruptSource(uint32_t int_id)
 {
   uint32_t gic_version;
 
@@ -61,7 +61,7 @@ val_bsa_gic_enableInterruptSource(uint32_t int_id)
   @return none
 **/
 void
-val_bsa_gic_disableInterruptSource(uint32_t int_id)
+val_gic_disableInterruptSource(uint32_t int_id)
 {
   uint32_t gic_version;
 
@@ -78,7 +78,7 @@ val_bsa_gic_disableInterruptSource(uint32_t int_id)
   @return none
 **/
 uint32_t
-val_bsa_gic_acknowledgeInterrupt(void)
+val_gic_acknowledgeInterrupt(void)
 {
   uint32_t gic_version;
 
@@ -95,7 +95,7 @@ val_bsa_gic_acknowledgeInterrupt(void)
   @return none
 **/
 void
-val_bsa_gic_endofInterrupt(uint32_t int_id)
+val_gic_endofInterrupt(uint32_t int_id)
 {
   uint32_t gic_version;
 
@@ -112,7 +112,7 @@ val_bsa_gic_endofInterrupt(uint32_t int_id)
   @return 0 if not supported, 1 supported
 **/
 uint32_t
-val_bsa_gic_espi_support(void)
+val_gic_espi_support(void)
 {
   uint32_t gic_version;
 
@@ -129,19 +129,25 @@ val_bsa_gic_espi_support(void)
   @return max espi value
 **/
 uint32_t
-val_bsa_gic_max_espi_val(void)
+val_gic_max_espi_val(void)
 {
   uint32_t gic_version;
   uint32_t espi_range;
+  uint32_t max_espi_val = 0;
 
   gic_version = val_gic_get_info(GIC_INFO_VERSION);
   if (gic_version >= 3) {
       espi_range = (v3_read_gicdTyper() >> GICD_TYPER_ESPI_RANGE_SHIFT) &
                                                                     GICD_TYPER_ESPI_RANGE_MASK;
-      return (32 * (espi_range + 1) + 4095);
+      max_espi_val = (32 * (espi_range + 1) + 4095);
+
+      val_print(ACS_PRINT_INFO, "\n    max ESPI value %d  ", max_espi_val);
+      return max_espi_val;
   }
-  else
+  else {
+      val_print(ACS_PRINT_INFO, "\n    max ESPI value %d  ", max_espi_val);
       return 0;
+  }
 }
 
 
@@ -151,9 +157,9 @@ val_bsa_gic_max_espi_val(void)
   @return 1: espi interrupt, 0: non-espi interrupt
 **/
 uint32_t
-val_bsa_gic_check_espi_interrupt(uint32_t int_id)
+val_gic_check_espi_interrupt(uint32_t int_id)
 {
-  if (val_bsa_gic_espi_support() && v3_is_extended_spi(int_id))
+  if (val_gic_espi_support() && v3_is_extended_spi(int_id))
     return 1;
   else
     return 0;
@@ -164,7 +170,7 @@ val_bsa_gic_check_espi_interrupt(uint32_t int_id)
   @param  interrupt
   @return none
 **/
-void val_bsa_gic_clear_espi_interrupt(uint32_t int_id)
+void val_gic_clear_espi_interrupt(uint32_t int_id)
 {
   v3_clear_extended_spi_interrupt(int_id);
 }
@@ -176,7 +182,7 @@ void val_bsa_gic_clear_espi_interrupt(uint32_t int_id)
   @return 0 if not supported, 1 supported
 **/
 uint32_t
-val_bsa_gic_eppi_support(void)
+val_gic_eppi_support(void)
 {
   uint32_t gic_version;
 
@@ -197,7 +203,7 @@ val_bsa_gic_eppi_support(void)
   @return max eppi value
 **/
 uint32_t
-val_bsa_gic_max_eppi_val(void)
+val_gic_max_eppi_val(void)
 {
   uint32_t gic_version;
   uint32_t ppi_range;
@@ -222,9 +228,9 @@ val_bsa_gic_max_eppi_val(void)
   @return 1: eppi interrupt
 **/
 uint32_t
-val_bsa_gic_check_eppi_interrupt(uint32_t int_id)
+val_gic_check_eppi_interrupt(uint32_t int_id)
 {
-  if (val_bsa_gic_eppi_support() && v3_is_extended_ppi(int_id))
+  if (val_gic_eppi_support() && v3_is_extended_ppi(int_id))
     return 1;
   else
     return 0;
@@ -236,9 +242,9 @@ val_bsa_gic_check_eppi_interrupt(uint32_t int_id)
   @return 1: ppi interrupt
 **/
 uint32_t
-val_bsa_gic_check_ppi(uint32_t int_id)
+val_gic_check_ppi(uint32_t int_id)
 {
-  if ((val_bsa_gic_eppi_support() && v3_is_extended_ppi(int_id)) || (int_id > 15 && int_id < 32))
+  if ((val_gic_eppi_support() && v3_is_extended_ppi(int_id)) || (int_id > 15 && int_id < 32))
     return 1;
   else
     return 0;

--- a/val/common/sys_arch_src/gic/gic.h
+++ b/val/common/sys_arch_src/gic/gic.h
@@ -53,18 +53,18 @@
 #define PE_AFF3   (0xFFULL << 32)
 
 
-void val_bsa_gic_init(void);
-void val_bsa_gic_disableInterruptSource(uint32_t int_id);
-void val_bsa_gic_enableInterruptSource(uint32_t int_id);
-uint32_t val_bsa_gic_acknowledgeInterrupt(void);
-void val_bsa_gic_endofInterrupt(uint32_t int_id);
-uint32_t val_bsa_gic_espi_support(void);
-uint32_t val_bsa_gic_max_espi_val(void);
-uint32_t val_bsa_gic_check_espi_interrupt(uint32_t int_id);
-void val_bsa_gic_clear_espi_interrupt(uint32_t int_id);
-uint32_t val_bsa_gic_eppi_support(void);
-uint32_t val_bsa_gic_max_eppi_val(void);
-uint32_t val_bsa_gic_check_eppi_interrupt(uint32_t int_id);
-uint32_t val_bsa_gic_check_ppi(uint32_t int_id);
+void val_gic_init(void);
+void val_gic_disableInterruptSource(uint32_t int_id);
+void val_gic_enableInterruptSource(uint32_t int_id);
+uint32_t val_gic_acknowledgeInterrupt(void);
+void val_gic_endofInterrupt(uint32_t int_id);
+uint32_t val_gic_espi_support(void);
+uint32_t val_gic_max_espi_val(void);
+uint32_t val_gic_check_espi_interrupt(uint32_t int_id);
+void val_gic_clear_espi_interrupt(uint32_t int_id);
+uint32_t val_gic_eppi_support(void);
+uint32_t val_gic_max_eppi_val(void);
+uint32_t val_gic_check_eppi_interrupt(uint32_t int_id);
+uint32_t val_gic_check_ppi(uint32_t int_id);
 
 #endif /*__GIC_H__ */

--- a/val/common/sys_arch_src/gic/v3/gic_v3.c
+++ b/val/common/sys_arch_src/gic/v3/gic_v3.c
@@ -298,7 +298,7 @@ v3_Init(void)
   uint64_t   cpuTarget;
   uint64_t   Mpidr;
 
-  if (val_bsa_gic_espi_support() || val_bsa_gic_eppi_support())
+  if (val_gic_espi_support() || val_gic_eppi_support())
     v3_extended_init();
 
   /* Get the distributor base */

--- a/val/common/sys_arch_src/gic/v3/gic_v3_extended.c
+++ b/val/common/sys_arch_src/gic/v3/gic_v3_extended.c
@@ -45,7 +45,7 @@ void v3_clear_extended_spi_interrupt(uint32_t int_id)
 uint32_t
 v3_is_extended_spi(uint32_t int_id)
 {
-  if (int_id >= EXTENDED_SPI_START_INTID && int_id <= val_bsa_gic_max_espi_val())
+  if (int_id >= EXTENDED_SPI_START_INTID && int_id <= val_gic_max_espi_val())
       return 1;
   else
       return 0;
@@ -59,7 +59,7 @@ v3_is_extended_spi(uint32_t int_id)
 uint32_t
 v3_is_extended_ppi(uint32_t int_id)
 {
-  if (int_id >= EXTENDED_PPI_START_INTID && int_id <= val_bsa_gic_max_eppi_val())
+  if (int_id >= EXTENDED_PPI_START_INTID && int_id <= val_gic_max_eppi_val())
       return 1;
   else
       return 0;
@@ -195,8 +195,8 @@ v3_extended_init(void)
   uint32_t   index;
 
   /* Get the max interrupt */
-  max_num_espi_interrupts = val_bsa_gic_max_espi_val();
-  max_num_eppi_interrupts = val_bsa_gic_max_eppi_val();
+  max_num_espi_interrupts = val_gic_max_espi_val();
+  max_num_eppi_interrupts = val_gic_max_eppi_val();
 
   val_print(ACS_PRINT_DEBUG, "\n GIC_INIT: Extended SPI Interrupts %d\n", max_num_espi_interrupts);
   val_print(ACS_PRINT_DEBUG, "\n GIC_INIT: Extended PPI Interrupts %d\n", max_num_eppi_interrupts);


### PR DESCRIPTION
- Renaming of the VAL API's used by SBSA and BSA starting as val_bsa_* to val_module_*