### PR TITLE
New Test B_PE_25 for FR in BSA

### DIFF
--- a/baremetal_app/BsaAcs.inf
+++ b/baremetal_app/BsaAcs.inf
@@ -44,6 +44,7 @@
   ../test_pool/pe/operating_system/test_os_c012.c
   ../test_pool/pe/operating_system/test_os_c013.c
   ../test_pool/pe/operating_system/test_os_c014.c
+  ../test_pool/pe/operating_system/test_os_c015.c
   ../test_pool/pe/operating_system/test_os_c016.c
   ../test_pool/pe/hypervisor/test_hyp_c001.c
   ../test_pool/pe/hypervisor/test_hyp_c002.c

--- a/test_pool/pe/operating_system/test_os_c015.c
+++ b/test_pool/pe/operating_system/test_os_c015.c
@@ -1,0 +1,62 @@
+/** @file
+ * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+#include "val/common/include/acs_val.h"
+#include "val/common/include/acs_pe.h"
+
+#define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  15)
+#define TEST_RULE  "B_PE_25"
+#define TEST_DESC  "Check for FEAT_LSE support            "
+
+static
+void
+payload()
+{
+  uint64_t data = 0;
+  uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+
+  data = val_pe_reg_read(ID_AA64ISAR0_EL1);
+  data = (data & 0xF00000) >> 20;
+
+  /* Must support LSE as indicated by ID_AA64ISAR0_EL1.Atomic = 0b0010 or 0b0011 */
+  if ((data == 0x2) || (data == 0x3))
+      val_set_status(index, RESULT_PASS(TEST_NUM, 1));
+  else
+      val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
+
+  return;
+
+}
+
+uint32_t
+os_c015_entry(uint32_t num_pe)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;  //default value
+
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
+
+  /* This check is when user is forcing us to skip this test */
+  if (status != ACS_STATUS_SKIP)
+      val_run_test_payload(TEST_NUM, num_pe, payload, 0);
+
+  /* get the result from all PE and check for failure */
+  status = val_check_for_error(TEST_NUM, num_pe, TEST_RULE);
+
+  val_report_status(0, ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -44,6 +44,7 @@
   ../test_pool/pe/operating_system/test_os_c012.c
   ../test_pool/pe/operating_system/test_os_c013.c
   ../test_pool/pe/operating_system/test_os_c014.c
+  ../test_pool/pe/operating_system/test_os_c015.c
   ../test_pool/pe/operating_system/test_os_c016.c
   ../test_pool/pe/hypervisor/test_hyp_c001.c
   ../test_pool/pe/hypervisor/test_hyp_c002.c

--- a/uefi_app/BsaAcsMem.inf
+++ b/uefi_app/BsaAcsMem.inf
@@ -44,6 +44,7 @@
   ../test_pool/pe/operating_system/test_os_c012.c
   ../test_pool/pe/operating_system/test_os_c013.c
   ../test_pool/pe/operating_system/test_os_c014.c
+  ../test_pool/pe/operating_system/test_os_c015.c
   ../test_pool/pe/operating_system/test_os_c016.c
   ../test_pool/pe/hypervisor/test_hyp_c001.c
   ../test_pool/pe/hypervisor/test_hyp_c002.c

--- a/val/bsa/include/bsa_acs_pe.h
+++ b/val/bsa/include/bsa_acs_pe.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/val/bsa/src/bsa_execute_test.c
+++ b/val/bsa/src/bsa_execute_test.c
@@ -97,7 +97,7 @@ val_bsa_pe_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
 {
   uint32_t status, i;
 
-  if (!(g_bsa_level >= 1 || g_bsa_only_level == 1 || g_bsa_only_level == 1))
+  if (!(g_bsa_level >= 1 || g_bsa_only_level == 1 || g_bsa_only_level == 2))
       return ACS_STATUS_SKIP;
 
   for (i = 0; i < g_num_skip; i++) {
@@ -142,6 +142,10 @@ val_bsa_pe_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
           status |= os_c016_entry(num_pe);
       }
 
+      if (g_bsa_level > 1 || g_bsa_only_level == 2) {
+          view_print_info(OPERATING_SYSTEM);
+          status |= os_c015_entry(num_pe);
+      }
   }
 
   if (g_sw_view[G_SW_HYP]) {


### PR DESCRIPTION
Changes:
- A new test file has been added for Rule B_PE25.
- This file includes a test for checking FEAT_LSE support by reading and validating the ID_AA64ISAR0_EL1 register.
- The test sets the status to pass if the Atomic feature is supported (values 0b0010 or 0b0011), otherwise it fails.
- A new condition is added to call the os_c015_entry function if g_bsa_level > 1 or g_bsa_only_level == 2.