### PR TITLE
Fix for Uefi Print Lib Issue in DRTM

### DIFF
--- a/drtm/test_pool/dl/test_dl001.c
+++ b/drtm/test_pool/dl/test_dl001.c
@@ -76,6 +76,7 @@ payload(uint32_t num_pe)
   if (status != DRTM_ACS_INVALID_PARAMETERS) {
     val_print(ACS_PRINT_ERR, "\n       Incorrect Status. Expected = -2 Found = %d", status);
     val_set_status(index, RESULT_FAIL(TEST_NUM, 4));
+    drtm_params->dlme_region_address = drtm_params->dlme_region_address - 0x4;
     goto free_dlme_region;
   }
   drtm_params->dlme_region_address = drtm_params->dlme_region_address - 0x4;
@@ -87,6 +88,7 @@ payload(uint32_t num_pe)
   if (status != DRTM_ACS_INVALID_PARAMETERS) {
     val_print(ACS_PRINT_ERR, "\n       Incorrect Status. Expected = -2 Found = %d", status);
     val_set_status(index, RESULT_FAIL(TEST_NUM, 5));
+    drtm_params->dlme_image_start = drtm_params->dlme_image_start - 0x4;
     goto free_dlme_region;
   }
   drtm_params->dlme_image_start = drtm_params->dlme_image_start - 0x4;
@@ -98,6 +100,7 @@ payload(uint32_t num_pe)
   if (status != DRTM_ACS_INVALID_PARAMETERS) {
     val_print(ACS_PRINT_ERR, "\n       Incorrect Status. Expected = -2 Found = %d", status);
     val_set_status(index, RESULT_FAIL(TEST_NUM, 6));
+    drtm_params->dlme_data_offset = drtm_params->dlme_data_offset - 0x4;
     goto free_dlme_region;
   }
   drtm_params->dlme_data_offset = drtm_params->dlme_data_offset - 0x4;
@@ -113,6 +116,9 @@ payload(uint32_t num_pe)
   if (status != DRTM_ACS_INVALID_PARAMETERS) {
     val_print(ACS_PRINT_ERR, "\n       Incorrect Status. Expected = -2 Found = %d", status);
     val_set_status(index, RESULT_FAIL(TEST_NUM, 7));
+    temp = drtm_params->dlme_image_start;
+    drtm_params->dlme_image_start = drtm_params->dlme_data_offset;
+    drtm_params->dlme_data_offset = temp;
     goto free_dlme_region;
   }
 


### PR DESCRIPTION
- Fix unaligned memory free issue in DLME region
- Added 0x4 to dlme_region_address to make it unaligned and in test 101 part-2 error case attempted to free this unaligned memory.
- To handle this correctly in the error case, now subtracts 0x4 before freeing the memory