### PR TITLE
PMU changes: Read PMU PMDEVARCH reg to query cs complaint

### DIFF
--- a/pal/baremetal/sbsa/include/pal_sbsa_common_support.h
+++ b/pal/baremetal/sbsa/include/pal_sbsa_common_support.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version  2.0 (the "License");
@@ -35,6 +35,7 @@ typedef struct {
     uint64_t base0;               /* Base address of Page 0 of the PMU*/
     uint64_t base1;               /* Base address of Page 1 of the PMU,
                                    valid only if dual_page_extension is 1*/
+    uint32_t coresight_compliant; /* node coresight compliant or not */
 } PMU_INFO_BLOCK;
 
 typedef struct {

--- a/pal/baremetal/target/RDN2/sbsa/include/platform_override_sbsa_struct.h
+++ b/pal/baremetal/target/RDN2/sbsa/include/platform_override_sbsa_struct.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -102,6 +102,7 @@ typedef struct {
   uint64_t base0;               /* Base address of Page 0 of the PMU */
   uint64_t base1;               /* Base address of Page 1 of the PMU,
                                      valid only if dual_page_extension is 1 */
+  uint32_t coresight_compliant;  /* node CS arch complaint */
 } PLATFORM_OVERRIDE_PMU_INFO_BLOCK;
 
 typedef struct {

--- a/pal/uefi_acpi/sbsa/include/pal_sbsa_uefi.h
+++ b/pal/uefi_acpi/sbsa/include/pal_sbsa_uefi.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,6 +38,7 @@ typedef struct {
     UINT64 base0;               /* Base address of Page 0 of the PMU*/
     UINT64 base1;               /* Base address of Page 1 of the PMU,
                                    valid only if dual_page_extension is 1*/
+    UINT32 coresight_compliant; /* node is CS arch complaint or not */
 } PMU_INFO_BLOCK;
 
 typedef struct {

--- a/val/sbsa/include/sbsa_acs_pmu.h
+++ b/val/sbsa/include/sbsa_acs_pmu.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,6 +41,7 @@ uint32_t val_generate_traffic(uint64_t interface_acpiid, uint32_t pmu_node_index
                                      uint32_t mon_index, uint32_t eventid);
 uint32_t val_pmu_check_monitor_count_value(uint64_t interface_acpiid, uint32_t count_value,
                                                                           uint32_t eventid);
+void     val_pmu_set_node_coresight_complaint(uint32_t flag, uint32_t node_index);
 
 uint32_t pmu001_entry(uint32_t num_pe);
 uint32_t pmu002_entry(uint32_t num_pe);

--- a/val/sbsa/include/sbsa_acs_pmu_reg.h
+++ b/val/sbsa/include/sbsa_acs_pmu_reg.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -126,5 +126,8 @@ BITFIELD_DECL(uint32_t, PMSCR_NSMSI, 2, 2)
 BITFIELD_DECL(uint32_t, PMSCR_MSI_MPAM_NS, 3, 3)
 BITFIELD_DECL(uint32_t, PMSCR_NAO, 4, 4)
 BITFIELD_DECL(uint32_t, PMSCR_IMPL, 31, 31)
+
+/* PMDEVARCH bit configuration */
+BITFIELD_DECL(uint32_t, PMDEVARCH_ARCHITECT, 31, 21)
 
 #endif /*__PMU_REG_H__ */

--- a/val/sbsa/include/sbsa_pal_interface.h
+++ b/val/sbsa/include/sbsa_pal_interface.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,6 +53,7 @@ typedef struct {
     uint64_t base0;               /* Base address of Page 0 of the PMU*/
     uint64_t base1;               /* Base address of Page 1 of the PMU,
                                    valid only if dual_page_extension is 1*/
+    uint32_t coresight_compliant; /* node is CS complaint or not */
 } PMU_INFO_BLOCK;
 
 typedef struct {

--- a/val/sbsa/include/sbsa_val_interface.h
+++ b/val/sbsa/include/sbsa_val_interface.h
@@ -161,6 +161,7 @@ typedef enum {
   PMU_NODE_SEC_INST,   /* Secondary instance          */
   PMU_NODE_COUNT,      /* PMU Node count              */
   PMU_NODE_DP_EXTN,    /* Dual page extension support */
+  PMU_NODE_CS_COM,     /* Node is Coresight arch complaint */
 } PMU_INFO_e;
 
 uint32_t val_sbsa_pe_execute_tests(uint32_t level, uint32_t num_pe);


### PR DESCRIPTION
- The SBSA PMU test relies on the CoreSight PMU architecture for register memory layout.
- Read the PMDEVARCH register to check the same and skip if PMU node not following CS register layout.