### PR TITLE
Preserve memory ordering for PCIe writes

### DIFF
--- a/val/common/include/acs_memory.h
+++ b/val/common/include/acs_memory.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2021, 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2021, 2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,4 +38,6 @@ void *val_aligned_alloc(uint32_t alignment, uint32_t size);
 void val_memory_free_aligned(void *addr);
 uint32_t val_memory_region_has_52bit_addr(void);
 
+void AA64IssueDSB(void);
+void val_mem_issue_dsb(void);
 #endif // __ACS_PERIPHERAL_H__

--- a/val/common/src/AArch64/PeTestSupport.S
+++ b/val/common/src/AArch64/PeTestSupport.S
@@ -1,5 +1,5 @@
 #/** @file
-# Copyright (c) 2016-2019, 2022-2024, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2016-2019, 2022-2025, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,6 @@
 #
 #**/
 
-#ifdef TARGET_EMULATION
 /* Private worker functions for ASM_PFX() */
 #define _CONCATENATE(a, b)  __CONCATENATE(a, b)
 #define __CONCATENATE(a, b) a ## b
@@ -33,8 +32,6 @@
 
 #define GCC_ASM_IMPORT(func__)  \
        .extern  _CONCATENATE (__USER_LABEL_PREFIX__, func__)
-#endif
-
 
 .text
 .align 3
@@ -43,6 +40,7 @@ GCC_ASM_EXPORT (ArmCallWFI)
 GCC_ASM_EXPORT (SpeProgramUnderProfiling)
 GCC_ASM_EXPORT (DisableSpe)
 GCC_ASM_EXPORT (ArmExecuteMemoryBarrier)
+GCC_ASM_EXPORT (AA64IssueDSB)
 
 ASM_PFX(ArmCallWFI):
   wfi
@@ -87,4 +85,8 @@ ASM_PFX(DisableSpe):
 
 ASM_PFX(ArmExecuteMemoryBarrier):
   dmb sy
+  ret
+
+ASM_PFX(AA64IssueDSB):
+  dsb sy
   ret

--- a/val/common/src/acs_exerciser.c
+++ b/val/common/src/acs_exerciser.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@
 #include "common/include/acs_pcie.h"
 #include "common/include/acs_smmu.h"
 #include "common/include/acs_iovirt.h"
+#include "common/include/acs_memory.h"
 
 EXERCISER_INFO_TABLE g_exerciser_info_table;
 
@@ -103,8 +104,12 @@ uint32_t val_exerciser_get_info(EXERCISER_INFO_TYPE type)
 uint32_t val_exerciser_set_param(EXERCISER_PARAM_TYPE type, uint64_t value1, uint64_t value2,
                                  uint32_t instance)
 {
-    return pal_exerciser_set_param(type, value1, value2,
+    uint32_t status;
+
+    status = pal_exerciser_set_param(type, value1, value2,
                                    g_exerciser_info_table.e_info[instance].bdf);
+    val_mem_issue_dsb();
+    return status;
 }
 
 /**
@@ -190,7 +195,11 @@ uint32_t val_exerciser_init(uint32_t instance)
 **/
 uint32_t val_exerciser_ops(EXERCISER_OPS ops, uint64_t param, uint32_t instance)
 {
-    return pal_exerciser_ops(ops, param, g_exerciser_info_table.e_info[instance].bdf);
+    uint32_t status;
+
+    status = pal_exerciser_ops(ops, param, g_exerciser_info_table.e_info[instance].bdf);
+    val_mem_issue_dsb();
+    return status;
 }
 
 /**

--- a/val/common/src/acs_memory.c
+++ b/val/common/src/acs_memory.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -374,4 +374,17 @@ uint32_t val_memory_region_has_52bit_addr(void)
   }
 
   return 0;
+}
+
+/**
+  @brief   This API issues a DSB Memory barrier instruction
+  @param   None
+  @return  None
+**/
+void
+val_mem_issue_dsb(void)
+{
+#ifndef TARGET_LINUX
+    AA64IssueDSB();
+#endif
 }

--- a/val/common/src/acs_pcie.c
+++ b/val/common/src/acs_pcie.c
@@ -18,7 +18,7 @@
 #include "common/include/acs_val.h"
 #include "common/include/acs_common.h"
 #include "common/include/acs_pcie_enumeration.h"
-
+#include "common/include/acs_memory.h"
 #include "common/include/val_interface.h"
 #include "common/include/acs_pcie.h"
 #include "common/sys_arch_src/pcie/pcie.h"
@@ -161,6 +161,7 @@ val_pcie_write_cfg(uint32_t bdf, uint32_t offset, uint32_t data)
                (dev * PCIE_MAX_FUNC * 4096) + (func * 4096);
 
   pal_mmio_write(ecam_base + cfg_addr + offset, data);
+  val_mem_issue_dsb();
 }
 
 /**
@@ -177,7 +178,10 @@ val_pcie_write_cfg(uint32_t bdf, uint32_t offset, uint32_t data)
 void
 val_pcie_io_write_cfg(uint32_t bdf, uint32_t offset, uint32_t data)
 {
-    return pal_pcie_io_write_cfg(bdf, offset, data);
+
+    pal_pcie_io_write_cfg(bdf, offset, data);
+    val_mem_issue_dsb();
+    return;
 }
 
 /**
@@ -192,7 +196,11 @@ val_pcie_io_write_cfg(uint32_t bdf, uint32_t offset, uint32_t data)
 uint32_t
 val_pcie_bar_mem_write(uint32_t bdf, uint64_t offset, uint32_t data)
 {
-    return pal_pcie_bar_mem_write(bdf, offset, data);
+    uint32_t status;
+
+    status = pal_pcie_bar_mem_write(bdf, offset, data);
+    val_mem_issue_dsb();
+    return status;
 }
 
 /**

--- a/val/sbsa/include/sbsa_acs_mpam.h
+++ b/val/sbsa/include/sbsa_acs_mpam.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,7 +63,6 @@ uint64_t val_mpam_reg_read(MPAM_SYS_REGS reg_id);
 uint64_t AA64ReadMpamidr(void);
 uint64_t AA64ReadMpam1(void);
 uint64_t AA64ReadMpam2(void);
-void AA64IssueDSB(void);
 void AA64WriteMpam1(uint64_t write_data);
 void AA64WriteMpam2(uint64_t write_data);
 
@@ -93,7 +92,6 @@ uint32_t val_mpam_msc_get_version(uint32_t msc_index);
 uint32_t val_mpam_get_max_pmg(uint32_t msc_index);
 void val_mpam_configure_cpor(uint32_t msc_index, uint16_t partid, uint32_t cpbm_percentage);
 uint32_t val_mpam_get_cpbm_width(uint32_t msc_index);
-void val_mem_issue_dsb(void);
 void val_mpam_configure_csu_mon(uint32_t msc_index, uint16_t partid, uint8_t pmg, uint16_t mon_sel);
 void val_mpam_csumon_enable(uint32_t msc_index);
 void val_mpam_csumon_disable(uint32_t msc_index);

--- a/val/sbsa/src/AArch64/MpamSupport.S
+++ b/val/sbsa/src/AArch64/MpamSupport.S
@@ -1,5 +1,5 @@
 #/** @file
-# Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,8 +44,6 @@ GCC_ASM_EXPORT(AA64WriteMpam1)
 GCC_ASM_EXPORT(AA64ReadMpam2)
 GCC_ASM_EXPORT(AA64WriteMpam2)
 GCC_ASM_EXPORT(AA64ReadMpamidr)
-GCC_ASM_EXPORT(AA64IssueDSB)
-
 
 ASM_PFX(AA64ReadMpam1):
   mrs  x0, mpam1_el1
@@ -65,10 +63,6 @@ ASM_PFX(AA64WriteMpam2):
 
 ASM_PFX(AA64ReadMpamidr):
   mrs  x0, mpamidr_el1
-  ret
-
-ASM_PFX(AA64IssueDSB):
-  dsb sy
   ret
 
 #ifndef TARGET_EMULATION

--- a/val/sbsa/src/sbsa_acs_mpam.c
+++ b/val/sbsa/src/sbsa_acs_mpam.c
@@ -15,9 +15,10 @@
  * limitations under the License.
  **/
 
-#include "sbsa/include/sbsa_val_interface.h"
 #include "common/include/acs_val.h"
 #include "common/include/acs_common.h"
+#include "common/include/acs_memory.h"
+#include "sbsa/include/sbsa_val_interface.h"
 #include "sbsa/include/sbsa_acs_mpam.h"
 #include "sbsa/include/sbsa_acs_mpam_reg.h"
 
@@ -850,17 +851,6 @@ val_mpam_get_cpbm_width(uint32_t msc_index)
         return BITFIELD_READ(CPOR_IDR_CPBM_WD, val_mpam_mmr_read(msc_index, REG_MPAMF_CPOR_IDR));
     else
         return 0;
-}
-
-/**
-  @brief   This API issues a DSB Memory barrier instruction
-  @param   None
-  @return  None
-**/
-void
-val_mem_issue_dsb(void)
-{
-    AA64IssueDSB();
 }
 
 /**


### PR DESCRIPTION
- Fixes #422
- Update copyright years to 2025
- Writes to PCIe address can go out of order due to support of weak memory modelling
- Adding DSB SY instruction after every PCIe write to ensure the writes are successful before execution of next instruction