### PR TITLE
Enhancment of Print for ERR in BSA test summary

### DIFF
--- a/baremetal_app/BsaAcsMain.c
+++ b/baremetal_app/BsaAcsMain.c
@@ -345,15 +345,15 @@ ShellAppMainbsa(
   Status |= val_bsa_exerciser_execute_tests(g_sw_view);
 
 print_test_status:
-  val_print(ACS_PRINT_TEST, "\n     -------------------------------------------------------\n", 0);
-  val_print(ACS_PRINT_TEST, "     Total Tests run  = %4d", g_acs_tests_total);
-  val_print(ACS_PRINT_TEST, "  Tests Passed  = %4d", g_acs_tests_pass);
-  val_print(ACS_PRINT_TEST, "  Tests Failed = %4d\n", g_acs_tests_fail);
-  val_print(ACS_PRINT_TEST, "     -------------------------------------------------------\n", 0);
+  val_print(ACS_PRINT_ERR, "\n     -------------------------------------------------------\n", 0);
+  val_print(ACS_PRINT_ERR, "     Total Tests run  = %4d", g_acs_tests_total);
+  val_print(ACS_PRINT_ERR, "  Tests Passed  = %4d", g_acs_tests_pass);
+  val_print(ACS_PRINT_ERR, "  Tests Failed = %4d\n", g_acs_tests_fail);
+  val_print(ACS_PRINT_ERR, "     -------------------------------------------------------\n", 0);
 
   freeBsaAcsMem();
 
-  val_print(ACS_PRINT_TEST, "\n      *** BSA tests complete. Reset the system. ***\n\n", 0);
+  val_print(ACS_PRINT_ERR, "\n      *** BSA tests complete. Reset the system. ***\n\n", 0);
 
   val_pe_context_restore(AA64WriteSp(g_stack_pointer));
   while (1);

--- a/uefi_app/BsaAcsMain.c
+++ b/uefi_app/BsaAcsMain.c
@@ -637,11 +637,11 @@ ShellAppMain (
   Status |= val_bsa_exerciser_execute_tests(g_sw_view);
 
 print_test_status:
-  val_print(ACS_PRINT_TEST, "\n     -------------------------------------------------------\n", 0);
-  val_print(ACS_PRINT_TEST, "     Total Tests run  = %4d", g_acs_tests_total);
-  val_print(ACS_PRINT_TEST, "  Tests Passed  = %4d", g_acs_tests_pass);
-  val_print(ACS_PRINT_TEST, "  Tests Failed = %4d\n", g_acs_tests_fail);
-  val_print(ACS_PRINT_TEST, "     -------------------------------------------------------\n", 0);
+  val_print(ACS_PRINT_ERR, "\n     -------------------------------------------------------\n", 0);
+  val_print(ACS_PRINT_ERR, "     Total Tests run  = %4d", g_acs_tests_total);
+  val_print(ACS_PRINT_ERR, "  Tests Passed  = %4d", g_acs_tests_pass);
+  val_print(ACS_PRINT_ERR, "  Tests Failed = %4d\n", g_acs_tests_fail);
+  val_print(ACS_PRINT_ERR, "     -------------------------------------------------------\n", 0);
 
   freeBsaAcsMem();
 
@@ -649,7 +649,7 @@ print_test_status:
     ShellCloseFile(&g_dtb_log_file_handle);
   }
 
-  val_print(ACS_PRINT_TEST, "\n      *** BSA tests complete. Reset the system. ***\n\n", 0);
+  val_print(ACS_PRINT_ERR, "\n      *** BSA tests complete. Reset the system. ***\n\n", 0);
 
 #ifdef ENABLE_MEMTEST
   /***  Starting memory model consistency tests ***/


### PR DESCRIPTION
-  The messages indicating the total tests run, passed, and failed, along with the final BSA test completion message, are printed for verbose 4 and 5.