### PR TITLE
Run max pasid check on all PCIe devices

### DIFF
--- a/test_pool/pcie/operating_system/test_os_p042.c
+++ b/test_pool/pcie/operating_system/test_os_p042.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2019, 2022-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019, 2022-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,84 +28,80 @@
 
 static void payload(void)
 {
-  int num_per = 0, num_smmu = 0, skip = 1;
+  int num_smmu = 0, skip = 1;
   uint32_t max_pasids = 0;
   uint32_t status;
   uint32_t bdf;
+  uint32_t fail_cnt = 0;
+  uint32_t tbl_index;
+  pcie_device_bdf_table *bdf_tbl_ptr;
   uint32_t index = val_pe_get_index_mpid (val_pe_get_mpid());
 
-  num_per = val_peripheral_get_info(NUM_ALL, 0);
+  /* Get pointer to bdf table */
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
 
-  /* For each peripheral check for PASID support */
+  /* Iterate through bdf info table and check for PASID support */
+  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
+  {
+      /* Index the bdf table using the iterator */
+      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
+      /* Get max PASID with from device bdf */
+      status = val_pcie_get_max_pasid_width(bdf, &max_pasids);
+      /* Skip the device if PASID extended capability not supported */
+      if (status == PCIE_CAP_NOT_FOUND)
+      {
+          val_print(ACS_PRINT_DEBUG, "\n       PASID extended capability not supported.", 0);
+          val_print(ACS_PRINT_DEBUG, " Skipping for BDF: 0x%x", bdf);
+          continue;
+      }
+      /* Raise an error if any failure in obtaining the PASID max width */
+      else if (status)
+      {
+          val_print(ACS_PRINT_ERR,
+                    "\n       Error in obtaining the PASID max width for BDF: 0x%x", bdf);
+          fail_cnt++;
+      }
+      val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
+      val_print(ACS_PRINT_DEBUG, "- Max PASID bits - 0x%x", max_pasids);
+      if (max_pasids > 0)
+      {
+          skip = 0;
+          if (max_pasids < MIN_PASID_SUPPORT)
+          {
+              val_print(ACS_PRINT_ERR, "\n       Max PASID support less than 16 bits  ", 0);
+              fail_cnt++;
+          }
+      }
+  }
+
+  /* For each SMMUv3 check for PASID support */
   /* If PASID is supported, test the max number of PASIDs supported */
-  for (num_per--; num_per >= 0; num_per--)
+  num_smmu = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
+  for (num_smmu--; num_smmu >= 0; num_smmu--)
   {
-     bdf = (uint32_t)val_peripheral_get_info(ANY_BDF, num_per);
-     /* Presently, BDF is 0x0 for UART devices */
-     if (bdf == 0)
-         continue;
-
-     status = val_pcie_get_max_pasid_width(bdf, &max_pasids);
-     if (status == PCIE_CAP_NOT_FOUND)
-     {
-         val_print(ACS_PRINT_DEBUG, "\n       PASID extended capability not supported.", 0);
-         val_print(ACS_PRINT_DEBUG, " Skipping for BDF: 0x%x", bdf);
-         continue;
-     }
-     else if (status)
-     {
-         val_print(ACS_PRINT_ERR,
-                   "\n       Error in obtaining the PASID max width for BDF: 0x%x", bdf);
-         val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
-         break;
-     }
-     val_print(ACS_PRINT_DEBUG, "\n       Peripheral check - Max PASID bits - 0x%x", max_pasids);
-
-     if (max_pasids > 0)
-     {
-        skip = 0;
-        if (max_pasids < MIN_PASID_SUPPORT)
-        {
-           val_print(ACS_PRINT_ERR, "\n       Max PASID support less than 16 bits  ", 0);
-           val_set_status(index, RESULT_FAIL(TEST_NUM, 2));
-           break;
-        }
-     }
+      if (val_iovirt_get_smmu_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) == 3)
+      {
+          max_pasids = val_smmu_max_pasids(num_smmu);
+          val_print(ACS_PRINT_DEBUG, "\n       SMMU check- Max PASID bits- 0x%x", max_pasids);
+          if (max_pasids > 0)
+          {
+              skip = 0;
+              if (max_pasids < MIN_PASID_SUPPORT)
+              {
+                  val_print(ACS_PRINT_ERR, "\n      Max PASID support less than 16 bits  ", 0);
+                  fail_cnt++;
+              }
+          }
+      }
   }
 
-  if (num_per < 0)
-  {
-     /* For each SMMUv3 check for PASID support */
-     /* If PASID is supported, test the max number of PASIDs supported */
-
-     num_smmu = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
-     for (num_smmu--; num_smmu >= 0; num_smmu--)
-     {
-         if (val_iovirt_get_smmu_info(SMMU_CTRL_ARCH_MAJOR_REV, num_smmu) == 3)
-         {
-           max_pasids = val_smmu_max_pasids(num_smmu);
-           val_print(ACS_PRINT_DEBUG, "\n       SMMU check- Max PASID bits- 0x%x", max_pasids);
-
-           if (max_pasids > 0)
-             {
-                 skip = 0;
-                 if (max_pasids < MIN_PASID_SUPPORT)
-                 {
-                    val_print(ACS_PRINT_ERR, "\n      Max PASID support less than 16 bits  ", 0);
-                    val_set_status(index, RESULT_FAIL(TEST_NUM, 3));
-                    break;
-                 }
-             }
-         }
-     }
-  }
-
-  if (num_smmu < 0) {
-      if (skip)
-          val_set_status(index, RESULT_SKIP(TEST_NUM, 3));
-      else
-          val_set_status(index, RESULT_PASS(TEST_NUM, 0));
-  }
+  /* Report the status of test */
+  if (skip)
+      val_set_status(index, RESULT_SKIP(TEST_NUM, 0));
+  else if (fail_cnt)
+      val_set_status(index, RESULT_FAIL(TEST_NUM, 0));
+  else
+      val_set_status(index, RESULT_PASS(TEST_NUM, 0));
 }
 
 uint32_t


### PR DESCRIPTION
- iterating the bdf info table rather than peripheral table, to target all PCIe devices to check.
- test 842 was modified.

Fixes: ARM-software/arm-systemready#243