### PR TITLE
if the PMU node are not memory mapped, map them

### DIFF
--- a/val/sbsa/src/sbsa_acs_pmu.c
+++ b/val/sbsa/src/sbsa_acs_pmu.c
@@ -16,6 +16,7 @@
  **/
 
 #include "sbsa/include/sbsa_val_interface.h"
+#include "common/include/acs_mmu.h"
 #include "common/include/acs_val.h"
 #include "common/include/acs_common.h"
 #include "sbsa/include/sbsa_acs_pmu.h"

--- a/val/sbsa/src/sbsa_acs_pmu.c
+++ b/val/sbsa/src/sbsa_acs_pmu.c
@@ -51,7 +51,10 @@ val_pmu_create_info_table(uint64_t *pmu_info_table)
             g_pmu_info_table->pmu_count);
 
   for (node_index = 0; node_index < g_pmu_info_table->pmu_count; node_index++) {
+      val_print(ACS_PRINT_INFO, " PMU node index: %4d\n", node_index);
       base = val_pmu_get_info(PMU_NODE_BASE0, node_index);
+      val_mmu_update_entry(base, 0x1000);
+      val_print(ACS_PRINT_INFO, " PMU node mapped \n", 0);
       reg_value = BITFIELD_READ(PMDEVARCH_ARCHITECT, val_mmio_read(base + REG_PMDEVARCH));
       /* 0x23B is value for Arm Limited */
       if (reg_value == 0x23B)


### PR DESCRIPTION
- Accessing a unmapped region results in exception