### PR TITLE
Support to limit scanning entire PCIe space

### DIFF
--- a/pal/baremetal/common/src/pal_pcie_enumeration.c
+++ b/pal/baremetal/common/src/pal_pcie_enumeration.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -793,5 +793,19 @@ pal_bsa_pcie_enumerate()
   return 0; /* uefi takes care of it */
 }
 
+/**
+  @brief  This API is used as placeholder to check if the bus
+          is to be skipped for PCIe table creation
 
-
+  @param  bus_index
+  @return 1 if bus to be skipped else 0
+**/
+uint32_t
+pal_pcie_check_bus_valid(uint32_t bus_index)
+{
+  /* Add Bus index to this function if PCIe table
+     creation need to be ignored for a bus
+  */
+  (void) bus_index;
+  return 0;
+}

--- a/pal/uefi_acpi/common/src/pal_pcie_enumeration.c
+++ b/pal/uefi_acpi/common/src/pal_pcie_enumeration.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2019, 2022-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019, 2022-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -276,3 +276,19 @@ pal_pcie_check_device_valid(UINT32 bdf)
   return 0;
 }
 
+/**
+  @brief  This API is used as placeholder to check if the bus
+          is to be skipped for PCIe table creation
+
+  @param  bus_index
+  @return 1 if bus to be skipped else 0
+**/
+UINT32
+pal_pcie_check_bus_valid(UINT32 bus_index)
+{
+  /* Add Bus index to this function if PCIe table
+     creation need to be ignored for a bus
+  */
+
+  return 0;
+}

--- a/pal/uefi_dt/bsa/src/pal_pcie_enumeration.c
+++ b/pal/uefi_dt/bsa/src/pal_pcie_enumeration.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2019,2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019,2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -275,3 +275,19 @@ pal_pcie_check_device_valid(UINT32 bdf)
   return 0;
 }
 
+/**
+  @brief  This API is used as placeholder to check if the bus
+          is to be skipped for PCIe table creation
+
+  @param  bus_index
+  @return 1 if bus to be skipped else 0
+**/
+UINT32
+pal_pcie_check_bus_valid(UINT32 bus_index)
+{
+  /* Add Bus index to this function if PCIe table
+     creation need to be ignored for a bus
+  */
+
+  return 0;
+}

--- a/val/common/include/pal_interface.h
+++ b/val/common/include/pal_interface.h
@@ -466,6 +466,7 @@ void pal_pcie_io_write_cfg(uint32_t bdf, uint32_t offset, uint32_t data);
 uint32_t pal_bsa_pcie_enumerate(void);
 uint32_t pal_pcie_check_device_list(void);
 uint32_t pal_pcie_check_device_valid(uint32_t bdf);
+uint32_t pal_pcie_check_bus_valid(uint32_t bus_index);
 uint32_t pal_pcie_mem_get_offset(uint32_t bdf, PCIE_MEM_TYPE_INFO_e mem_type);
 
 uint32_t pal_pcie_bar_mem_read(uint32_t bdf, uint64_t address, uint32_t *data);

--- a/val/common/src/acs_pcie.c
+++ b/val/common/src/acs_pcie.c
@@ -571,6 +571,12 @@ val_pcie_create_device_bdf_table()
           {
               for (func_index = 0; func_index < PCIE_MAX_FUNC; func_index++)
               {
+                  if (pal_pcie_check_bus_valid(bus_index)) {
+                      val_print(ACS_PRINT_DEBUG,
+                       "       Bus 0x%x marked as invalid in Platform API...Skipping\n", bus_index);
+                      continue;
+                  }
+
                   /* Form bdf using seg, bus, device, function numbers */
                   bdf = PCIE_CREATE_BDF(seg_num, bus_index, dev_index, func_index);
 


### PR DESCRIPTION
- Fixes #418
- Added PAL API to provide support to skip the buses during PCIe table creation to ensure less time taken in pre-silicon
- Change in Copyright of files.