### PR TITLE
Fix for PCIe Enumeration

### DIFF
--- a/pal/baremetal/common/include/pal_common_support.h
+++ b/pal/baremetal/common/include/pal_common_support.h
@@ -155,6 +155,11 @@ void *mem_alloc(size_t alignment, size_t size);
 #define DCAP2R_OFFSET  0x24
 #define DCTL2R_OFFSET  0x28
 
+/* RAS related Offset, shift and mask */
+#define RAS_OFFSET     0x10000
+#define CTRL_OFFSET    0x08
+#define STATUS_OFFSET  0x10
+
 /* PCIe capabilities reg shifts and masks */
 #define PCIECR_DPT_SHIFT 4
 #define PCIECR_DPT_MASK  0xf

--- a/pal/baremetal/target/RDN2/sbsa/src/pal_sbsa_bm_exerciser.c
+++ b/pal/baremetal/target/RDN2/sbsa/src/pal_sbsa_bm_exerciser.c
@@ -72,11 +72,13 @@ pal_exerciser_get_ras_status(uint32_t ras_node, uint32_t bdf, uint32_t rp_bdf)
   (void) ras_node;
   uint64_t EcamBAR0;
   uint64_t status_reg;
+  uint32_t data;
 
   EcamBAR0 = pal_exerciser_get_ecsr_base(rp_bdf, 0);
   EcamBAR0 = EcamBAR0 & BAR64_MASK;
   status_reg = EcamBAR0 + RAS_OFFSET + STATUS_OFFSET;
-  return status_reg;
+  data = pal_mmio_read(status_reg);
+  return data;
 }
 
 /**


### PR DESCRIPTION
- Index to be incremented after the ECAM index
- When there is only one 64-bit BAR, the BAR range to be populated in the RP Register
- Fix for incrementing the 64-bit bar size, if RP supports 64-bit BAR.
- Addition of RAS and Poison feature support in the reference code for BareMetal.