### PR TITLE
Limit Scanning entire PCIe space

### DIFF
--- a/val/common/src/acs_pcie.c
+++ b/val/common/src/acs_pcie.c
@@ -567,16 +567,16 @@ val_pcie_create_device_bdf_table()
       /* Iterate over all buses, devices and functions in this ecam */
       for (bus_index = start_bus; bus_index <= end_bus; bus_index++)
       {
+          if (pal_pcie_check_bus_valid(bus_index)) {
+              val_print(ACS_PRINT_DEBUG,
+               "       Bus 0x%x marked as invalid in Platform API...Skipping\n", bus_index);
+              continue;
+          }
+
           for (dev_index = 0; dev_index < PCIE_MAX_DEV; dev_index++)
           {
               for (func_index = 0; func_index < PCIE_MAX_FUNC; func_index++)
               {
-                  if (pal_pcie_check_bus_valid(bus_index)) {
-                      val_print(ACS_PRINT_DEBUG,
-                       "       Bus 0x%x marked as invalid in Platform API...Skipping\n", bus_index);
-                      continue;
-                  }
-
                   /* Form bdf using seg, bus, device, function numbers */
                   bdf = PCIE_CREATE_BDF(seg_num, bus_index, dev_index, func_index);
 

--- a/val/common/src/acs_peripherals.c
+++ b/val/common/src/acs_peripherals.c
@@ -229,6 +229,12 @@ val_peripheral_dump_info(void)
 
       for (bus = start_bus; bus <= end_bus; bus++)
       {
+          if (pal_pcie_check_bus_valid(bus)) {
+              val_print(ACS_PRINT_DEBUG,
+               "       Bus 0x%x marked as invalid in Platform API...Skipping\n", bus);
+              continue;
+          }
+
           for (dev = 0; dev < PCIE_MAX_DEV; dev++)
           {
               for (func = 0; func < PCIE_MAX_FUNC; func++)


### PR DESCRIPTION
- Fixes #478 and #479
- Moved the code to skip the PCIe buses before the check of the device and function of that bus.
- Added same logic to Peripheral create info table