### PR TITLE
Test 863 skips without explanation

### DIFF
--- a/docs/arm_bsa_testcase_checklist.rst
+++ b/docs/arm_bsa_testcase_checklist.rst
@@ -1,7 +1,7 @@
 ###########################
 BSA ACS Testcase checklist
 ###########################
- 
+
 The below table provides the following details
 
 #. BSA rules covered by a test.

--- a/val/common/src/acs_pcie.c
+++ b/val/common/src/acs_pcie.c
@@ -1413,8 +1413,10 @@ val_pcie_register_bitfields_check(uint64_t *bf_info_table, uint32_t num_bitfield
   /* Return register check status */
   if (num_pass > 0 || num_fails > 0)
       return num_fails;
-  else
+  else {
+      val_print(ACS_PRINT_ERR, "\n       No PCIe device of type %d present", dp_type);
       return ACS_STATUS_SKIP;
+  }
 }
 
 /**


### PR DESCRIPTION
Test 863 skips without explanation

- Added the skip reason for bitfield checks in VAL

Signed-off-by: Sujana M <sujana.murali@arm.com>