### PR TITLE
Errata - 483: Clarify the MPAM PARTID

### DIFF
--- a/val/sbsa/include/sbsa_acs_mpam.h
+++ b/val/sbsa/include/sbsa_acs_mpam.h
@@ -108,8 +108,8 @@ void     val_mpam_pcc_write(uint32_t msc_index, uint32_t reg_offset, uint32_t da
 uint32_t mpam001_entry(uint32_t num_pe);
 uint32_t mpam002_entry(uint32_t num_pe);
 uint32_t mpam003_entry(uint32_t num_pe);
-uint32_t mpam004_entry(uint32_t num_pe);
 uint32_t mpam005_entry(uint32_t num_pe);
 uint32_t mpam006_entry(uint32_t num_pe);
+uint32_t mpam007_entry(uint32_t num_pe);
 
 #endif /*__SBSA_ACS_MPAM_H__ */

--- a/val/sbsa/include/sbsa_acs_pe.h
+++ b/val/sbsa/include/sbsa_acs_pe.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,8 +32,6 @@ uint32_t c011_entry(uint32_t num_pe);
 uint32_t c012_entry(uint32_t num_pe);
 uint32_t c013_entry(uint32_t num_pe);
 uint32_t c014_entry(uint32_t num_pe);
-uint32_t c015_entry(uint32_t num_pe);
-uint32_t c016_entry(uint32_t num_pe);
 uint32_t c017_entry(uint32_t num_pe);
 uint32_t c018_entry(uint32_t num_pe);
 uint32_t c019_entry(uint32_t num_pe);

--- a/val/sbsa/src/sbsa_execute_test.c
+++ b/val/sbsa/src/sbsa_execute_test.c
@@ -92,8 +92,6 @@ val_sbsa_pe_execute_tests(uint32_t level, uint32_t num_pe)
       status |= c012_entry(num_pe);
       status |= c013_entry(num_pe);
       status |= c014_entry(num_pe);
-      status |= c015_entry(num_pe);
-      status |= c016_entry(num_pe);
   }
 
   if (((level > 5)  && (g_sbsa_only_level == 0)) || (g_sbsa_only_level == 6)) {
@@ -773,9 +771,9 @@ val_sbsa_mpam_execute_tests(uint32_t level, uint32_t num_pe)
 
       status |= mpam002_entry(num_pe);
       status |= mpam003_entry(num_pe);
-      status |= mpam004_entry(num_pe);
       status |= mpam005_entry(num_pe);
       status |= mpam006_entry(num_pe);
+      status |= mpam007_entry(num_pe);
   }
   val_print_test_end(status, "MPAM");
 


### PR DESCRIPTION
Changes:
- This is part of sbsa errata 483
- The S_MPAM_PE rule is removed from level 5
- The virtual PARTID and cache portion partioning is moved from l5 to l7
- The rule S_L7MP_06. S_L7MP_07 are removed