### PR TITLE
acs_timer: Fix timer indexing access

### DIFF
--- a/val/common/src/acs_timer.c
+++ b/val/common/src/acs_timer.c
@@ -112,7 +112,7 @@ val_platform_timer_get_entry_index(uint64_t instance, uint32_t *block, uint32_t 
 
   *block = 0;
   *index = instance;
-  while (instance > g_timer_info_table->gt_info[*block].timer_count){
+  while (instance >= g_timer_info_table->gt_info[*block].timer_count) {
       instance = instance - g_timer_info_table->gt_info[*block].timer_count;
       *index   = instance;
       *block   = *block + 1;


### PR DESCRIPTION
- val_platform_timer_get_entry_index incorrectly iterated through the available timers.
- Change instance > timers_in_block to instance >= timers_in_block.

Change-Id: Ie32de61f7cff1a23bbb6932778165ea6e08f9daf