### PR TITLE
Bug fix in PAL mpam Code

### DIFF
--- a/pal/uefi_acpi/sbsa/src/pal_sbsa_mpam.c
+++ b/pal/uefi_acpi/sbsa/src/pal_sbsa_mpam.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -160,7 +160,7 @@ pal_mpam_create_info_table(MPAM_INFO_TABLE *MpamTable)
       curr_entry->identifier = msc_node->identifier;
 
       /* if MSC interface type is PCC (0x0A), store PCC information in pcc_info_table */
-      if (curr_entry->identifier == MPAM_INTERFACE_TYPE_PCC) {
+      if (curr_entry->intrf_type == MPAM_INTERFACE_TYPE_PCC) {
           pal_pcc_store_info(curr_entry->msc_base_addr);
       }
 


### PR DESCRIPTION
- intrf_type is used in place of identifier to correctly get the Interface type