### PR TITLE
Fixes #521 Exerciser on multi-segments

### DIFF
--- a/pal/baremetal/common/src/pal_exerciser.c
+++ b/pal/baremetal/common/src/pal_exerciser.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,12 +40,14 @@ pal_exerciser_get_ecam(uint32_t bdf)
 {
 
   uint32_t i = 0;
+  uint32_t seg = PCIE_EXTRACT_BDF_SEG(bdf);
   uint32_t bus = PCIE_EXTRACT_BDF_BUS(bdf);
 
   while (i < g_pcie_info_table->num_entries)
   {
     if ((bus >= g_pcie_info_table->block[i].start_bus_num) &&
-         (bus <= g_pcie_info_table->block[i].end_bus_num))
+        (bus <= g_pcie_info_table->block[i].end_bus_num) &&
+        (seg == g_pcie_info_table->block[i].segment_num))
     {
       return g_pcie_info_table->block[i].ecam_base;
     }

--- a/pal/baremetal/common/src/pal_pcie.c
+++ b/pal/baremetal/common/src/pal_pcie.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,11 +25,12 @@ extern PCIE_READ_TABLE platform_pcie_device_hierarchy;
 extern PERIPHERAL_INFO_TABLE  *g_peripheral_info_table;
 
 uint64_t
-pal_pcie_get_mcfg_ecam()
+pal_pcie_get_mcfg_ecam(uint32_t bdf)
 {
 
+  (void) bdf;
   /* Not Applicable for Baremetal as no MCFG table */
-  return (platform_pcie_cfg.block[0].ecam_base);
+  return 0;
 }
 
 

--- a/pal/uefi_acpi/common/src/pal_exerciser.c
+++ b/pal/uefi_acpi/common/src/pal_exerciser.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,7 +37,7 @@ VOID
 pal_mmio_write(UINT64 addr, UINT32 data);
 
 UINT64
-pal_pcie_get_mcfg_ecam();
+pal_pcie_get_mcfg_ecam(UINT32 bdf);
 
 
 /**
@@ -121,7 +121,7 @@ pal_is_bdf_exerciser(UINT32 bdf)
 {
   UINT64 Ecam;
   UINT32 vendor_dev_id;
-  Ecam = pal_pcie_get_mcfg_ecam();
+  Ecam = pal_pcie_get_mcfg_ecam(bdf);
 
   vendor_dev_id = pal_mmio_read(Ecam + pal_exerciser_get_pcie_config_offset(bdf));
   if (vendor_dev_id == EXERCISER_ID)
@@ -188,7 +188,7 @@ pal_exerciser_find_pcie_capability (
   UINT32 PtrMask;
   UINT32 PtrOffset;
 
-  Ecam = pal_pcie_get_mcfg_ecam();
+  Ecam = pal_pcie_get_mcfg_ecam(Bdf);
   NxtPtr = PCIE_CAP_OFFSET;
 
   if (Value == 1) {
@@ -239,7 +239,7 @@ UINT32 pal_exerciser_set_param (
   UINT32 bdf;
 
   Base = pal_exerciser_get_ecsr_base(Bdf,0);
-  Ecam = pal_pcie_get_mcfg_ecam(); // Getting the ECAM address
+  Ecam = pal_pcie_get_mcfg_ecam(Bdf); // Getting the ECAM address
 
   switch (Type) {
 
@@ -499,7 +499,7 @@ pal_exerciser_ops (
   UINT32 data;
 
   Base = pal_exerciser_get_ecsr_base(Bdf,0);
-  Ecam = pal_pcie_get_mcfg_ecam(); // Getting the ECAM address
+  Ecam = pal_pcie_get_mcfg_ecam(Bdf); // Getting the ECAM address
   switch(Ops){
 
     case START_DMA:

--- a/pal/uefi_dt/bsa/src/pal_exerciser.c
+++ b/pal/uefi_dt/bsa/src/pal_exerciser.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2020,2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020,2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,7 +38,7 @@ VOID
 pal_mmio_write(UINT64 addr, UINT32 data);
 
 UINT64
-pal_pcie_get_mcfg_ecam();
+pal_pcie_get_mcfg_ecam(UINT32 bdf);
 
 
 /**
@@ -122,7 +122,7 @@ pal_is_bdf_exerciser(UINT32 bdf)
 {
   UINT64 Ecam;
   UINT32 vendor_dev_id;
-  Ecam = pal_pcie_get_mcfg_ecam();
+  Ecam = pal_pcie_get_mcfg_ecam(bdf);
 
   vendor_dev_id = pal_mmio_read(Ecam + pal_exerciser_get_pcie_config_offset(bdf));
   if (vendor_dev_id == EXERCISER_ID)
@@ -189,7 +189,7 @@ pal_exerciser_find_pcie_capability (
   UINT32 PtrMask;
   UINT32 PtrOffset;
 
-  Ecam = pal_pcie_get_mcfg_ecam();
+  Ecam = pal_pcie_get_mcfg_ecam(Bdf);
   NxtPtr = PCIE_CAP_OFFSET;
 
   if (Value == 1) {
@@ -415,7 +415,7 @@ pal_exerciser_ops (
   UINT32 data;
 
   Base = pal_exerciser_get_ecsr_base(Bdf,0);
-  Ecam = pal_pcie_get_mcfg_ecam(); // Getting the ECAM address
+  Ecam = pal_pcie_get_mcfg_ecam(Bdf); // Getting the ECAM address
   switch(Ops){
 
     case START_DMA:

--- a/pal/uefi_dt/bsa/src/pal_pcie.c
+++ b/pal/uefi_dt/bsa/src/pal_pcie.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,11 +56,38 @@ pal_get_mcfg_ptr();
   @return  None
 **/
 UINT64
-pal_pcie_get_mcfg_ecam()
+pal_pcie_get_mcfg_ecam(UINT32 bdf)
 {
-  if (g_pal_pcie_info_table)
-      return g_pal_pcie_info_table->block[0].ecam_base;
+  EFI_ACPI_MEMORY_MAPPED_ENHANCED_CONFIGURATION_SPACE_BASE_ADDRESS_ALLOCATION_STRUCTURE  *Entry;
+  UINT32 length = sizeof(EFI_ACPI_MEMORY_MAPPED_CONFIGURATION_BASE_ADDRESS_TABLE_HEADER);
+  UINT32 seg, bus;
 
+  gMcfgHdr = (EFI_ACPI_MEMORY_MAPPED_CONFIGURATION_BASE_ADDRESS_TABLE_HEADER *) pal_get_mcfg_ptr();
+
+  if (gMcfgHdr == NULL) {
+      acs_print(ACS_PRINT_WARN, L" ACPI - MCFG Table not found. Setting ECAM Base to 0.\n");
+      return 0x0;
+  }
+
+  Entry = (EFI_ACPI_MEMORY_MAPPED_ENHANCED_CONFIGURATION_SPACE_BASE_ADDRESS_ALLOCATION_STRUCTURE *)
+          (gMcfgHdr + 1);
+
+  seg = PCIE_EXTRACT_BDF_SEG(bdf);
+  bus = PCIE_EXTRACT_BDF_BUS(bdf);
+  while ((length < gMcfgHdr->Header.Length) && (Entry))
+  {
+      if ((bus >= Entry->StartBusNumber) && (bus <= Entry->EndBusNumber) &&
+          (seg == Entry->PciSegmentGroupNumber)) {
+          acs_print(ACS_PRINT_INFO, L" ECAM base address is %llx\n", Entry->BaseAddress);
+          return Entry->BaseAddress;
+      }
+
+      Entry++;
+      length +=
+      sizeof(EFI_ACPI_MEMORY_MAPPED_ENHANCED_CONFIGURATION_SPACE_BASE_ADDRESS_ALLOCATION_STRUCTURE);
+  }
+
+  acs_print(ACS_PRINT_ERR, L" ECAM base address for bdf 0x%x is 0\n", bdf);
   return 0;
 }
 

--- a/val/common/include/acs_pcie.h
+++ b/val/common/include/acs_pcie.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -165,7 +165,6 @@ uint32_t val_pcie_bar_mem_write(uint32_t bdf, uint64_t address, uint32_t data);
 typedef enum {
   PCIE_INFO_NUM_ECAM = 1,
   PCIE_INFO_ECAM,
-  PCIE_INFO_MCFG_ECAM,
   PCIE_INFO_START_BUS,
   PCIE_INFO_END_BUS,
   PCIE_INFO_SEGMENT

--- a/val/common/include/pal_interface.h
+++ b/val/common/include/pal_interface.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -428,7 +428,7 @@ void     pal_pcie_program_bar_reg(uint32_t bus, uint32_t dev, uint32_t func);
 void     pal_pci_cfg_write(uint32_t bus, uint32_t dev, uint32_t func, int offset, int data);
 uint32_t pal_pci_cfg_read(uint32_t bus, uint32_t dev, uint32_t func, int offset, uint32_t *value);
 
-uint64_t pal_pcie_get_mcfg_ecam(void);
+uint64_t pal_pcie_get_mcfg_ecam(uint32_t bdf);
 void     pal_pcie_create_info_table(PCIE_INFO_TABLE *PcieTable);
 uint32_t pal_pcie_io_read_cfg(uint32_t bdf, uint32_t offset, uint32_t *data);
 uint32_t pal_pcie_get_bdf_wrapper(uint32_t class_code, uint32_t start_bdf);

--- a/val/common/src/acs_pcie.c
+++ b/val/common/src/acs_pcie.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -746,8 +746,6 @@ val_pcie_get_info(PCIE_INFO_e type, uint32_t index)
   switch (type) {
       case PCIE_INFO_NUM_ECAM:
           return g_pcie_info_table->num_entries;
-      case PCIE_INFO_MCFG_ECAM:
-          return pal_pcie_get_mcfg_ecam();
       case PCIE_INFO_ECAM:
           return g_pcie_info_table->block[index].ecam_base;
       case PCIE_INFO_START_BUS:


### PR DESCRIPTION
- The UEFI PAL implementation to get the ECAM address was getting only from the segment 0 and not w.r.t the respective segments.
- Modified the PAL to check for the Segment and bus no of the BDF