### PR TITLE
Skip test for PE Already On state

### DIFF
--- a/val/common/src/acs_pe_infra.c
+++ b/val/common/src/acs_pe_infra.c
@@ -218,6 +218,7 @@ val_pe_get_index_mpid(uint64_t mpid)
   @param   None
   @return  None
 **/
+
 void
 val_test_entry(void)
 {
@@ -268,8 +269,14 @@ val_execute_on_pe(uint32_t index, void (*payload)(void), uint64_t test_input)
 
   } while (g_smc_args.Arg0 == (uint64_t)ARM_SMC_PSCI_RET_ALREADY_ON && timeout--);
 
-  if (g_smc_args.Arg0 == (uint64_t)ARM_SMC_PSCI_RET_ALREADY_ON)
+  if (g_smc_args.Arg0 == (uint64_t)ARM_SMC_PSCI_RET_ALREADY_ON) {
       val_print(ACS_PRINT_ERR, "\n       PSCI_CPU_ON: cpu already on", 0);
+      val_print(ACS_PRINT_WARN, "\n       WARNING: Skipping test for PE index %d "
+                              "since it is already on\n", index);
+
+      val_set_status(index, RESULT_SKIP(0, 0x120 - (int)g_smc_args.Arg0));
+      return;
+  }
   else {
       if(g_smc_args.Arg0 == 0) {
           val_print(ACS_PRINT_INFO, "\n       PSCI_CPU_ON: success", 0);

--- a/val/common/src/acs_status.c
+++ b/val/common/src/acs_status.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,6 +40,10 @@ val_report_status(uint32_t index, uint32_t status, char8_t *ruleid)
 
   if (IS_TEST_FAIL(status)) {
       val_print(ACS_PRINT_ERR, "\n       Failed on PE - %4d", index);
+  }
+
+  if (IS_TEST_SKIP(status)) {
+      val_print(ACS_PRINT_ERR, "\n       Skipped on PE - %4d", index);
   }
 
   if (IS_TEST_PASS(status)) {


### PR DESCRIPTION
 
IF PE is already is on state, but fail the test but skip the PE and continue to test with others PE.
The warning print and skip print are added for this state

Fixes #411 
