### PR TITLE
Fixes https://github.com/ARM-software/sbsa-acs/issues/526: FLR test

### DIFF
--- a/test_pool/pcie/operating_system/test_os_p035.c
+++ b/test_pool/pcie/operating_system/test_os_p035.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,6 +69,7 @@ payload(void)
   uint32_t idx;
   uint32_t timeout;
   uint32_t status;
+  uint32_t device_id, vendor_id;
   addr_t config_space_addr;
   void *func_config_space;
   pcie_device_bdf_table *bdf_tbl_ptr;
@@ -155,13 +156,20 @@ payload(void)
           /* If test runs for atleast an endpoint */
           test_skip = 0;
 
-          /* If Vendor Id is 0xFF after max FLR period, wait
-           * for 1 ms and read again. Keep polling for 5 secs */
+          /* If Vendor Id is 0xFFFF after max FLR period, wait
+           * for 1 ms and read again. Keep polling for 5 secs
+           * Vendor Id will be 0x0001 if the device is not yet
+           * ready to respond to configuration read. Hence check
+           * for the vendor id to be 0x0001 to ensure device is
+           * initilaised and ready to respond */
           timeout = (5 * TIMEOUT_LARGE);
           while (timeout-- > 0)
           {
               val_pcie_read_cfg(bdf, 0, &reg_value);
-              if ((reg_value & TYPE01_VIDR_MASK) == TYPE01_VIDR_MASK)
+              vendor_id = reg_value & TYPE01_VIDR_MASK;
+              device_id = (reg_value >> TYPE01_DIDR_SHIFT) & TYPE01_DIDR_MASK;
+              if ((device_id == DIDR_RRS_MASK) &&
+                 ((vendor_id == TYPE01_VIDR_MASK) || (vendor_id == VIDR_RRS_MASK)))
               {
                   status = val_time_delay_ms(ONE_MILLISECOND);
                   continue;
@@ -170,9 +178,12 @@ payload(void)
                   break;
           }
 
-          /* Vendor Id must not be 0xFF after max timeout period */
+          /* Vendor Id must not be 0xFFFF or 0x0001 after max timeout period */
           val_pcie_read_cfg(bdf, 0, &reg_value);
-          if ((reg_value & TYPE01_VIDR_MASK) == TYPE01_VIDR_MASK)
+          vendor_id = reg_value & TYPE01_VIDR_MASK;
+          device_id = (reg_value >> TYPE01_DIDR_SHIFT) & TYPE01_DIDR_MASK;
+          if ((device_id == DIDR_RRS_MASK) &&
+             ((vendor_id == TYPE01_VIDR_MASK) || (vendor_id == VIDR_RRS_MASK)))
           {
               val_print(ACS_PRINT_ERR, "\n       BDF 0x%x not present", bdf);
               test_fails++;

--- a/val/common/include/acs_pcie_spec.h
+++ b/val/common/include/acs_pcie_spec.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,6 +43,8 @@
 #define TYPE01_ILR_SHIFT    0
 #define TYPE01_ILR_MASK     0xFF
 #define TYPE01_BCC_SHIFT    24
+#define VIDR_RRS_MASK       0x0001
+#define DIDR_RRS_MASK       0xFFFF
 
 #define TYPE0_HEADER 0
 #define TYPE1_HEADER 1


### PR DESCRIPTION
- When an FLR is initiated, and before the FLR being completed, the device will respond with Return Retry status (RRS) if Function-specific initialization sequence is not yet completed.
- The test should check for this status as well before proceeding to configuring the registers after FLR is completed

Related to #https://github.com/ARM-software/sbsa-acs/issues/526