### PR TITLE
Support for MSI and MSI-X

### DIFF
--- a/test_pool/exerciser/operating_system/test_os_e004.c
+++ b/test_pool/exerciser/operating_system/test_os_e004.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021, 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021, 2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -92,9 +92,10 @@ payload (void)
     e_bdf = val_exerciser_get_bdf(instance);
     val_print(ACS_PRINT_DEBUG, "\n       Exerciser BDF - 0x%x", e_bdf);
 
-    /* Search for MSI-X Capability */
-    if (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) {
-      val_print(ACS_PRINT_INFO, "\n       No MSI-X Capability, Skipping for 0x%x", e_bdf);
+    /* Search for MSI-X/MSI Capability */
+    if ((val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) &&
+        (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSI, &msi_cap_offset))) {
+      val_print(ACS_PRINT_DEBUG, "\n       No MSI/MSI-X Capability, Skipping for 0x%x", e_bdf);
       continue;
     }
 

--- a/test_pool/exerciser/operating_system/test_os_e011.c
+++ b/test_pool/exerciser/operating_system/test_os_e011.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2021, 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -89,9 +89,10 @@ payload (void)
     e_bdf = val_exerciser_get_bdf(instance);
     val_print(ACS_PRINT_DEBUG, "\n       Exerciser BDF - 0x%x", e_bdf);
 
-    /* Search for MSI-X Capability */
-    if (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) {
-      val_print(ACS_PRINT_DEBUG, "\n       No MSI-X Capability, Skipping for 0x%x", e_bdf);
+    /* Search for MSI/MSI-X Capability */
+    if ((val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) &&
+        (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSI, &msi_cap_offset))) {
+      val_print(ACS_PRINT_DEBUG, "\n       No MSI/MSI-X Capability, Skipping for 0x%x", e_bdf);
       continue;
     }
 

--- a/test_pool/exerciser/operating_system/test_os_e012.c
+++ b/test_pool/exerciser/operating_system/test_os_e012.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2021, 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -91,9 +91,10 @@ payload (void)
     e_bdf = val_exerciser_get_bdf(instance);
     val_print(ACS_PRINT_DEBUG, "\n       Exerciser BDF - 0x%x", e_bdf);
 
-    /* Search for MSI-X Capability */
-    if (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) {
-      val_print(ACS_PRINT_INFO, "\n       No MSI-X Capability, Skipping for 0x%x", e_bdf);
+    /* Search for MSI/MSI-X Capability */
+    if ((val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) &&
+        (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSI, &msi_cap_offset))) {
+      val_print(ACS_PRINT_INFO, "\n       No MSI/MSI-X Capability, Skipping for 0x%x", e_bdf);
       continue;
     }
 

--- a/test_pool/exerciser/operating_system/test_os_e013.c
+++ b/test_pool/exerciser/operating_system/test_os_e013.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021, 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021, 2023-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -133,9 +133,10 @@ payload (void)
     e_bdf = val_exerciser_get_bdf(instance);
     val_print(ACS_PRINT_DEBUG, "\n       Exerciser BDF - 0x%x", e_bdf);
 
-    /* Search for MSI-X Capability */
-    if (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) {
-      val_print(ACS_PRINT_INFO, "\n       No MSI-X Capability, Skipping for 0x%x", e_bdf);
+    /* Search for MSI/MSI-X Capability */
+    if ((val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) &&
+        (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSI, &msi_cap_offset))) {
+      val_print(ACS_PRINT_INFO, "\n       No MSI/MSI-X Capability, Skipping for 0x%x", e_bdf);
       continue;
     }
 

--- a/val/common/include/acs_pcie_spec.h
+++ b/val/common/include/acs_pcie_spec.h
@@ -373,6 +373,13 @@
 #define PCIE_PCI (1 << 0b0111)
 #define PCIe_ALL (iEP_RP | iEP_EP | RP | EP | RCEC | RCiEP)
 
+/*MSI Capabilities */
+#define MSI_ENABLE_SHIFT                16
+#define MSI_ADDR_SHIFT                  32
+#define MSI_MSG_TBL_LOWER_ADDR_OFFSET   0x4
+#define MSI_MSG_TBL_HIGHER_ADDR_OFFSET  0x8
+#define MSI_MSG_TBL_DATA_OFFSET         0xC
+
 /* MSI-X Capabilities */
 #define MSI_X_ENABLE_SHIFT          31
 


### PR DESCRIPTION
- Fixes #338
- Provided support for both MSI and MSI-X support
- If both are supported, MSI-X is taken precedence and that is enabled and verified.