### PR TITLE
Errata 574: Check SVE2 if pe is armv9

### DIFF
--- a/baremetal_app/BsaAcs.inf
+++ b/baremetal_app/BsaAcs.inf
@@ -1,5 +1,5 @@
 ## @file
-#  Copyright (c) 2023-2025 Arm Limited or its affiliates. All rights reserved.
+#  Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
 #  SPDX-License-Identifier : Apache-2.0
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,6 +44,7 @@
   ../test_pool/pe/operating_system/test_os_c012.c
   ../test_pool/pe/operating_system/test_os_c013.c
   ../test_pool/pe/operating_system/test_os_c014.c
+  ../test_pool/pe/operating_system/test_os_c016.c
   ../test_pool/pe/hypervisor/test_hyp_c001.c
   ../test_pool/pe/hypervisor/test_hyp_c002.c
   ../test_pool/pe/hypervisor/test_hyp_c003.c
@@ -172,6 +173,7 @@
   gEfiCpuArchProtocolGuid                       ## CONSUMES
   gEfiPciIoProtocolGuid                         ## CONSUMES
   gEfiLoadedImageProtocolGuid                   ## CONSUMES
+  gEfiSmbiosProtocolGuid                        ## CONSUMES
 
 [Guids]
   gEfiAcpi20TableGuid

--- a/baremetal_app/BsaAcsMain.c
+++ b/baremetal_app/BsaAcsMain.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,6 +49,18 @@ extern uint32_t g_test_array[];
 extern uint32_t g_num_tests;
 extern uint32_t g_module_array[];
 extern uint32_t g_num_modules;
+
+void
+createSmbiosInfoTable(
+)
+{
+  uint64_t *SmbiosInfoTable;
+
+  SmbiosInfoTable = val_aligned_alloc(SIZE_4K, sizeof(PE_SMBIOS_PROCESSOR_INFO_TABLE) +
+                           (PLATFORM_OVERRIDE_SMBIOS_SLOT_COUNT * sizeof(PE_SMBIOS_TYPE4_INFO)));
+
+  val_smbios_create_info_table(SmbiosInfoTable);
+}
 
 uint32_t
 createPeInfoTable(
@@ -170,6 +182,7 @@ freeBsaAcsMem()
   val_pcie_free_info_table();
   val_iovirt_free_info_table();
   val_peripheral_free_info_table();
+  val_smbios_free_info_table();
   val_dma_free_info_table();
   val_free_shared_mem();
 }
@@ -256,7 +269,7 @@ ShellAppMainbsa(
   createPcieVirtInfoTable();
   createPeripheralInfoTable();
   createDmaInfoTable();
-
+  createSmbiosInfoTable();
   val_allocate_shared_mem();
 
   /* Initialise exception vector, so any unexpected exception gets handled

--- a/pal/baremetal/BsaPalBaremetalLib.inf
+++ b/pal/baremetal/BsaPalBaremetalLib.inf
@@ -1,5 +1,5 @@
 ## @file
-# Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
 #  SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -74,6 +74,7 @@
   gEfiCpuArchProtocolGuid                       ## CONSUMES
   gEfiPciIoProtocolGuid                         ## CONSUMES
   gHardwareInterrupt2ProtocolGuid               ## CONSUMES
+  gEfiSmbiosProtocolGuid                        ## CONSUMES
 
 [Guids]
   gEfiAcpi20TableGuid

--- a/pal/baremetal/common/include/pal_common_support.h
+++ b/pal/baremetal/common/include/pal_common_support.h
@@ -275,6 +275,22 @@ typedef struct {
   PE_INFO_ENTRY  pe_info[];
 } PE_INFO_TABLE;
 
+/**
+  @brief  Instance of smbios type 4 processor info
+**/
+typedef struct {
+  uint16_t processor_family;
+  uint16_t core_count;
+} PE_SMBIOS_TYPE4_INFO;
+
+/**
+  @brief  Instance of smbios info
+**/
+typedef struct {
+  uint32_t slot_count;
+  PE_SMBIOS_TYPE4_INFO type4_info[];
+} PE_SMBIOS_PROCESSOR_INFO_TABLE;
+
 void pal_pe_data_cache_ops_by_va(uint64_t addr, uint32_t type);
 
 typedef struct {

--- a/pal/baremetal/common/src/pal_pe.c
+++ b/pal/baremetal/common/src/pal_pe.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,7 @@
 
 
 extern PE_INFO_TABLE platform_pe_cfg;
+extern PE_SMBIOS_PROCESSOR_INFO_TABLE platform_smbios_cfg;
 extern PE_INFO_TABLE *g_pe_info_table;
 extern int32_t gPsciConduit;
 
@@ -70,6 +71,38 @@ PalGetMaxMpidr()
 {
 
   return gMpidrMax;
+}
+
+/**
+  @brief  This API fills in the SMBIOS Info Table with information about the processor info
+          in the system. This is achieved by parsing the SMBIOS table.
+
+  @param  SmbiosTable  - Address where the processor information needs to be filled.
+
+  @return  None
+**/
+void
+pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
+{
+  uint32_t count = 0;
+
+  if (SmbiosTable == NULL) {
+    return;
+  }
+
+  SmbiosTable->slot_count = platform_smbios_cfg.slot_count;
+  if (SmbiosTable->slot_count == 0) {
+    print(ACS_PRINT_ERR, "SMBIOS Table Not Found\n", 0);
+    return;
+  }
+
+  while (count < SmbiosTable->slot_count) {
+    SmbiosTable->type4_info[count].processor_family =
+                platform_smbios_cfg.type4_info[count].processor_family;
+    SmbiosTable->type4_info[count].core_count = platform_smbios_cfg.type4_info[count].core_count;
+    count++;
+  }
+
 }
 
 /**

--- a/pal/baremetal/target/RDN2/BsaPalFVPLib.inf
+++ b/pal/baremetal/target/RDN2/BsaPalFVPLib.inf
@@ -1,5 +1,5 @@
 ## @file
-# Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
 #  SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,6 +54,7 @@
   gEfiCpuArchProtocolGuid                       ## CONSUMES
   gEfiPciIoProtocolGuid                         ## CONSUMES
   gHardwareInterrupt2ProtocolGuid               ## CONSUMES
+  gEfiSmbiosProtocolGuid                        ## CONSUMES
 
 [Guids]
   gEfiAcpi20TableGuid

--- a/pal/baremetal/target/RDN2/common/include/platform_override_fvp.h
+++ b/pal/baremetal/target/RDN2/common/include/platform_override_fvp.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,10 @@
 /* Settings */
 #define PLATFORM_OVERRIDE_PRINT_LEVEL  0x3     //The permissible levels are 1,2,3,4 and 5
 
+/*SMBIOS config parameters*/
+#define PLATFORM_OVERRIDE_SMBIOS_SLOT_COUNT       0x1
+#define PLATFROM_OVERRIDE_SMBIOS_SLOT0_FAMILY     0x102
+#define PLATFROM_OVERRIDE_SMBIOS_SLOT0_CORE_COUNT 16
 
 /* MMU PGT config parameters */
 #define PLATFORM_PAGE_SIZE              0x1000

--- a/pal/baremetal/target/RDN2/common/src/platform_cfg_fvp.c
+++ b/pal/baremetal/target/RDN2/common/src/platform_cfg_fvp.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,6 +56,13 @@ uint32_t  g_el1physkip       = FALSE;
    g_crypto_support to FALSE (Default value is TRUE)
 */
 uint32_t g_crypto_support    = TRUE;
+
+PE_SMBIOS_PROCESSOR_INFO_TABLE platform_smbios_cfg = {
+    .slot_count = PLATFORM_OVERRIDE_SMBIOS_SLOT_COUNT,
+
+    .type4_info[0].processor_family = PLATFROM_OVERRIDE_SMBIOS_SLOT0_FAMILY,
+    .type4_info[0].core_count = PLATFROM_OVERRIDE_SMBIOS_SLOT0_CORE_COUNT,
+};
 
 PE_INFO_TABLE platform_pe_cfg = {
 

--- a/pal/uefi_acpi/BsaPalLib.inf
+++ b/pal/uefi_acpi/BsaPalLib.inf
@@ -1,5 +1,5 @@
 ## @file
-# Copyright (c) 2016-2020,2024, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2016-2020,2024-2025, Arm Limited or its affiliates. All rights reserved.
 #  SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -72,6 +72,7 @@
   gEfiPciIoProtocolGuid                         ## CONSUMES
   gHardwareInterrupt2ProtocolGuid               ## CONSUMES
   gEfiPciRootBridgeIoProtocolGuid               ## CONSUMES
+  gEfiSmbiosProtocolGuid                        ## CONSUMES
 
 [Guids]
   gEfiAcpi20TableGuid

--- a/pal/uefi_acpi/common/include/pal_uefi.h
+++ b/pal/uefi_acpi/common/include/pal_uefi.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,6 +54,10 @@ extern UINT32 g_pcie_cache_present;
 #define BAR_MDT_SHIFT   1
 #define BAR_MT_SHIFT    3
 #define BAR_BASE_SHIFT  4
+
+/* smbios defines */
+#define SMBIOS_OBTAIN_PROCESSOR_FAMILY2 0xFE
+#define SMBIOS_OBTAIN_CORE_COUNT2       0xFF
 
 typedef enum {
   MMIO = 0,
@@ -114,6 +118,22 @@ typedef struct {
   PE_INFO_HDR    header;
   PE_INFO_ENTRY  pe_info[];
 }PE_INFO_TABLE;
+
+/**
+  @brief  Instance of smbios type 4 processor info
+**/
+typedef struct {
+  UINT16 processor_family;
+  UINT16 core_count;
+} PE_SMBIOS_TYPE4_INFO;
+
+/**
+  @brief  Instance of smbios info
+**/
+typedef struct {
+  UINT32 slot_count;
+  PE_SMBIOS_TYPE4_INFO type4_info[];
+} PE_SMBIOS_PROCESSOR_INFO_TABLE;
 
 VOID     pal_pe_data_cache_ops_by_va(UINT64 addr, UINT32 type);
 

--- a/pal/uefi_acpi/common/src/pal_pe.c
+++ b/pal/uefi_acpi/common/src/pal_pe.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,8 @@
 #include "Include/IndustryStandard/Acpi61.h"
 #include <Protocol/AcpiTable.h>
 #include <Protocol/Cpu.h>
+#include "Include/IndustryStandard/SmBios.h"
+#include <Protocol/Smbios.h>
 
 #include "common/include/pal_uefi.h"
 
@@ -31,7 +33,8 @@ UINT64  gMpidrMax;
 static UINT32 g_num_pe;
 extern INT32 gPsciConduit;
 
-#define SIZE_STACK_SECONDARY_PE  0x100		//256 bytes per core
+#define MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED  16
+#define SIZE_STACK_SECONDARY_PE  0x100      //256 bytes per core
 #define UPDATE_AFF_MAX(src,dest,mask)  ((dest & mask) > (src & mask) ? (dest & mask) : (src & mask))
 
 #define ENABLED_BIT(flags)  (flags & 0x1)
@@ -50,6 +53,82 @@ ArmCallSmc (
   IN OUT ARM_SMC_ARGS *Args,
   IN     INT32        Conduit
   );
+
+/**
+  @brief  This API fills in the SMBIOS Info Table with information about the processor info
+          in the system. This is achieved by parsing the SMBIOS table.
+
+  @param  SmbiosTable  - Address where the processor information needs to be filled.
+
+  @return  None
+**/
+VOID
+pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
+{
+  EFI_STATUS Status;
+  EFI_SMBIOS_PROTOCOL *SmbiosProtocol = NULL;
+  EFI_SMBIOS_HANDLE SmbiosHandle = SMBIOS_HANDLE_PI_RESERVED;
+  EFI_SMBIOS_TABLE_HEADER *Record;
+  SMBIOS_TABLE_TYPE4 *Type4Record;
+  PE_SMBIOS_TYPE4_INFO *Type4Entry = NULL;
+
+  if (SmbiosTable == NULL) {
+    acs_print(ACS_PRINT_ERR, L" Input SMBIOS Table Pointer is NULL. Cannot create SMBIOS INFO\n");
+    return;
+  }
+
+  Type4Entry = SmbiosTable->type4_info;
+  SmbiosTable->slot_count = 0;
+
+  /* Get SMBIOS Protocol Handler */
+  Status = gBS->LocateProtocol(&gEfiSmbiosProtocolGuid, NULL, (VOID **)&SmbiosProtocol);
+  if (EFI_ERROR(Status)) {
+    return;
+  }
+
+  while (!EFI_ERROR(Status)) {
+    /* Get all records from SMBIOS Table */
+    Status = SmbiosProtocol->GetNext(SmbiosProtocol, &SmbiosHandle, NULL, &Record, NULL);
+    if (EFI_ERROR(Status)) {
+      return;
+    }
+
+    /* Check of record if of type 4 */
+    if (Record->Type == SMBIOS_TYPE_PROCESSOR_INFORMATION) {
+      acs_print(ACS_PRINT_DEBUG, L" Smbios type %d found\n", Record->Type);
+
+      Type4Record = (SMBIOS_TABLE_TYPE4 *)Record;
+
+      /* Save Processor family type */
+      if (Type4Record->ProcessorFamily == SMBIOS_OBTAIN_PROCESSOR_FAMILY2)
+        Type4Entry->processor_family = Type4Record->ProcessorFamily2;
+      else
+        Type4Entry->processor_family = Type4Record->ProcessorFamily;
+
+      acs_print(ACS_PRINT_DEBUG, L"  Processor Family 0x%x\n", Type4Entry->processor_family);
+
+      /* Save Processor core count */
+      if (Type4Record->CoreCount == SMBIOS_OBTAIN_CORE_COUNT2)
+        Type4Entry->core_count = Type4Record->CoreCount2;
+      else
+        Type4Entry->core_count = Type4Record->CoreCount;
+
+      acs_print(ACS_PRINT_DEBUG, L"  Processor Count 0x%x\n", Type4Entry->core_count);
+
+      Type4Entry++;
+      SmbiosTable->slot_count++;
+
+      if (SmbiosTable->slot_count >= MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED) {
+        acs_print(ACS_PRINT_WARN, L" Total Slots/Sockets 0x%x\n", SmbiosTable->slot_count);
+        acs_print(ACS_PRINT_WARN, L" Number of SMBIOS Slots greater than %d\n",
+                        MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED);
+        SmbiosTable->slot_count = MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED;
+        return;
+      }
+    }
+  }
+  acs_print(ACS_PRINT_DEBUG, L" Total Slots/Sockets 0x%x\n", SmbiosTable->slot_count);
+}
 
 /**
   @brief   Queries the FADT ACPI table to check whether PSCI is implemented and,

--- a/pal/uefi_dt/BsaPalLib.inf
+++ b/pal/uefi_dt/BsaPalLib.inf
@@ -1,5 +1,5 @@
 ## @file
-# Copyright (c) 2016-2020, 2021,2024, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2016-2020, 2021,2024-2025, Arm Limited or its affiliates. All rights reserved.
 #  SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,6 +68,7 @@
   gEfiPciIoProtocolGuid                         ## CONSUMES
   gHardwareInterrupt2ProtocolGuid               ## CONSUMES
   gEfiPciRootBridgeIoProtocolGuid               ## CONSUMES
+  gEfiSmbiosProtocolGuid                        ## CONSUMES
 
 [Guids]
   gEfiAcpi20TableGuid

--- a/pal/uefi_dt/bsa/include/pal_dt.h
+++ b/pal/uefi_dt/bsa/include/pal_dt.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2021,2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021,2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,6 +49,9 @@ pal_peripheral_sata_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
 
 VOID
 pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTable);
+
+VOID
+pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable);
 
 int
 fdt_node_offset_by_prop_name(const void *fdt, int startoffset, const char *p_name, int p_len);

--- a/pal/uefi_dt/bsa/include/pal_uefi.h
+++ b/pal/uefi_dt/bsa/include/pal_uefi.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -113,6 +113,22 @@ typedef struct {
   PE_INFO_HDR    header;
   PE_INFO_ENTRY  pe_info[];
 }PE_INFO_TABLE;
+
+/**
+  @brief  Instance of smbios type 4 processor info
+**/
+typedef struct {
+  UINT16 processor_family;
+  UINT16 core_count;
+} PE_SMBIOS_TYPE4_INFO;
+
+/**
+  @brief  Instance of smbios info
+**/
+typedef struct {
+  UINT32 slot_count;
+  PE_SMBIOS_TYPE4_INFO type4_info[];
+} PE_SMBIOS_PROCESSOR_INFO_TABLE;
 
 VOID     pal_pe_data_cache_ops_by_va(UINT64 addr, UINT32 type);
 

--- a/test_pool/pe/operating_system/test_os_c016.c
+++ b/test_pool/pe/operating_system/test_os_c016.c
@@ -1,0 +1,126 @@
+/** @file
+ * Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+#include "val/common/include/acs_val.h"
+#include "val/common/include/acs_pe.h"
+#include "val/common/include/acs_memory.h"
+
+#define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  16)
+#define TEST_RULE  "B_PE_14"
+#define TEST_DESC  "Check SVE2 for v9 PE                  "
+
+typedef struct {
+  uint64_t data;
+  uint32_t status;
+} sve_reg_details;
+
+sve_reg_details *g_sve_reg_info;
+
+static
+void
+payload()
+{
+  uint32_t pe_family;
+  uint64_t data;
+  uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+  sve_reg_details *tmp_reg_data;
+
+  tmp_reg_data = g_sve_reg_info + index;
+
+  /* Get PE family for each PE index*/
+  pe_family = val_get_pe_architecture(index);
+
+  if (pe_family == ACS_STATUS_ERR) {
+    val_set_status(index, RESULT_SKIP(TEST_NUM, 2));
+    tmp_reg_data->status = ACS_STATUS_ERR;
+    return;
+  }
+
+  /* If processor is not Armv9, FEAT_SVE2 is not required */
+  if (pe_family != PROCESSOR_FAMILY_ARMV9) {
+    val_set_status(index, RESULT_SKIP(TEST_NUM, 3));
+    tmp_reg_data->status = ACS_STATUS_SKIP;
+    return;
+  }
+
+ /* Read ID_AA64ZFR0_EL1 for SVE2 support */
+  data = val_pe_reg_read(ID_AA64ZFR0_EL1);
+  tmp_reg_data->data = data;
+
+  /* For Armv9, the ID_AA64ZFR0_EL1.SVEver, bits [3:0] value 0b0000 is not permitted */
+  if (VAL_EXTRACT_BITS(data, 0, 3) == 0) {
+    val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
+    tmp_reg_data->status = ACS_STATUS_FAIL;
+    return;
+  }
+
+  val_set_status(index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+os_c016_entry(uint32_t num_pe)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;  //default value
+  uint32_t i, smbios_slots, index = val_pe_get_index_mpid(val_pe_get_mpid());
+  sve_reg_details *reg_buffer;
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
+
+  smbios_slots = val_get_num_smbios_slots();
+  if (smbios_slots == 0) {
+    val_print(ACS_PRINT_WARN, "\n       SMBIOS Table Not Found, Skipping the test\n", 0);
+    status = ACS_STATUS_SKIP;
+    val_set_status(index, RESULT_SKIP(TEST_NUM, 1));
+
+    /* get the result from all PE and check for failure */
+    status = val_check_for_error(TEST_NUM, 1, TEST_RULE);
+  }
+
+  /* This check is when user is forcing us to skip this test */
+  if (status != ACS_STATUS_SKIP) {
+    g_sve_reg_info = (sve_reg_details *) val_memory_calloc(num_pe, sizeof(sve_reg_details));
+    if (g_sve_reg_info == NULL) {
+      val_print(ACS_PRINT_ERR, "\n       Memory Allocation for SVE Register data Failed", 0);
+      return ACS_STATUS_FAIL;
+    }
+
+    val_run_test_payload(TEST_NUM, num_pe, payload, 0);
+
+    for (i = 0; i < num_pe; i++) {
+      reg_buffer = g_sve_reg_info + i;
+      val_print(ACS_PRINT_DEBUG, "\n       PE Index = %d", i);
+
+      if (reg_buffer->status == ACS_STATUS_SKIP)
+        val_print(ACS_PRINT_DEBUG, "\n       Processor is not v9, Skipping the test", 0);
+      else if (reg_buffer->status == ACS_STATUS_FAIL)
+        val_print(ACS_PRINT_DEBUG, "\n       Reg Value = 0x%llx  FAIL", reg_buffer->data);
+      else if (reg_buffer->status == ACS_STATUS_ERR)
+        val_print(ACS_PRINT_DEBUG, "\n       Processor Family Not Found in SMBIOS Table", 0);
+      else
+        val_print(ACS_PRINT_DEBUG, "\n       Reg Value = 0x%llx  PASS", reg_buffer->data);
+    }
+
+    val_memory_free((void *) g_sve_reg_info);
+
+    /* get the result from all PE and check for failure */
+    status = val_check_for_error(TEST_NUM, num_pe, TEST_RULE);
+  }
+
+  val_report_status(0, ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/uefi_app/BsaAcs.h
+++ b/uefi_app/BsaAcs.h
@@ -18,44 +18,44 @@
 #ifndef __BSA_ACS_LEVEL_H__
 #define __BSA_ACS_LEVEL_H__
 
+#define BSA_ACS_MAJOR_VER       1
+#define BSA_ACS_MINOR_VER       0
+#define BSA_ACS_SUBMINOR_VER    9
 
+#define G_PRINT_LEVEL ACS_PRINT_TEST
 
-  #define BSA_ACS_MAJOR_VER      1
-  #define BSA_ACS_MINOR_VER      0
-  #define BSA_ACS_SUBMINOR_VER   9
+#define G_SW_OS                 0
+#define G_SW_HYP                1
+#define G_SW_PS                 2
 
-  #define G_PRINT_LEVEL ACS_PRINT_TEST
+#define SIZE_4K                 0x1000
 
-  #define G_SW_OS            0
-  #define G_SW_HYP           1
-  #define G_SW_PS            2
+/* Note : Total Size Required for Info tables ~ 550 KB
+  * Table size is required to be updated whenever new members
+  * are added in the info table structures
+  */
 
-  /* Note : Total Size Required for Info tables ~ 550 KB
-   * Table size is required to be updated whenever new members
-   * are added in the info table structures
-   */
+/* Please MAKE SURE all the table sizes are 16 Bytes aligned */
+#define PE_INFO_TBL_SZ          16384  /*Supports max 400 PEs     */
+                                       /*[24 B Each + 4 B Header] */
+#define GIC_INFO_TBL_SZ         240000 /*Supports max 832 GIC info (GICH,CPUIF,RD,ITS,MSI,D)*/
+                                       /*[48 B Each + 32 B Header]*/
+#define TIMER_INFO_TBL_SZ       2048   /*Supports max 4 system timers*/
+                                       /*[248 B Each + 56 B Header]  */
+#define WD_INFO_TBL_SZ          512    /*Supports max 20 Watchdogs*/
+                                       /*[24 B Each + 4 B Header] */
+#define MEM_INFO_TBL_SZ         32768  /*Supports max 800 memory regions*/
+                                       /*[40 B Each + 16 B Header]      */
+#define IOVIRT_INFO_TBL_SZ      1048576/*Supports max 2400 nodes of a typical iort table*/
+                                       /*[(268+32*5) B Each + 24 B Header]*/
+#define PERIPHERAL_INFO_TBL_SZ  2048   /*Supports max 20 PCIe EPs (USB and SATA controllers)*/
+                                       /*[72 B Each + 16 B Header]*/
+#define PCIE_INFO_TBL_SZ        1024   /*Supports max 40 RC's    */
+                                       /*[24 B Each + 4 B Header]*/
 
-  /* Please MAKE SURE all the table sizes are 16 Bytes aligned */
-  #define PE_INFO_TBL_SZ         16384  /*Supports max 400 PEs     */
-                                        /*[24 B Each + 4 B Header] */
-  #define GIC_INFO_TBL_SZ        240000 /*Supports max 832 GIC info (GICH,CPUIF,RD,ITS,MSI,D)*/
-                                        /*[48 B Each + 32 B Header]*/
-  #define TIMER_INFO_TBL_SZ      2048   /*Supports max 4 system timers*/
-                                        /*[248 B Each + 56 B Header]  */
-  #define WD_INFO_TBL_SZ         512    /*Supports max 20 Watchdogs*/
-                                        /*[24 B Each + 4 B Header] */
-  #define MEM_INFO_TBL_SZ        32768  /*Supports max 800 memory regions*/
-                                        /*[40 B Each + 16 B Header]      */
-  #define IOVIRT_INFO_TBL_SZ     1048576/*Supports max 2400 nodes of a typical iort table*/
-                                        /*[(268+32*5) B Each + 24 B Header]*/
-  #define PERIPHERAL_INFO_TBL_SZ 2048   /*Supports max 20 PCIe EPs (USB and SATA controllers)*/
-                                        /*[72 B Each + 16 B Header]*/
-  #define PCIE_INFO_TBL_SZ       1024   /*Supports max 40 RC's    */
-                                        /*[24 B Each + 4 B Header]*/
-
-  #ifdef _AARCH64_BUILD_
-  unsigned long __stack_chk_guard = 0xBAAAAAAD;
-  unsigned long __stack_chk_fail =  0xBAAFAAAD;
-  #endif
+#ifdef _AARCH64_BUILD_
+unsigned long __stack_chk_guard = 0xBAAAAAAD;
+unsigned long __stack_chk_fail =  0xBAAFAAAD;
+#endif
 
 #endif

--- a/uefi_app/BsaAcs.h
+++ b/uefi_app/BsaAcs.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -52,6 +52,8 @@
                                        /*[72 B Each + 16 B Header]*/
 #define PCIE_INFO_TBL_SZ        1024   /*Supports max 40 RC's    */
                                        /*[24 B Each + 4 B Header]*/
+#define SMBIOS_INFO_TBL_SZ      1024   /*Supports max 16 Processor Slots/Sockets*/
+                                       /*[64 B Each]*/
 
 #ifdef _AARCH64_BUILD_
 unsigned long __stack_chk_guard = 0xBAAAAAAD;

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -44,6 +44,7 @@
   ../test_pool/pe/operating_system/test_os_c012.c
   ../test_pool/pe/operating_system/test_os_c013.c
   ../test_pool/pe/operating_system/test_os_c014.c
+  ../test_pool/pe/operating_system/test_os_c016.c
   ../test_pool/pe/hypervisor/test_hyp_c001.c
   ../test_pool/pe/hypervisor/test_hyp_c002.c
   ../test_pool/pe/hypervisor/test_hyp_c003.c
@@ -162,6 +163,7 @@
   gEfiCpuArchProtocolGuid                       ## CONSUMES
   gEfiPciIoProtocolGuid                         ## CONSUMES
   gEfiLoadedImageProtocolGuid                   ## CONSUMES
+  gEfiSmbiosProtocolGuid                        ## CONSUMES
 
 [Guids]
   gEfiAcpi20TableGuid

--- a/uefi_app/BsaAcsMain.c
+++ b/uefi_app/BsaAcsMain.c
@@ -166,6 +166,17 @@ createPeripheralInfoTable(
 }
 
 VOID
+createSmbiosInfoTable(
+)
+{
+  UINT64 *SmbiosInfoTable;
+
+  SmbiosInfoTable = val_aligned_alloc(SIZE_4K, SMBIOS_INFO_TBL_SZ);
+
+  val_smbios_create_info_table(SmbiosInfoTable);
+}
+
+VOID
 freeBsaAcsMem()
 {
   val_pe_free_info_table();
@@ -175,6 +186,7 @@ freeBsaAcsMem()
   val_pcie_free_info_table();
   val_iovirt_free_info_table();
   val_peripheral_free_info_table();
+  val_smbios_free_info_table();
   val_free_shared_mem();
 }
 
@@ -529,6 +541,7 @@ ShellAppMain (
   createWatchdogInfoTable();
   createPcieVirtInfoTable();
   createPeripheralInfoTable();
+  createSmbiosInfoTable();
 
   val_allocate_shared_mem();
 

--- a/uefi_app/BsaAcsMain.c
+++ b/uefi_app/BsaAcsMain.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,20 +20,18 @@
 #include  <Library/ShellCEntryLib.h>
 #include  <Library/ShellLib.h>
 #include  <Library/UefiBootServicesTableLib.h>
-#include  <Library/CacheMaintenanceLib.h>
-#include  <Protocol/LoadedImage.h>
 
 #include "val/common/include/val_interface.h"
 #include "val/bsa/include/bsa_val_interface.h"
 #include "val/bsa/include/bsa_acs_pe.h"
 #include "val/common/include/acs_pe.h"
 #include "val/common/include/acs_val.h"
+#include "val/common/include/acs_memory.h"
 
 #include "BsaAcs.h"
 
-UINT32 g_pcie_p2p;
-UINT32 g_pcie_cache_present;
-
+UINT32  g_pcie_p2p;
+UINT32  g_pcie_cache_present;
 UINT32  g_print_level;
 UINT32  g_sw_view[3] = {1, 1, 1}; //Operating System, Hypervisor, Platform Security
 UINT32  *g_skip_test_num;
@@ -84,172 +82,92 @@ STATIC VOID FlushImage (VOID)
 
 }
 
-EFI_STATUS
+UINT32
 createPeInfoTable (
 )
 {
+  UINT32 Status;
+  UINT64 *PeInfoTable;
 
-  EFI_STATUS Status;
-
-  UINT64   *PeInfoTable;
-
-/* allowing room for growth, at present each entry is 16 bytes, so we can support upto 511 PEs with 8192 bytes*/
-  Status = gBS->AllocatePool ( EfiBootServicesData,
-                               PE_INFO_TBL_SZ,
-                               (VOID **) &PeInfoTable );
-
-  if (EFI_ERROR(Status))
-  {
-    Print(L"Allocate Pool failed %x\n", Status);
-    return Status;
-  }
+  PeInfoTable = val_aligned_alloc(SIZE_4K, PE_INFO_TBL_SZ);
 
   Status = val_pe_create_info_table(PeInfoTable);
 
   return Status;
-
 }
 
-EFI_STATUS
+UINT32
 createGicInfoTable (
 )
 {
-  EFI_STATUS Status;
-  UINT64     *GicInfoTable;
+  UINT32 Status;
+  UINT64 *GicInfoTable;
 
-  Status = gBS->AllocatePool (EfiBootServicesData,
-                               GIC_INFO_TBL_SZ,
-                               (VOID **) &GicInfoTable);
-
-  if (EFI_ERROR(Status))
-  {
-    Print(L"Allocate Pool failed %x\n", Status);
-    return Status;
-  }
+  GicInfoTable = val_aligned_alloc(SIZE_4K, GIC_INFO_TBL_SZ);
 
   Status = val_gic_create_info_table(GicInfoTable);
-
-  return Status;
-
-}
-
-EFI_STATUS
-createTimerInfoTable(
-)
-{
-  UINT64   *TimerInfoTable;
-  EFI_STATUS Status;
-
-  Status = gBS->AllocatePool (EfiBootServicesData,
-                              TIMER_INFO_TBL_SZ,
-                              (VOID **) &TimerInfoTable);
-
-  if (EFI_ERROR(Status))
-  {
-    Print(L"Allocate Pool failed %x\n", Status);
-    return Status;
-  }
-  val_timer_create_info_table(TimerInfoTable);
-
-  return Status;
-}
-
-EFI_STATUS
-createWatchdogInfoTable(
-)
-{
-  UINT64   *WdInfoTable;
-  EFI_STATUS Status;
-
-  Status = gBS->AllocatePool (EfiBootServicesData,
-                              WD_INFO_TBL_SZ,
-                              (VOID **) &WdInfoTable);
-
-  if (EFI_ERROR(Status))
-  {
-    Print(L"Allocate Pool failed %x\n", Status);
-    return Status;
-  }
-  val_wd_create_info_table(WdInfoTable);
-
-  return Status;
-
-}
-
-
-EFI_STATUS
-createPcieVirtInfoTable(
-)
-{
-  UINT64   *PcieInfoTable;
-  UINT64   *IoVirtInfoTable;
-
-  EFI_STATUS Status;
-
-  Status = gBS->AllocatePool (EfiBootServicesData,
-                              PCIE_INFO_TBL_SZ,
-                              (VOID **) &PcieInfoTable);
-
-  if (EFI_ERROR(Status))
-  {
-    Print(L"Allocate Pool failed %x\n", Status);
-    return Status;
-  }
-  val_pcie_create_info_table(PcieInfoTable);
-
-  Status = gBS->AllocatePool (EfiBootServicesData,
-                              IOVIRT_INFO_TBL_SZ,
-                              (VOID **) &IoVirtInfoTable);
-
-  if (EFI_ERROR(Status))
-  {
-    Print(L"Allocate Pool failed %x\n", Status);
-    return Status;
-  }
-  val_iovirt_create_info_table(IoVirtInfoTable);
-
-  return Status;
-}
-
-EFI_STATUS
-createPeripheralInfoTable(
-)
-{
-  UINT64   *PeripheralInfoTable;
-  UINT64   *MemoryInfoTable;
-
-  EFI_STATUS Status;
-
-  Status = gBS->AllocatePool (EfiBootServicesData,
-                              PERIPHERAL_INFO_TBL_SZ,
-                              (VOID **) &PeripheralInfoTable);
-
-  if (EFI_ERROR(Status))
-  {
-    Print(L"Allocate Pool failed %x\n", Status);
-    return Status;
-  }
-  val_peripheral_create_info_table(PeripheralInfoTable);
-
-  Status = gBS->AllocatePool (EfiBootServicesData,
-                              MEM_INFO_TBL_SZ,
-                              (VOID **) &MemoryInfoTable);
-
-  if (EFI_ERROR(Status))
-  {
-    Print(L"Allocate Pool failed %x\n", Status);
-    return Status;
-  }
-
-  val_memory_create_info_table(MemoryInfoTable);
 
   return Status;
 }
 
 VOID
+createTimerInfoTable(
+)
+{
+  UINT64 *TimerInfoTable;
+
+  TimerInfoTable = val_aligned_alloc(SIZE_4K, TIMER_INFO_TBL_SZ);
+
+  val_timer_create_info_table(TimerInfoTable);
+}
+
+VOID
+createWatchdogInfoTable(
+)
+{
+  UINT64 *WdInfoTable;
+
+  WdInfoTable = val_aligned_alloc(SIZE_4K, WD_INFO_TBL_SZ);
+
+  val_wd_create_info_table(WdInfoTable);
+}
+
+
+VOID
+createPcieVirtInfoTable(
+)
+{
+  UINT64 *PcieInfoTable;
+  UINT64 *IoVirtInfoTable;
+
+  PcieInfoTable   = val_aligned_alloc(SIZE_4K, PCIE_INFO_TBL_SZ);
+
+  val_pcie_create_info_table(PcieInfoTable);
+
+  IoVirtInfoTable = val_aligned_alloc(SIZE_4K, IOVIRT_INFO_TBL_SZ);
+
+  val_iovirt_create_info_table(IoVirtInfoTable);
+}
+
+VOID
+createPeripheralInfoTable(
+)
+{
+  UINT64 *PeripheralInfoTable;
+  UINT64 *MemoryInfoTable;
+
+  PeripheralInfoTable = val_aligned_alloc(SIZE_4K, PERIPHERAL_INFO_TBL_SZ);
+
+  val_peripheral_create_info_table(PeripheralInfoTable);
+
+  MemoryInfoTable = val_aligned_alloc(SIZE_4K, MEM_INFO_TBL_SZ);
+
+  val_memory_create_info_table(MemoryInfoTable);
+}
+
+VOID
 freeBsaAcsMem()
 {
-
   val_pe_free_info_table();
   val_gic_free_info_table();
   val_timer_free_info_table();

--- a/uefi_app/BsaAcsMem.inf
+++ b/uefi_app/BsaAcsMem.inf
@@ -44,6 +44,7 @@
   ../test_pool/pe/operating_system/test_os_c012.c
   ../test_pool/pe/operating_system/test_os_c013.c
   ../test_pool/pe/operating_system/test_os_c014.c
+  ../test_pool/pe/operating_system/test_os_c016.c
   ../test_pool/pe/hypervisor/test_hyp_c001.c
   ../test_pool/pe/hypervisor/test_hyp_c002.c
   ../test_pool/pe/hypervisor/test_hyp_c003.c
@@ -196,6 +197,7 @@
   gEfiCpuArchProtocolGuid                       ## CONSUMES
   gEfiPciIoProtocolGuid                         ## CONSUMES
   gEfiLoadedImageProtocolGuid                   ## CONSUMES
+  gEfiSmbiosProtocolGuid                        ## CONSUMES
 
 [Guids]
   gEfiAcpi20TableGuid

--- a/val/bsa/include/bsa_acs_pe.h
+++ b/val/bsa/include/bsa_acs_pe.h
@@ -34,10 +34,6 @@ uint32_t os_c013_entry(uint32_t num_pe);
 uint32_t os_c014_entry(uint32_t num_pe);
 uint32_t os_c015_entry(uint32_t num_pe);
 uint32_t os_c016_entry(uint32_t num_pe);
-uint32_t os_c017_entry(uint32_t num_pe);
-uint32_t os_c018_entry(uint32_t num_pe);
-uint32_t os_c019_entry(uint32_t num_pe);
-uint32_t os_c020_entry(uint32_t num_pe);
 
 uint32_t hyp_c001_entry(uint32_t num_pe);
 uint32_t hyp_c002_entry(uint32_t num_pe);

--- a/val/bsa/src/bsa_execute_test.c
+++ b/val/bsa/src/bsa_execute_test.c
@@ -91,6 +91,8 @@ val_bsa_pe_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
       status |= os_c013_entry(num_pe);
 if (!g_build_sbsa) { /* B_PE_15 is only in BSA checklist */
       status |= os_c014_entry(num_pe);
+
+      status |= os_c016_entry(num_pe);
 }
   }
 

--- a/val/common/include/acs_pe.h
+++ b/val/common/include/acs_pe.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2020,2022-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2020,2022-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,9 @@
 
 #ifndef __ACS_PE_H__
 #define __ACS_PE_H__
+
+/* Processor Family Type 4 */
+#define PROCESSOR_FAMILY_ARMV9         0x102
 
 #define MPIDR_AFF_MASK           (0xFF00FFFFFF)
 #define INVALID_PE_INFO          (0xDEADDEAD)

--- a/val/common/include/pal_interface.h
+++ b/val/common/include/pal_interface.h
@@ -239,6 +239,24 @@ typedef struct {
   uint64_t  Arg7;
 } ARM_SMC_ARGS;
 
+/**
+  @brief  Instance of smbios type 4 processor info
+**/
+typedef struct {
+  uint16_t processor_family;
+  uint16_t core_count;
+} PE_SMBIOS_TYPE4_INFO;
+
+/**
+  @brief  Instance of smbios info
+**/
+typedef struct {
+  uint32_t slot_count;
+  PE_SMBIOS_TYPE4_INFO type4_info[];
+} PE_SMBIOS_PROCESSOR_INFO_TABLE;
+
+void pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable);
+
 void pal_pe_call_smc(ARM_SMC_ARGS *args, int32_t conduit);
 void pal_pe_execute_payload(ARM_SMC_ARGS *args);
 uint32_t pal_pe_install_esr(uint32_t exception_type, void (*esr)(uint64_t, void *));

--- a/val/common/include/val_interface.h
+++ b/val/common/include/val_interface.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -74,6 +74,10 @@ uint32_t val_pe_get_index_mpid(uint64_t mpid);
 uint32_t val_pe_install_esr(uint32_t exception_type, void (*esr)(uint64_t, void *));
 uint32_t val_pe_get_primary_index(void);
 uint64_t val_get_primary_mpidr(void);
+uint32_t val_get_pe_architecture(uint32_t index);
+void     val_smbios_create_info_table(uint64_t *smbios_info_table);
+void     val_smbios_free_info_table(void);
+uint32_t val_get_num_smbios_slots(void);
 
 void     val_execute_on_pe(uint32_t index, void (*payload)(void), uint64_t args);
 

--- a/val/common/src/acs_gic.c
+++ b/val/common/src/acs_gic.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -91,7 +91,7 @@ val_gic_create_info_table(uint64_t *gic_info_table)
 void
 val_gic_free_info_table(void)
 {
-  pal_mem_free((void *)g_gic_info_table);
+  pal_mem_free_aligned((void *)g_gic_info_table);
 }
 
 /**

--- a/val/common/src/acs_iovirt.c
+++ b/val/common/src/acs_iovirt.c
@@ -307,7 +307,7 @@ val_iovirt_create_info_table(uint64_t *iovirt_info_table)
 void
 val_iovirt_free_info_table()
 {
-  pal_mem_free((void *)g_iovirt_info_table);
+  pal_mem_free_aligned((void *)g_iovirt_info_table);
 }
 
 /**

--- a/val/common/src/acs_pcie.c
+++ b/val/common/src/acs_pcie.c
@@ -715,7 +715,7 @@ val_pcie_bdf_table_ptr()
 void
 val_pcie_free_info_table()
 {
-  pal_mem_free((void *)g_pcie_info_table);
+  pal_mem_free_aligned((void *)g_pcie_info_table);
 }
 
 

--- a/val/common/src/acs_pe_infra.c
+++ b/val/common/src/acs_pe_infra.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2020-2021,2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2020-2021,2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -111,7 +111,7 @@ val_print(ACS_PRINT_TEST, " Primary PE: MIDR_EL1                 :    0x%llx \n"
 void
 val_pe_free_info_table()
 {
-  pal_mem_free((void *)g_pe_info_table);
+  pal_mem_free_aligned((void *)g_pe_info_table);
 }
 
 /**

--- a/val/common/src/acs_peripherals.c
+++ b/val/common/src/acs_peripherals.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -308,5 +308,5 @@ val_peripheral_create_info_table(uint64_t *peripheral_info_table)
 void
 val_peripheral_free_info_table()
 {
-  pal_mem_free((void *)g_peripheral_info_table);
+  pal_mem_free_aligned((void *)g_peripheral_info_table);
 }

--- a/val/common/src/acs_timer.c
+++ b/val/common/src/acs_timer.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2019, 2021-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019, 2021-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -296,5 +296,5 @@ val_timer_create_info_table(uint64_t *timer_info_table)
 void
 val_timer_free_info_table()
 {
-  pal_mem_free((void *)g_timer_info_table);
+  pal_mem_free_aligned((void *)g_timer_info_table);
 }

--- a/val/common/src/acs_wd.c
+++ b/val/common/src/acs_wd.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -93,5 +93,5 @@ val_wd_create_info_table(uint64_t *wd_info_table)
 void
 val_wd_free_info_table()
 {
-  pal_mem_free((void *)g_wd_info_table);
+  pal_mem_free_aligned((void *)g_wd_info_table);
 }

--- a/val/sbsa/src/sbsa_acs_mpam.c
+++ b/val/sbsa/src/sbsa_acs_mpam.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -686,7 +686,7 @@ val_mpam_create_info_table(uint64_t *mpam_info_table)
 void
 val_mpam_free_info_table(void)
 {
-  pal_mem_free((void *)g_mpam_info_table);
+  pal_mem_free_aligned((void *)g_mpam_info_table);
 }
 
 /**
@@ -724,7 +724,7 @@ val_hmat_create_info_table(uint64_t *hmat_info_table)
 void
 val_hmat_free_info_table(void)
 {
-    pal_mem_free((void *)g_hmat_info_table);
+    pal_mem_free_aligned((void *)g_hmat_info_table);
 }
 
 /**
@@ -762,7 +762,7 @@ val_srat_create_info_table(uint64_t *srat_info_table)
 void
 val_srat_free_info_table(void)
 {
-    pal_mem_free((void *)g_srat_info_table);
+    pal_mem_free_aligned((void *)g_srat_info_table);
 }
 
 /**

--- a/val/sbsa/src/sbsa_acs_pcc.c
+++ b/val/sbsa/src/sbsa_acs_pcc.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -185,5 +185,5 @@ void
 void
 val_pcc_free_info_table(void)
 {
-  pal_mem_free((void *)g_pcc_info_table);
+  pal_mem_free_aligned((void *)g_pcc_info_table);
 }

--- a/val/sbsa/src/sbsa_acs_pe.c
+++ b/val/sbsa/src/sbsa_acs_pe.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -71,7 +71,7 @@ val_cache_create_info_table(uint64_t *cache_info_table)
 void
 val_cache_free_info_table(void)
 {
-  pal_mem_free((void *)g_cache_info_table);
+  pal_mem_free_aligned((void *)g_cache_info_table);
 }
 
 /**

--- a/val/sbsa/src/sbsa_acs_pmu.c
+++ b/val/sbsa/src/sbsa_acs_pmu.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,7 +55,7 @@ val_pmu_create_info_table(uint64_t *pmu_info_table)
 void
 val_pmu_free_info_table()
 {
-  pal_mem_free((void *)g_pmu_info_table);
+  pal_mem_free_aligned((void *)g_pmu_info_table);
   g_pmu_info_table = NULL;
 }
 

--- a/val/sbsa/src/sbsa_acs_ras.c
+++ b/val/sbsa/src/sbsa_acs_ras.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -97,7 +97,7 @@ return;
 void
 val_ras2_free_info_table()
 {
-  pal_mem_free((void *)g_ras2_info_table);
+  pal_mem_free_aligned((void *)g_ras2_info_table);
 }
 
 /**


### PR DESCRIPTION
 - Added new pe test to check for FEAT_SVE2 if pe is armv9
 - Implimented pal for uefi, dt and baremetel
 - Implimented val support for smbios table creation