### PR TITLE
GICv4 consideration for Redistributor base fetch

### DIFF
--- a/val/common/src/acs_gic.c
+++ b/val/common/src/acs_gic.c
@@ -149,12 +149,19 @@ val_gic_get_pe_rdbase(uint64_t mpidr)
 {
   uint32_t     gicrd_baselen;
   uint32_t     gicr_rdindex = 0;
+  uint32_t     gic_version;
   uint64_t     affinity, pe_affinity;
   uint64_t     gicrd_granularity;
   uint64_t     gicrd_base, pe_gicrd_base;
 
   pe_affinity = (mpidr & (PE_AFF0 | PE_AFF1 | PE_AFF2)) | ((mpidr & PE_AFF3) >> 8);
+  gic_version = val_gic_get_info(GIC_INFO_VERSION);
+
   gicrd_granularity = GICR_CTLR_FRAME_SIZE + GICR_SGI_PPI_FRAME_SIZE;
+
+  /* Redistributors in GICv4 define 2 additional 64KB frames - One each for VLPI and Reserved */
+  if (gic_version > 3)
+    gicrd_granularity += GICR_VLPI_FRAME_SIZE + GICR_RES_FRAME_SIZE;
 
   gicr_rdindex = 0;
 

--- a/val/common/sys_arch_src/gic/gic.h
+++ b/val/common/sys_arch_src/gic/gic.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2021,2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021,2024-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,6 +38,8 @@
 #define GIC_DEFAULT_PRIORITY     0x80
 #define GICR_CTLR_FRAME_SIZE     0x00010000
 #define GICR_SGI_PPI_FRAME_SIZE  0x00010000
+#define GICR_VLPI_FRAME_SIZE     0x00010000
+#define GICR_RES_FRAME_SIZE      0x00010000
 #define GICR_TYPER_AFF           (0xFFFFFFFFULL << 32)
 
 #define GIC_ICDIPTR         0x800


### PR DESCRIPTION
 - Added 2x64KB offset to gicrd_granularity in the case of GICv4