### PR TITLE
Align IOVIRT_BLOCK to the correct length

### DIFF
--- a/pal/baremetal/common/include/pal_common_support.h
+++ b/pal/baremetal/common/include/pal_common_support.h
@@ -598,7 +598,7 @@ typedef union {
   ID_MAP map;
 }NODE_DATA_MAP;
 
-#define MAX_NAMED_COMP_LENGTH 256
+#define MAX_NAMED_COMP_LENGTH 150
 
 typedef struct {
   uint64_t smmu_base;                  /* SMMU base to which component is attached, else NULL */

--- a/pal/baremetal/target/RDN2/common/include/platform_override_struct.h
+++ b/pal/baremetal/target/RDN2/common/include/platform_override_struct.h
@@ -98,7 +98,7 @@ typedef struct {
   uint64_t smmu_base;
 } PLATFORM_OVERRIDE_IOVIRT_PMCG_INFO_BLOCK;
 
-#define MAX_NAMED_COMP_LENGTH 256
+#define MAX_NAMED_COMP_LENGTH 150
 typedef struct {
         uint32_t its_count;
         uint32_t identifiers[1];     /* GIC ITS identifier arrary */

--- a/pal/baremetal/target/RPi4/include/platform_override_struct.h
+++ b/pal/baremetal/target/RPi4/include/platform_override_struct.h
@@ -97,7 +97,7 @@ typedef struct {
   uint32_t node_ref;
 } PLATFORM_OVERRIDE_IOVIRT_PMCG_INFO_BLOCK;
 
-#define MAX_NAMED_COMP_LENGTH 256
+#define MAX_NAMED_COMP_LENGTH 150
 typedef struct {
         uint32_t its_count;
         uint32_t identifiers[1];     /* GIC ITS identifier arrary */

--- a/pal/uefi_dt/bsa/include/pal_uefi.h
+++ b/pal/uefi_dt/bsa/include/pal_uefi.h
@@ -321,7 +321,7 @@ typedef union {
   ID_MAP map;
 }NODE_DATA_MAP;
 
-#define MAX_NAMED_COMP_LENGTH 256
+#define MAX_NAMED_COMP_LENGTH 150
 
 typedef struct {
   UINT64 smmu_base;                     /* SMMU base to which component is attached, else NULL */


### PR DESCRIPTION
This PR fixes a bug for GET_SMMU_INFO. Currently there are two definitions of MAX_NAMED_COMP_LENGTH: 150 and 256, this will cause inconsistent IOVIRT_BLOCK size and trigger warning. Set all MAX_NAMED_COMP_LENGTH to 150 to fix it.

```
 SMMU_INFO: Number of SMMU CTRL       :    2
 SMMU_INFO: SMMU index 00 version     :    v3.1
GET_SMMU_INFO: Index (1) is greater than num of SMMU
 SMMU_INFO: SMMU index 01 version     :    v0
```