### PR TITLE
Bug fix to PCIe test 64

### DIFF
--- a/test_pool/pcie/operating_system/test_os_p064.c
+++ b/test_pool/pcie/operating_system/test_os_p064.c
@@ -37,7 +37,7 @@ static uint32_t check_msi_status(uint32_t bdf)
 
   /* Search for MSI/MSI-X Capability */
   if ((val_pcie_find_capability(bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) ||
-      (val_pcie_find_capability(bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)))
+      (val_pcie_find_capability(bdf, PCIE_CAP, CID_MSI, &msi_cap_offset)))
   {
       val_print(ACS_PRINT_DEBUG, "\n       No MSI/MSI-X Capability for bdf 0x%x", bdf);
       return 0;

--- a/val/sbsa/src/sbsa_execute_test.c
+++ b/val/sbsa/src/sbsa_execute_test.c
@@ -234,6 +234,7 @@ uint32_t
 val_sbsa_pcie_execute_tests(uint32_t level, uint32_t num_pe)
 {
   uint32_t status = ACS_STATUS_PASS, i;
+  uint32_t ecam_status = ACS_STATUS_PASS;
 
 #ifdef TARGET_LINUX
   if (!(((level > 2) && (g_sbsa_only_level == 0)) || (g_sbsa_only_level == 3)
@@ -283,17 +284,18 @@ val_sbsa_pcie_execute_tests(uint32_t level, uint32_t num_pe)
 
     if (((level > 3) && (g_sbsa_only_level == 0)) || (g_sbsa_only_level == 4)) {
     /* Only the test p062 will be run at L4+ with the test number (ACS_PER_TEST_NUM_BASE + 1) */
-      status = p062_entry(num_pe);
+      status |= p062_entry(num_pe);
   }
   #endif
 
   if (((level > 5) && (g_sbsa_only_level == 0)) || (g_sbsa_only_level == 6)) {
-    status = p001_entry(num_pe);
-    if (status == ACS_STATUS_FAIL) {
+    ecam_status = p001_entry(num_pe);
+    if (ecam_status == ACS_STATUS_FAIL) {
       val_print(ACS_PRINT_WARN, "\n     *** Skipping remaining PCIE tests ***\n", 0);
       return status;
     }
 
+    status |= ecam_status;
     #if defined(TARGET_LINUX) || defined(TARGET_EMULATION)
       status |= p005_entry(num_pe);
     #endif


### PR DESCRIPTION
- Both MSI and MSI-X capability to be checked for the PCIe devices
- The PCIe test status to be cumulative of all result. Currently the status of previous tests are overridden by the p001 test