### PR TITLE
Align memory access only for Baremetal

### DIFF
--- a/pal/baremetal/common/include/pal_common_support.h
+++ b/pal/baremetal/common/include/pal_common_support.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -617,8 +617,15 @@ typedef struct {
 }IOVIRT_INFO_TABLE;
 
 #define IOVIRT_NEXT_BLOCK(b) (IOVIRT_BLOCK *)((uint8_t*)(&b->data_map[0]) + b->num_data_map * sizeof(NODE_DATA_MAP))
-#define ALIGN_MEMORY(b, bound) (IOVIRT_BLOCK *) (((uint64_t)b + bound - 1) & (~(bound - 1)))
 #define IOVIRT_CCA_MASK ~((uint32_t)0)
+#ifdef TARGET_BM_BOOT
+  // Align memory access to nearest 8 byte boundary
+  #define BOUND 0x08
+  #define ALIGN_MEMORY_ACCESS(b) \
+            (IOVIRT_BLOCK *) (((uint64_t)b + BOUND - 1) & (~((uint64_t)BOUND - 1)))
+#else
+  #define ALIGN_MEMORY_ACCESS(b) (IOVIRT_BLOCK *) (b)
+#endif
 
 /* Memory INFO table */
 #define MEM_MAP_SUCCESS  0x0

--- a/pal/baremetal/common/src/pal_iovirt.c
+++ b/pal/baremetal/common/src/pal_iovirt.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,14 +23,6 @@ extern PLATFORM_OVERRIDE_NODE_DATA platform_node_type;
 extern PLATFORM_OVERRIDE_PMCG_NODE_DATA platform_pmcg_node_data;
 extern PLATFORM_OVERRIDE_NAMED_NODE_DATA platform_named_node_data;
 
-#ifdef TARGET_BM_BOOT
-    // Align the memory access by 8 bytes in case of baremetal boot.
-    static uint64_t bound = 0x08;
-#else
-    static uint64_t bound = 0x01;
-#endif
-
-
 uint64_t
 pal_iovirt_get_rc_smmu_base (
   IOVIRT_INFO_TABLE *Iovirt,
@@ -50,7 +42,7 @@ pal_iovirt_get_rc_smmu_base (
   mapping_found = 0;
   for (i = 0; i < Iovirt->num_blocks; i++, block = IOVIRT_NEXT_BLOCK(block))
   {
-      block = ALIGN_MEMORY(block, bound);
+      block = ALIGN_MEMORY_ACCESS(block);
       if (block->type == IOVIRT_NODE_PCI_ROOT_COMPLEX
           && block->data.rc.segment == RcSegmentNum)
       {
@@ -198,7 +190,7 @@ pal_iovirt_create_info_table(IOVIRT_INFO_TABLE *IoVirtTable)
   block = &(IoVirtTable->blocks[0]);
   for (i = 0; i < platform_iovirt_cfg.node_count; i++, block=IOVIRT_NEXT_BLOCK(block))
   {
-     block = ALIGN_MEMORY(block, bound);
+     block = ALIGN_MEMORY_ACCESS(block);
      block->type = platform_iovirt_cfg.type[i];
      block->flags = 0;
      switch(platform_iovirt_cfg.type[i]){
@@ -298,7 +290,7 @@ pal_iovirt_create_info_table(IOVIRT_INFO_TABLE *IoVirtTable)
   print(ACS_PRINT_DEBUG, " Number of IOVIRT blocks = %d\n", IoVirtTable->num_blocks);
   for(i = 0; i < IoVirtTable->num_blocks; i++, block = IOVIRT_NEXT_BLOCK(block))
   {
-    block = ALIGN_MEMORY(block, bound);
+    block = ALIGN_MEMORY_ACCESS(block);
     dump_block(block);
   }
 

--- a/val/bsa/src/bsa_acs_iovirt.c
+++ b/val/bsa/src/bsa_acs_iovirt.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,13 +21,6 @@
 #include "common/include/acs_smmu.h"
 
 extern IOVIRT_INFO_TABLE *g_iovirt_info_table;
-
-#ifdef TARGET_BM_BOOT
-    // Align the memory access by 8 bytes in case of baremetal boot.
-    static uint64_t bound = 0x08;
-#else
-    static uint64_t bound = 0x01;
-#endif
 
 /**
   @brief   This API is a single point of entry to retrieve
@@ -69,7 +62,7 @@ val_iovirt_get_its_info(
 
   for (i = 0; i < g_iovirt_info_table->num_blocks; i++, block = IOVIRT_NEXT_BLOCK(block))
   {
-      block = ALIGN_MEMORY(block, bound);
+      block = ALIGN_MEMORY_ACCESS(block);
       if (block->type == IOVIRT_NODE_ITS_GROUP) {
           if (type == ITS_GET_GRP_INDEX_FOR_ID) {
               /* Return the ITS Group Index for ITS_ID = param */

--- a/val/common/include/pal_interface.h
+++ b/val/common/include/pal_interface.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -524,8 +524,15 @@ typedef struct {
 }IOVIRT_BLOCK;
 
 #define IOVIRT_NEXT_BLOCK(b) (IOVIRT_BLOCK *)((uint8_t*)(&b->data_map[0]) + b->num_data_map * sizeof(NODE_DATA_MAP))
-#define ALIGN_MEMORY(b, bound) (IOVIRT_BLOCK *) (((uint64_t)b + bound - 1) & (~(bound - 1)))
 #define IOVIRT_CCA_MASK ~((uint32_t)0)
+#ifdef TARGET_BM_BOOT
+  // Align memory access to nearest 8 byte boundary
+  #define BOUND 0x08
+  #define ALIGN_MEMORY_ACCESS(b) \
+            (IOVIRT_BLOCK *) (((uint64_t)b + BOUND - 1) & (~((uint64_t)BOUND - 1)))
+#else
+  #define ALIGN_MEMORY_ACCESS(b) (IOVIRT_BLOCK *) (b)
+#endif
 
 typedef struct {
   uint32_t num_blocks;

--- a/val/common/src/acs_iovirt.c
+++ b/val/common/src/acs_iovirt.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,13 +22,6 @@
 
 IOVIRT_INFO_TABLE *g_iovirt_info_table;
 uint32_t g_num_smmus;
-
-#ifdef TARGET_BM_BOOT
-    // Align the memory access by 8 bytes in case of baremetal boot.
-    uint64_t bound = 0x08;
-#else
-    uint64_t bound = 0x01;
-#endif
 
 /**
   @brief   This API is a single point of entry to retrieve
@@ -59,7 +52,7 @@ val_iovirt_get_smmu_info(SMMU_INFO_e type, uint32_t index)
   block = &g_iovirt_info_table->blocks[0];
   for(i = 0; i < g_iovirt_info_table->num_blocks; i++, block=IOVIRT_NEXT_BLOCK(block))
   {
-      block = ALIGN_MEMORY(block, bound);
+      block = ALIGN_MEMORY_ACCESS(block);
       if(block->type == IOVIRT_NODE_SMMU || block->type == IOVIRT_NODE_SMMU_V3)
       {
           if(j == index)
@@ -118,7 +111,7 @@ val_iovirt_get_pcie_rc_info(PCIE_RC_INFO_e type, uint32_t index)
   block = &g_iovirt_info_table->blocks[0];
   for(i = 0; i < g_iovirt_info_table->num_blocks; i++, block=IOVIRT_NEXT_BLOCK(block))
   {
-      block = ALIGN_MEMORY(block, bound);
+      block = ALIGN_MEMORY_ACCESS(block);
       if(block->type == IOVIRT_NODE_PCI_ROOT_COMPLEX)
       {
           if(j == index)
@@ -189,7 +182,7 @@ val_iovirt_get_device_info(uint32_t rid, uint32_t segment, uint32_t *device_id,
   mapping_found = 0;
   for (i = 0; i < g_iovirt_info_table->num_blocks; i++, block = IOVIRT_NEXT_BLOCK(block))
   {
-      block = ALIGN_MEMORY(block, bound);
+      block = ALIGN_MEMORY_ACCESS(block);
       if (block->type == IOVIRT_NODE_PCI_ROOT_COMPLEX
           && block->data.rc.segment == segment)
       {

--- a/val/sbsa/src/sbsa_acs_iovirt.c
+++ b/val/sbsa/src/sbsa_acs_iovirt.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,6 @@
 #include "sbsa/include/sbsa_acs_iovirt.h"
 
 extern IOVIRT_INFO_TABLE *g_iovirt_info_table;
-extern uint32_t bound;
 
 #if defined(TARGET_LINUX) || defined(TARGET_EMULATION)
 /**
@@ -98,7 +97,7 @@ val_iovirt_get_named_comp_info(NAMED_COMP_INFO_e type, uint32_t index)
   block = &g_iovirt_info_table->blocks[0];
   for (i = 0; i < g_iovirt_info_table->num_blocks; i++, block = IOVIRT_NEXT_BLOCK(block))
   {
-      block = ALIGN_MEMORY(block, bound);
+      block = ALIGN_MEMORY_ACCESS(block);
       if (block->type == IOVIRT_NODE_NAMED_COMPONENT)
       {
           if (j == index)
@@ -155,7 +154,7 @@ val_iovirt_get_pmcg_info(PMCG_INFO_e type, uint32_t index)
   block = &g_iovirt_info_table->blocks[0];
   for (i = 0; i < g_iovirt_info_table->num_blocks; i++, block = IOVIRT_NEXT_BLOCK(block))
   {
-      block = ALIGN_MEMORY(block, bound);
+      block = ALIGN_MEMORY_ACCESS(block);
       if (block->type == IOVIRT_NODE_PMCG)
       {
           if (j == index)
@@ -203,7 +202,7 @@ val_iovirt_get_rc_index(uint32_t rc_seg_num)
   block = &g_iovirt_info_table->blocks[0];
   for (i = 0; i < g_iovirt_info_table->num_blocks; i++, block = IOVIRT_NEXT_BLOCK(block))
   {
-      block = ALIGN_MEMORY(block, bound);
+      block = ALIGN_MEMORY_ACCESS(block);
       if (block->type == IOVIRT_NODE_PCI_ROOT_COMPLEX)
       {
           if (block->data.rc.segment == rc_seg_num)


### PR DESCRIPTION
 - Resolves #413
 - Remove mem_align dependency for UEFI